### PR TITLE
Add parallax styling to reservation sections

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -75,3 +75,9 @@
   background-attachment:fixed;
 }
 
+
+.parallax{background-attachment:fixed;background-position:center;background-size:cover;background-repeat:no-repeat;position:relative;isolation:isolate;color:var(--text-color);}
+.parallax::before{content:"";position:absolute;inset:0;background:rgba(0,0,0,0.55);z-index:0;pointer-events:none;}
+.parallax>*{position:relative;z-index:1;}
+.como-reservar.parallax{background-image:linear-gradient(180deg,rgba(19,19,19,0.6),rgba(19,19,19,0.9)),url('../img/xolos/1.webp');}
+.politica-reserva.parallax{background-image:linear-gradient(180deg,rgba(19,19,19,0.6),rgba(19,19,19,0.9)),url('../img/xolos/2.webp');}

--- a/public/xolos-disponibles.html
+++ b/public/xolos-disponibles.html
@@ -132,7 +132,7 @@
     </section>
 
     <!-- Sección ¿Cómo reservo? -->
-    <section class="como-reservar">
+    <section class="como-reservar parallax">
       <h2>¿Cómo reservo?</h2>
       <div class="pasos-reserva">
         <div class="paso">
@@ -151,7 +151,7 @@
     </section>
 
     <!-- Sección Política de Reserva -->
-    <section class="politica-reserva">
+    <section class="politica-reserva parallax">
       <h2>Política de Reserva</h2>
       <p><strong>Anticipo:</strong> Para apartar un cachorro, solicitamos un depósito inicial. Este anticipo confirma tu reservación y <u>no es reembolsable</u> en caso de cancelación.</p>
       <p><strong>Métodos de pago:</strong> Puedes realizar el pago vía transferencia bancaria, depósito en OXXO o en efectivo (en CDMX). Te proporcionaremos los datos y opciones al momento de la reserva.</p>


### PR DESCRIPTION
## Summary
- add a reusable `.parallax` helper with fixed background support and overlays
- apply the parallax treatment to the reservation and policy sections on the availability page

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68f257e5fcd08332bc71811bcf2291e2