### PR TITLE
Improve navigation accessibility semantics

### DIFF
--- a/blog/cuidados-basicos.html
+++ b/blog/cuidados-basicos.html
@@ -62,11 +62,17 @@
           />
           <span>Xolos Ramirez</span>
         </a>
-        <button class="menu-toggle" type="button" data-menu-toggle aria-expanded="false">
+        <button
+          class="menu-toggle"
+          type="button"
+          data-menu-toggle
+          aria-expanded="false"
+          aria-controls="menu-principal"
+        >
           Menú
         </button>
         <nav role="navigation" aria-label="Navegación principal">
-          <ul data-menu-list data-open="false">
+          <ul id="menu-principal" data-menu-list data-open="false">
             <li><a href="../index.html">Inicio</a></li>
             <li><a href="../xolos-disponibles.html">Xolos disponibles</a></li>
             <li><a href="../galeria.html">Galería</a></li>

--- a/blog/cultura-mexicana.html
+++ b/blog/cultura-mexicana.html
@@ -62,11 +62,17 @@
           />
           <span>Xolos Ramirez</span>
         </a>
-        <button class="menu-toggle" type="button" data-menu-toggle aria-expanded="false">
+        <button
+          class="menu-toggle"
+          type="button"
+          data-menu-toggle
+          aria-expanded="false"
+          aria-controls="menu-principal"
+        >
           Menú
         </button>
         <nav role="navigation" aria-label="Navegación principal">
-          <ul data-menu-list data-open="false">
+          <ul id="menu-principal" data-menu-list data-open="false">
             <li><a href="../index.html">Inicio</a></li>
             <li><a href="../xolos-disponibles.html">Xolos disponibles</a></li>
             <li><a href="../galeria.html">Galería</a></li>

--- a/blog/entrada-1.html
+++ b/blog/entrada-1.html
@@ -62,11 +62,17 @@
           />
           <span>Xolos Ramirez</span>
         </a>
-        <button class="menu-toggle" type="button" data-menu-toggle aria-expanded="false">
+        <button
+          class="menu-toggle"
+          type="button"
+          data-menu-toggle
+          aria-expanded="false"
+          aria-controls="menu-principal"
+        >
           Menú
         </button>
         <nav role="navigation" aria-label="Navegación principal">
-          <ul data-menu-list data-open="false">
+          <ul id="menu-principal" data-menu-list data-open="false">
             <li><a href="../index.html">Inicio</a></li>
             <li><a href="../xolos-disponibles.html">Xolos disponibles</a></li>
             <li><a href="../galeria.html">Galería</a></li>

--- a/blog/entrada-2.html
+++ b/blog/entrada-2.html
@@ -62,11 +62,17 @@
           />
           <span>Xolos Ramirez</span>
         </a>
-        <button class="menu-toggle" type="button" data-menu-toggle aria-expanded="false">
+        <button
+          class="menu-toggle"
+          type="button"
+          data-menu-toggle
+          aria-expanded="false"
+          aria-controls="menu-principal"
+        >
           Menú
         </button>
         <nav role="navigation" aria-label="Navegación principal">
-          <ul data-menu-list data-open="false">
+          <ul id="menu-principal" data-menu-list data-open="false">
             <li><a href="../index.html">Inicio</a></li>
             <li><a href="../xolos-disponibles.html">Xolos disponibles</a></li>
             <li><a href="../galeria.html">Galería</a></li>

--- a/blog/historia-xoloitzcuintle.html
+++ b/blog/historia-xoloitzcuintle.html
@@ -62,11 +62,17 @@
           />
           <span>Xolos Ramirez</span>
         </a>
-        <button class="menu-toggle" type="button" data-menu-toggle aria-expanded="false">
+        <button
+          class="menu-toggle"
+          type="button"
+          data-menu-toggle
+          aria-expanded="false"
+          aria-controls="menu-principal"
+        >
           Menú
         </button>
         <nav role="navigation" aria-label="Navegación principal">
-          <ul data-menu-list data-open="false">
+          <ul id="menu-principal" data-menu-list data-open="false">
             <li><a href="../index.html">Inicio</a></li>
             <li><a href="../xolos-disponibles.html">Xolos disponibles</a></li>
             <li><a href="../galeria.html">Galería</a></li>

--- a/blog/index.html
+++ b/blog/index.html
@@ -35,11 +35,17 @@
           />
           <span>Xolos Ramirez</span>
         </a>
-        <button class="menu-toggle" type="button" data-menu-toggle aria-expanded="false">
+        <button
+          class="menu-toggle"
+          type="button"
+          data-menu-toggle
+          aria-expanded="false"
+          aria-controls="menu-principal"
+        >
           Menú
         </button>
         <nav role="navigation" aria-label="Navegación principal">
-          <ul data-menu-list data-open="false">
+          <ul id="menu-principal" data-menu-list data-open="false">
             <li><a href="../index.html">Inicio</a></li>
             <li><a href="../xolos-disponibles.html">Xolos disponibles</a></li>
             <li><a href="../galeria.html">Galería</a></li>

--- a/contacto.html
+++ b/contacto.html
@@ -35,11 +35,17 @@
           />
           <span>Xolos Ramirez</span>
         </a>
-        <button class="menu-toggle" type="button" data-menu-toggle aria-expanded="false">
+        <button
+          class="menu-toggle"
+          type="button"
+          data-menu-toggle
+          aria-expanded="false"
+          aria-controls="menu-principal"
+        >
           Menú
         </button>
         <nav role="navigation" aria-label="Navegación principal">
-          <ul data-menu-list data-open="false">
+          <ul id="menu-principal" data-menu-list data-open="false">
             <li><a href="index.html">Inicio</a></li>
             <li><a href="xolos-disponibles.html">Xolos disponibles</a></li>
             <li><a href="galeria.html">Galería</a></li>

--- a/galeria.html
+++ b/galeria.html
@@ -35,11 +35,17 @@
           />
           <span>Xolos Ramirez</span>
         </a>
-        <button class="menu-toggle" type="button" data-menu-toggle aria-expanded="false">
+        <button
+          class="menu-toggle"
+          type="button"
+          data-menu-toggle
+          aria-expanded="false"
+          aria-controls="menu-principal"
+        >
           Menú
         </button>
         <nav role="navigation" aria-label="Navegación principal">
-          <ul data-menu-list data-open="false">
+          <ul id="menu-principal" data-menu-list data-open="false">
             <li><a href="index.html">Inicio</a></li>
             <li><a href="xolos-disponibles.html">Xolos disponibles</a></li>
             <li><a href="galeria.html">Galería</a></li>

--- a/index.html
+++ b/index.html
@@ -35,11 +35,17 @@
           />
           <span>Xolos Ramirez</span>
         </a>
-        <button class="menu-toggle" type="button" data-menu-toggle aria-expanded="false">
+        <button
+          class="menu-toggle"
+          type="button"
+          data-menu-toggle
+          aria-expanded="false"
+          aria-controls="menu-principal"
+        >
           Menú
         </button>
         <nav role="navigation" aria-label="Navegación principal">
-          <ul data-menu-list data-open="false">
+          <ul id="menu-principal" data-menu-list data-open="false">
             <li><a href="index.html">Inicio</a></li>
             <li><a href="xolos-disponibles.html">Xolos disponibles</a></li>
             <li><a href="galeria.html">Galería</a></li>

--- a/js/main.js
+++ b/js/main.js
@@ -1,1 +1,73 @@
-const menuToggle=document.querySelector("[data-menu-toggle]"),menuList=document.querySelector("[data-menu-list]");menuToggle&&menuList&&menuToggle.addEventListener("click",()=>{const e="true"===menuList.getAttribute("data-open");menuList.setAttribute("data-open",String(!e)),menuToggle.setAttribute("aria-expanded",String(!e))});const yearElement=document.getElementById("year");yearElement&&(yearElement.textContent=String((new Date).getFullYear()));const currentPath=window.location.pathname.replace(/\/index\.html$/,"/");menuList&&[...menuList.querySelectorAll("a")].forEach(e=>{const t=new URL(e.getAttribute("href"),window.location.origin+window.location.pathname).pathname.replace(/\/index\.html$/,"/");("/"!==t&&currentPath.endsWith(t)||"/"===t&&"/"===currentPath)&&e.setAttribute("aria-current","page")});
+const menuToggle = document.querySelector('[data-menu-toggle]');
+const menuList = document.querySelector('[data-menu-list]');
+
+const setMenuState = (isOpen) => {
+  if (!menuList) return;
+  menuList.setAttribute('data-open', String(isOpen));
+  menuList.setAttribute('aria-hidden', isOpen ? 'false' : 'true');
+  if (menuToggle) {
+    menuToggle.setAttribute('aria-expanded', String(isOpen));
+  }
+};
+
+const syncMenuWithViewport = (mediaQuery) => {
+  if (!menuList) return;
+  if (mediaQuery.matches) {
+    setMenuState(true);
+    return;
+  }
+  const expanded =
+    menuToggle && menuToggle.getAttribute('aria-expanded') === 'true';
+  setMenuState(Boolean(expanded));
+};
+
+if (menuToggle && menuList) {
+  menuToggle.addEventListener('click', () => {
+    const isOpen = menuList.getAttribute('data-open') === 'true';
+    setMenuState(!isOpen);
+  });
+
+  const mediaQuery = window.matchMedia('(min-width: 769px)');
+  syncMenuWithViewport(mediaQuery);
+
+  const handleViewportChange = (event) => {
+    syncMenuWithViewport(event);
+  };
+
+  if (typeof mediaQuery.addEventListener === 'function') {
+    mediaQuery.addEventListener('change', handleViewportChange);
+  } else if (typeof mediaQuery.addListener === 'function') {
+    mediaQuery.addListener(handleViewportChange);
+  }
+} else if (menuList) {
+  setMenuState(true);
+}
+
+const yearElement = document.getElementById('year');
+if (yearElement) {
+  yearElement.textContent = String(new Date().getFullYear());
+}
+
+const currentPath = window.location.pathname.replace(/\/index\.html$/, '/');
+
+if (menuList) {
+  const links = menuList.querySelectorAll('a');
+  links.forEach((link) => {
+    const href = link.getAttribute('href');
+    if (!href) return;
+
+    const targetPath = new URL(
+      href,
+      window.location.origin + window.location.pathname,
+    )
+      .pathname.replace(/\/index\.html$/, '/');
+
+    const isCurrentPage =
+      (targetPath !== '/' && currentPath.endsWith(targetPath)) ||
+      (targetPath === '/' && currentPath === '/');
+
+    if (isCurrentPage) {
+      link.setAttribute('aria-current', 'page');
+    }
+  });
+}

--- a/testimonios.html
+++ b/testimonios.html
@@ -35,11 +35,17 @@
           />
           <span>Xolos Ramirez</span>
         </a>
-        <button class="menu-toggle" type="button" data-menu-toggle aria-expanded="false">
+        <button
+          class="menu-toggle"
+          type="button"
+          data-menu-toggle
+          aria-expanded="false"
+          aria-controls="menu-principal"
+        >
           Menú
         </button>
         <nav role="navigation" aria-label="Navegación principal">
-          <ul data-menu-list data-open="false">
+          <ul id="menu-principal" data-menu-list data-open="false">
             <li><a href="index.html">Inicio</a></li>
             <li><a href="xolos-disponibles.html">Xolos disponibles</a></li>
             <li><a href="galeria.html">Galería</a></li>

--- a/xolos-disponibles.html
+++ b/xolos-disponibles.html
@@ -35,11 +35,17 @@
           />
           <span>Xolos Ramirez</span>
         </a>
-        <button class="menu-toggle" type="button" data-menu-toggle aria-expanded="false">
+        <button
+          class="menu-toggle"
+          type="button"
+          data-menu-toggle
+          aria-expanded="false"
+          aria-controls="menu-principal"
+        >
           Menú
         </button>
         <nav role="navigation" aria-label="Navegación principal">
-          <ul data-menu-list data-open="false">
+          <ul id="menu-principal" data-menu-list data-open="false">
             <li><a href="index.html">Inicio</a></li>
             <li><a href="xolos-disponibles.html">Xolos disponibles</a></li>
             <li><a href="galeria.html">Galería</a></li>


### PR DESCRIPTION
## Summary
- connect the responsive menu toggle to the primary navigation list with matching aria-controls/ids across the site and blog pages
- update the menu script to manage aria-hidden and aria-expanded states for better keyboard and screen reader support while keeping existing highlighting logic

## Testing
- no automated tests were run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68e82ee9c9988332b5d3735f95f979bd