### PR TITLE
Apply soft palette and lazy-load images

### DIFF
--- a/blog/cuidados-basicos.html
+++ b/blog/cuidados-basicos.html
@@ -15,7 +15,7 @@
     <header>
       <div class="site-header">
         <a class="brand" href="../index.html">
-          <img src="../img/logo-xolos-ramirez.svg" alt="Logo de Xolos Ramirez" width="44" height="44" />
+          <img src="../img/logo-xolos-ramirez.svg" alt="Logo de Xolos Ramirez" width="44" height="44" loading="lazy" />
           <span>Xolos Ramirez</span>
         </a>
         <button class="menu-toggle" type="button" data-menu-toggle aria-expanded="false">

--- a/blog/cultura-mexicana.html
+++ b/blog/cultura-mexicana.html
@@ -15,7 +15,7 @@
     <header>
       <div class="site-header">
         <a class="brand" href="../index.html">
-          <img src="../img/logo-xolos-ramirez.svg" alt="Logo de Xolos Ramirez" width="44" height="44" />
+          <img src="../img/logo-xolos-ramirez.svg" alt="Logo de Xolos Ramirez" width="44" height="44" loading="lazy" />
           <span>Xolos Ramirez</span>
         </a>
         <button class="menu-toggle" type="button" data-menu-toggle aria-expanded="false">

--- a/blog/historia-xoloitzcuintle.html
+++ b/blog/historia-xoloitzcuintle.html
@@ -15,7 +15,7 @@
     <header>
       <div class="site-header">
         <a class="brand" href="../index.html">
-          <img src="../img/logo-xolos-ramirez.svg" alt="Logo de Xolos Ramirez" width="44" height="44" />
+          <img src="../img/logo-xolos-ramirez.svg" alt="Logo de Xolos Ramirez" width="44" height="44" loading="lazy" />
           <span>Xolos Ramirez</span>
         </a>
         <button class="menu-toggle" type="button" data-menu-toggle aria-expanded="false">
@@ -48,7 +48,7 @@
           <p><strong>Lectura:</strong> 6 minutos</p>
         </header>
         <figure>
-          <img src="../img/blog/historia.svg" alt="Escultura prehispánica de un xoloitzcuintle" />
+          <img src="../img/blog/historia.svg" alt="Escultura prehispánica de un xoloitzcuintle" loading="lazy" />
           <figcaption>Figura de barro encontrada en Colima, siglo XIII.</figcaption>
         </figure>
         <section>

--- a/blog/index.html
+++ b/blog/index.html
@@ -15,7 +15,7 @@
     <header>
       <div class="site-header">
         <a class="brand" href="../index.html">
-          <img src="../img/logo-xolos-ramirez.svg" alt="Logo de Xolos Ramirez" width="44" height="44" />
+          <img src="../img/logo-xolos-ramirez.svg" alt="Logo de Xolos Ramirez" width="44" height="44" loading="lazy" />
           <span>Xolos Ramirez</span>
         </a>
         <button class="menu-toggle" type="button" data-menu-toggle aria-expanded="false">

--- a/contacto.html
+++ b/contacto.html
@@ -15,7 +15,7 @@
     <header>
       <div class="site-header">
         <a class="brand" href="index.html">
-          <img src="img/logo-xolos-ramirez.svg" alt="Logo de Xolos Ramirez" width="44" height="44" />
+          <img src="img/logo-xolos-ramirez.svg" alt="Logo de Xolos Ramirez" width="44" height="44" loading="lazy" />
           <span>Xolos Ramirez</span>
         </a>
         <button class="menu-toggle" type="button" data-menu-toggle aria-expanded="false">

--- a/css/styles.css
+++ b/css/styles.css
@@ -1,11 +1,15 @@
 :root {
-  color-scheme: light dark;
-  font-family: 'Segoe UI', Roboto, Helvetica, Arial, sans-serif;
+  color-scheme: light;
+  font-family: 'Poppins', sans-serif;
   line-height: 1.6;
-  --color-primary: #7d1a0c;
-  --color-secondary: #f9f4ef;
-  --color-dark: #1d1b1a;
-  --color-muted: #6c6358;
+  --primary-color: #a62700;
+  --secondary-color: #6b705c;
+  --bg-color: #fdf8f0;
+  --text-color: #333333;
+  --accent-color: #b7b7a4;
+  --dark-accent: #323232;
+  --surface-color: #ffffff;
+  --muted-text: #4d4d4d;
   --max-width: 1100px;
 }
 
@@ -15,12 +19,12 @@
 
 body {
   margin: 0;
-  background: var(--color-secondary);
-  color: var(--color-dark);
+  background: var(--bg-color);
+  color: var(--text-color);
 }
 
 a {
-  color: inherit;
+  color: var(--primary-color);
   text-decoration: none;
 }
 
@@ -29,9 +33,34 @@ a:focus {
   text-decoration: underline;
 }
 
+.btn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.5rem;
+  background-color: var(--primary-color);
+  color: #ffffff;
+  padding: 0.8rem 1.6rem;
+  border-radius: 0.5rem;
+  border: none;
+  cursor: pointer;
+  font-weight: 600;
+  transition: background-color 0.3s ease, transform 0.2s ease;
+}
+
+.btn:hover,
+.btn:focus {
+  background-color: #872000;
+}
+
+.btn:focus-visible {
+  outline: 3px solid rgba(50, 50, 50, 0.35);
+  outline-offset: 2px;
+}
+
 header {
-  background: var(--color-dark);
-  color: var(--color-secondary);
+  background: var(--dark-accent);
+  color: var(--bg-color);
   position: sticky;
   top: 0;
   z-index: 10;
@@ -54,6 +83,7 @@ header {
   font-size: 1.1rem;
   letter-spacing: 0.08em;
   text-transform: uppercase;
+  color: var(--bg-color);
 }
 
 .brand img {
@@ -62,7 +92,7 @@ header {
   border-radius: 50%;
   object-fit: cover;
   box-shadow: 0 4px 12px rgba(0, 0, 0, 0.15);
-  background: #fff;
+  background: #ffffff;
   padding: 0.25rem;
 }
 
@@ -76,18 +106,19 @@ nav ul {
 
 nav a {
   font-weight: 600;
+  color: var(--bg-color);
   transition: color 0.2s ease;
 }
 
 nav a:hover,
 nav a:focus {
-  color: var(--color-primary);
+  color: var(--accent-color);
 }
 
 .hero {
-  background: linear-gradient(120deg, rgba(125, 26, 12, 0.9), rgba(29, 27, 26, 0.8)),
+  background: linear-gradient(120deg, rgba(166, 39, 0, 0.9), rgba(50, 50, 50, 0.85)),
     url('../img/hero/hero-placeholder.svg') center/cover no-repeat;
-  color: #fff;
+  color: #ffffff;
   padding: clamp(4rem, 8vw, 6rem) 1rem;
   text-align: center;
 }
@@ -111,15 +142,15 @@ main {
 }
 
 section {
-  background: #fff;
-  padding: 1.5rem;
+  background: var(--surface-color);
+  padding: 3rem 1rem;
   border-radius: 0.75rem;
-  box-shadow: 0 10px 30px rgba(0, 0, 0, 0.05);
+  box-shadow: 0 10px 30px rgba(50, 50, 50, 0.08);
 }
 
 section h2 {
   margin-top: 0;
-  color: var(--color-primary);
+  color: var(--dark-accent);
 }
 
 .grid {
@@ -132,12 +163,13 @@ section h2 {
 }
 
 .card {
-  background: var(--color-secondary);
+  background: var(--accent-color);
   border-radius: 0.75rem;
   padding: 1.25rem;
   display: flex;
   flex-direction: column;
-  gap: 0.5rem;
+  gap: 0.75rem;
+  color: var(--dark-accent);
 }
 
 .card img {
@@ -150,20 +182,20 @@ section h2 {
 blockquote {
   margin: 0;
   padding-left: 1.25rem;
-  border-left: 4px solid var(--color-primary);
-  color: var(--color-muted);
+  border-left: 4px solid var(--secondary-color);
+  color: var(--muted-text);
 }
 
 .callout {
-  background: rgba(125, 26, 12, 0.1);
-  border-left: 4px solid var(--color-primary);
+  background: rgba(107, 112, 92, 0.15);
+  border-left: 4px solid var(--secondary-color);
   padding: 1rem 1.25rem;
   border-radius: 0.5rem;
 }
 
 footer {
-  background: var(--color-dark);
-  color: var(--color-secondary);
+  background: var(--dark-accent);
+  color: var(--bg-color);
 }
 
 .site-footer {
@@ -181,14 +213,110 @@ footer {
   gap: 0.75rem;
 }
 
+.footer-nav a {
+  color: var(--bg-color);
+}
+
+.footer-nav a:hover,
+.footer-nav a:focus {
+  color: var(--accent-color);
+}
+
 small {
-  color: rgba(255, 255, 255, 0.8);
+  color: rgba(253, 248, 240, 0.8);
+}
+
+form {
+  display: grid;
+  gap: 1rem;
+}
+
+label {
+  font-weight: 600;
+  color: var(--dark-accent);
+}
+
+input,
+textarea,
+select {
+  width: 100%;
+  padding: 0.75rem;
+  border-radius: 0.5rem;
+  border: 1px solid rgba(50, 50, 50, 0.15);
+  font-size: 1rem;
+  font-family: inherit;
+  background: #ffffff;
+  color: var(--text-color);
+}
+
+input:focus,
+textarea:focus,
+select:focus {
+  outline: 3px solid rgba(166, 39, 0, 0.35);
+  outline-offset: 2px;
+}
+
+button {
+  background: var(--primary-color);
+  color: #ffffff;
+  border: none;
+  padding: 0.75rem 1.5rem;
+  border-radius: 999px;
+  font-size: 1rem;
+  font-weight: 600;
+  cursor: pointer;
+  transition: background-color 0.3s ease;
+}
+
+button:hover,
+button:focus {
+  background: #872000;
+}
+
+button:focus-visible {
+  outline: 3px solid rgba(50, 50, 50, 0.35);
+  outline-offset: 2px;
+}
+
+.table {
+  width: 100%;
+  border-collapse: collapse;
+}
+
+.table th,
+.table td {
+  padding: 0.75rem;
+  border-bottom: 1px solid rgba(50, 50, 50, 0.15);
+  text-align: left;
+}
+
+.table th {
+  color: var(--primary-color);
+  font-size: 0.95rem;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+}
+
+img {
+  max-width: 100%;
+  border-radius: 8px;
+  display: block;
+}
+
+.visually-hidden {
+  position: absolute;
+  clip: rect(1px, 1px, 1px, 1px);
+  padding: 0;
+  border: 0;
+  height: 1px;
+  width: 1px;
+  overflow: hidden;
 }
 
 @media (max-width: 768px) {
   nav ul {
     flex-direction: column;
-    background: var(--color-dark);
+    background: var(--dark-accent);
     position: absolute;
     right: 1rem;
     top: 72px;
@@ -200,15 +328,15 @@ small {
     transition: transform 0.2s ease;
   }
 
-  nav ul[data-open="true"] {
+  nav ul[data-open='true'] {
     transform: scale(1);
   }
 
   .menu-toggle {
     display: inline-flex;
     background: transparent;
-    border: 2px solid var(--color-secondary);
-    color: var(--color-secondary);
+    border: 2px solid var(--bg-color);
+    color: var(--bg-color);
     padding: 0.25rem 0.75rem;
     border-radius: 999px;
     font-weight: 600;
@@ -222,7 +350,7 @@ small {
 }
 
 .blog-hero {
-  background: linear-gradient(120deg, rgba(125, 26, 12, 0.85), rgba(29, 27, 26, 0.9));
+  background: linear-gradient(120deg, rgba(166, 39, 0, 0.85), rgba(50, 50, 50, 0.9));
 }
 
 .article {
@@ -248,69 +376,4 @@ small {
 .article footer {
   background: transparent;
   color: inherit;
-}
-
-form {
-  display: grid;
-  gap: 1rem;
-}
-
-label {
-  font-weight: 600;
-}
-
-input,
-textarea,
-select {
-  width: 100%;
-  padding: 0.75rem;
-  border-radius: 0.5rem;
-  border: 1px solid rgba(0, 0, 0, 0.1);
-  font-size: 1rem;
-  font-family: inherit;
-}
-
-button {
-  background: var(--color-primary);
-  color: #fff;
-  border: none;
-  padding: 0.75rem 1.5rem;
-  border-radius: 999px;
-  font-size: 1rem;
-  font-weight: 600;
-  cursor: pointer;
-}
-
-button:hover,
-button:focus {
-  background: #5d1207;
-}
-
-.table {
-  width: 100%;
-  border-collapse: collapse;
-}
-
-.table th,
-.table td {
-  padding: 0.75rem;
-  border-bottom: 1px solid rgba(0, 0, 0, 0.1);
-  text-align: left;
-}
-
-.table th {
-  color: var(--color-primary);
-  font-size: 0.95rem;
-  text-transform: uppercase;
-  letter-spacing: 0.05em;
-}
-
-.visually-hidden {
-  position: absolute;
-  clip: rect(1px, 1px, 1px, 1px);
-  padding: 0;
-  border: 0;
-  height: 1px;
-  width: 1px;
-  overflow: hidden;
 }

--- a/galeria.html
+++ b/galeria.html
@@ -15,7 +15,7 @@
     <header>
       <div class="site-header">
         <a class="brand" href="index.html">
-          <img src="img/logo-xolos-ramirez.svg" alt="Logo de Xolos Ramirez" width="44" height="44" />
+          <img src="img/logo-xolos-ramirez.svg" alt="Logo de Xolos Ramirez" width="44" height="44" loading="lazy" />
           <span>Xolos Ramirez</span>
         </a>
         <button class="menu-toggle" type="button" data-menu-toggle aria-expanded="false">
@@ -47,19 +47,19 @@
         <h2>Momentos destacados</h2>
         <div class="grid grid-2">
           <figure class="card">
-            <img src="img/hero/ceremonia.svg" alt="Ceremonia cultural con un xoloitzcuintle" />
+            <img src="img/hero/ceremonia.svg" alt="Ceremonia cultural con un xoloitzcuintle" loading="lazy" />
             <figcaption>Ceremonia tradicional en Tepoztlán.</figcaption>
           </figure>
           <figure class="card">
-            <img src="img/xolos/pareja.svg" alt="Pareja de xolos posando en un jardín" />
+            <img src="img/xolos/pareja.svg" alt="Pareja de xolos posando en un jardín" loading="lazy" />
             <figcaption>Xolos de talla mediana en sesión fotográfica.</figcaption>
           </figure>
           <figure class="card">
-            <img src="img/xolos/familia.svg" alt="Familia con su nuevo xolo" />
+            <img src="img/xolos/familia.svg" alt="Familia con su nuevo xolo" loading="lazy" />
             <figcaption>Entrega oficial de adopción responsable.</figcaption>
           </figure>
           <figure class="card">
-            <img src="img/blog/artesania.svg" alt="Artesanía inspirada en xoloitzcuintles" />
+            <img src="img/blog/artesania.svg" alt="Artesanía inspirada en xoloitzcuintles" loading="lazy" />
             <figcaption>Artesanías de barro inspiradas en el xolo.</figcaption>
           </figure>
         </div>

--- a/index.html
+++ b/index.html
@@ -15,7 +15,7 @@
     <header>
       <div class="site-header">
         <a class="brand" href="index.html">
-          <img src="img/logo-xolos-ramirez.svg" alt="Logo de Xolos Ramirez" width="44" height="44" />
+          <img src="img/logo-xolos-ramirez.svg" alt="Logo de Xolos Ramirez" width="44" height="44" loading="lazy" />
           <span>Xolos Ramirez</span>
         </a>
         <button class="menu-toggle" type="button" data-menu-toggle aria-expanded="false">
@@ -56,7 +56,7 @@
 
       <section class="grid grid-2">
         <article class="card">
-          <img src="img/xolos/ejemplar-1.svg" alt="Xoloitzcuintle joven color oscuro" />
+          <img src="img/xolos/ejemplar-1.svg" alt="Xoloitzcuintle joven color oscuro" loading="lazy" />
           <h3>Conoce a los xolos disponibles</h3>
           <p>
             Perfiles detallados con información de salud, temperamento y
@@ -65,7 +65,7 @@
           <a href="xolos-disponibles.html">Explorar ejemplares</a>
         </article>
         <article class="card">
-          <img src="img/blog/historia.svg" alt="Representación histórica de un xoloitzcuintle" />
+          <img src="img/blog/historia.svg" alt="Representación histórica de un xoloitzcuintle" loading="lazy" />
           <h3>Aprende sobre su historia</h3>
           <p>
             Recopilamos relatos, investigaciones y datos arqueológicos que

--- a/testimonios.html
+++ b/testimonios.html
@@ -15,7 +15,7 @@
     <header>
       <div class="site-header">
         <a class="brand" href="index.html">
-          <img src="img/logo-xolos-ramirez.svg" alt="Logo de Xolos Ramirez" width="44" height="44" />
+          <img src="img/logo-xolos-ramirez.svg" alt="Logo de Xolos Ramirez" width="44" height="44" loading="lazy" />
           <span>Xolos Ramirez</span>
         </a>
         <button class="menu-toggle" type="button" data-menu-toggle aria-expanded="false">

--- a/xolos-disponibles.html
+++ b/xolos-disponibles.html
@@ -15,7 +15,7 @@
     <header>
       <div class="site-header">
         <a class="brand" href="index.html">
-          <img src="img/logo-xolos-ramirez.svg" alt="Logo de Xolos Ramirez" width="44" height="44" />
+          <img src="img/logo-xolos-ramirez.svg" alt="Logo de Xolos Ramirez" width="44" height="44" loading="lazy" />
           <span>Xolos Ramirez</span>
         </a>
         <button class="menu-toggle" type="button" data-menu-toggle aria-expanded="false">
@@ -57,7 +57,7 @@
         <h2>Perfiles destacados</h2>
         <div class="grid grid-2">
           <article class="card">
-            <img src="img/xolos/tonatiuh.svg" alt="Xoloitzcuintle joven llamado Tonatiuh" />
+            <img src="img/xolos/tonatiuh.svg" alt="Xoloitzcuintle joven llamado Tonatiuh" loading="lazy" />
             <h3>Tonatiuh</h3>
             <p>
               Macho de 1 año, energético y sociable. Ideal para familias activas
@@ -67,7 +67,7 @@
             <a href="contacto.html">Solicitar entrevista</a>
           </article>
           <article class="card">
-            <img src="img/xolos/itzel.svg" alt="Xoloitzcuintle adulta llamada Itzel" />
+            <img src="img/xolos/itzel.svg" alt="Xoloitzcuintle adulta llamada Itzel" loading="lazy" />
             <h3>Itzel</h3>
             <p>
               Hembra de 4 años, tranquila y cariñosa. Se adapta perfectamente a
@@ -77,7 +77,7 @@
             <a href="contacto.html">Concertar visita</a>
           </article>
           <article class="card">
-            <img src="img/xolos/xolo-mini.svg" alt="Xoloitzcuintle miniatura en adopción" />
+            <img src="img/xolos/xolo-mini.svg" alt="Xoloitzcuintle miniatura en adopción" loading="lazy" />
             <h3>Citlali</h3>
             <p>
               Xolo miniatura de 8 meses. Necesita rutinas de estimulación mental y
@@ -87,7 +87,7 @@
             <a href="contacto.html">Más información</a>
           </article>
           <article class="card">
-            <img src="img/xolos/ancestro.svg" alt="Xoloitzcuintle senior descansando" />
+            <img src="img/xolos/ancestro.svg" alt="Xoloitzcuintle senior descansando" loading="lazy" />
             <h3>Huehue</h3>
             <p>
               Senior de 9 años con carácter noble. Requiere controles veterinarios


### PR DESCRIPTION
## Summary
- replace the global stylesheet with the new soft terracotta palette while improving focus and hover states for WCAG AA contrast
- align section, button, and layout styles with the refreshed palette across the site
- add loading="lazy" to every image on the public pages to defer non-critical loading

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68e80ec7e1cc8332bf81edce70b6ddfb