### PR TITLE
Add parallax hero background to xolos disponibles page

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -59,3 +59,19 @@
   box-shadow:0 12px 24px rgba(166,39,0,.35);
 }
 
+.hero.hero-disponibles{
+  position:relative;
+  display:flex;
+  flex-direction:column;
+  justify-content:center;
+  align-items:center;
+  min-height:100vh;
+  padding:0 1.5rem;
+  text-align:center;
+  background-image:linear-gradient(120deg,rgba(166,39,0,.75),rgba(50,50,50,.85)),url('../img/hero/ceremonia.svg');
+  background-size:cover;
+  background-position:center;
+  background-repeat:no-repeat;
+  background-attachment:fixed;
+}
+

--- a/public/xolos-disponibles.html
+++ b/public/xolos-disponibles.html
@@ -39,7 +39,7 @@
   <!-- Contenido principal -->
   <main id="contenido-principal">
     <!-- Hero Section -->
-    <section class="hero">
+    <section class="hero hero-disponibles">
       <h1>Xoloitzcuintles disponibles</h1>
       <p>Conoce a nuestros cachorros Xoloitzcuintle disponibles. Aquí encontrarás su talla, color, sexo, edad y estado. ¡El guardián de tu historia te espera!</p>
     </section>

--- a/xolos-disponibles.html
+++ b/xolos-disponibles.html
@@ -59,7 +59,7 @@
     </header>
 
     <main id="contenido-principal">
-      <section class="hero">
+      <section class="hero hero-disponibles">
         <h1>Xolos disponibles</h1>
         <p>
           Conoce a los xolositzcuintles que buscan un hogar. Cada ficha incluye


### PR DESCRIPTION
## Summary
- update the hero section on xolos disponibles to use a full-screen parallax background
- add page-specific styling to center the content and pin the background image
- mirror the hero markup change in the public build output

## Testing
- no automated tests were run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68f256f3eff08332a891bc239f81f3db