### PR TITLE
Apply noir-inspired color palette

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -1,83 +1,640 @@
-:root{color-scheme:dark;font-family:Poppins,sans-serif;line-height:1.6;--primary-color:#cba135;--secondary-color:#8c6a3b;--bg-color:#111111;--text-color:#f1e6d6;--accent-color:#bfa87a;--dark-accent:#cba135;--surface-color:#1c1c1c;--muted-text:#d1c6b5;--max-width:1100px}*{box-sizing:border-box}body{margin:0;background-color:#111111;color:#f1e6d6;font-family:'Poppins',sans-serif;line-height:1.6}h1,h2,h3,h4,h5,h6{color:#cba135;text-shadow:2px 2px 8px rgba(0,0,0,0.7);font-family:'Marcellus',serif;text-transform:uppercase;letter-spacing:1px}a{color:#cba135;text-decoration:none}a:focus,a:hover{text-decoration:underline}.btn{display:inline-flex;align-items:center;justify-content:center;gap:.5rem;background-color:var(--primary-color);color:#fff;padding:.8rem 1.6rem;border-radius:.5rem;border:none;cursor:pointer;font-weight:600;transition:background-color .3s ease,transform .2s ease}.btn:focus,.btn:hover{background-color:#872000}.btn:focus-visible{outline:3px solid rgba(50,50,50,.35);outline-offset:2px}header{background:var(--dark-accent);color:var(--bg-color);position:sticky;top:0;z-index:10}.site-header{display:flex;align-items:center;justify-content:space-between;max-width:var(--max-width);margin:0 auto;padding:1rem}.brand{display:inline-flex;align-items:center;gap:.75rem;font-weight:700;font-size:1.1rem;letter-spacing:.08em;text-transform:uppercase;color:var(--bg-color)}.brand img{width:44px;height:44px;border-radius:50%;object-fit:cover;box-shadow:0 4px 12px rgba(0,0,0,.15);background:#fff;padding:.25rem}nav ul{list-style:none;display:flex;gap:1rem;margin:0;padding:0}nav a{font-weight:600;color:var(--bg-color);transition:color .2s ease}nav a:focus,nav a:hover{color:var(--accent-color)}.hero{background-image:linear-gradient(120deg,rgba(166,39,0,.9),rgba(50,50,50,.85)),url('../img/hero/hero-placeholder.svg');background-position:center;background-size:cover;background-repeat:no-repeat;color:#fff;padding:clamp(4rem,8vw,6rem) 1rem;text-align:center}.hero{background-image:linear-gradient(120deg,rgba(166,39,0,.9),rgba(50,50,50,.85)),url('../img/hero/hero-placeholder.svg')}.hero h1{font-size:clamp(2.5rem, 6vw, 3.5rem);margin-bottom:1rem}.hero p{max-width:45ch;margin:0 auto}main{max-width:var(--max-width);margin:0 auto;padding:2rem 1rem 4rem;display:grid;gap:2rem}section{background:var(--surface-color);padding:3rem 1rem;border-radius:.75rem;box-shadow:0 10px 30px rgba(50,50,50,.08)}section h2{margin-top:0;color:var(--dark-accent)}.grid{display:grid;gap:1.5rem}.grid-2{grid-template-columns:repeat(auto-fit,minmax(250px,1fr))}.card{background:rgba(0,0,0,.6);border:2px solid #d4af37;border-radius:.75rem;padding:1.25rem;display:flex;flex-direction:column;gap:.75rem;color:#fdf6d8;box-shadow:0 10px 30px rgba(0,0,0,.15);transition:transform .25s ease,box-shadow .25s ease}.card:hover{transform:translateY(-4px);box-shadow:0 16px 40px rgba(0,0,0,.25)}.card img{width:100%;height:200px;object-fit:cover;border-radius:.5rem}blockquote{margin:0;padding-left:1.25rem;border-left:4px solid var(--secondary-color);color:var(--muted-text)}.callout{background:rgba(107,112,92,.15);border-left:4px solid var(--secondary-color);padding:1rem 1.25rem;border-radius:.5rem}footer{background:var(--dark-accent);color:var(--bg-color)}.footer-grid{max-width:var(--max-width);margin:0 auto;padding:2rem 1rem;display:grid;gap:1.5rem}.footer-grid div{display:flex;flex-direction:column;gap:.75rem}.footer-grid h3,.footer-grid h4{margin:0;font-weight:600}.footer-grid p{margin:0;line-height:1.6}.footer-grid ul{list-style:none;margin:0;padding:0;display:flex;flex-direction:column;gap:.5rem}.footer-grid a{color:var(--bg-color);text-decoration:none}.footer-grid a:focus,.footer-grid a:hover{text-decoration:underline}.copyright{text-align:center;margin:0;padding:1.5rem 1rem;border-top:1px solid rgba(253,248,240,.15);font-size:.875rem;color:rgba(253,248,240,.8)}@media (min-width:768px){.footer-grid{grid-template-columns:repeat(3,minmax(0,1fr));align-items:flex-start}.footer-grid div:nth-child(1){max-width:22rem}}small{color:rgba(253,248,240,.8)}form{display:grid;gap:1rem}label{font-weight:600;color:var(--dark-accent)}input,select,textarea{width:100%;padding:.75rem;border-radius:.5rem;border:1px solid rgba(50,50,50,.15);font-size:1rem;font-family:inherit;background:#fff;color:var(--text-color)}input:focus,select:focus,textarea:focus{outline:3px solid rgba(166,39,0,.35);outline-offset:2px}button{background:var(--primary-color);color:#fff;border:none;padding:.75rem 1.5rem;border-radius:999px;font-size:1rem;font-weight:600;cursor:pointer;transition:background-color .3s ease}button:focus,button:hover{background:#872000}button:focus-visible{outline:3px solid rgba(50,50,50,.35);outline-offset:2px}.table{width:100%;border-collapse:collapse}.table td,.table th{padding:.75rem;border-bottom:1px solid rgba(50,50,50,.15);text-align:left}.table th{color:var(--primary-color);font-size:.95rem;text-transform:uppercase;letter-spacing:.05em}img{max-width:100%;border-radius:8px;display:block}.visually-hidden{position:absolute;clip:rect(1px,1px,1px,1px);padding:0;border:0;height:1px;width:1px;overflow:hidden}@media (max-width:768px){nav ul{flex-direction:column;background:var(--dark-accent);position:absolute;right:1rem;top:72px;padding:1rem;border-radius:.75rem;box-shadow:0 15px 30px rgba(0,0,0,.25);transform:scale(0);transform-origin:top right;transition:transform .2s ease}nav ul[data-open=true]{transform:scale(1)}.menu-toggle{display:inline-flex;background:0 0;border:2px solid var(--bg-color);color:var(--bg-color);padding:.25rem .75rem;border-radius:999px;font-weight:600}}@media (min-width:769px){.menu-toggle{display:none}}.blog-hero{background:linear-gradient(120deg,rgba(166,39,0,.85),rgba(50,50,50,.9))}.article{display:grid;gap:1.5rem}.article header{position:static;background:0 0;color:inherit}.article figure{margin:0}.article img{width:100%;border-radius:.75rem}.article footer{background:0 0;color:inherit}
-.skip-link{position:absolute;left:0;top:-200px;background:var(--primary-color);color:#ffffff;padding:.75rem 1.5rem;font-weight:600;border-radius:0 0 .75rem .75rem;transition:top .3s ease;z-index:100}.skip-link:focus-visible{top:0}body :focus-visible{outline:3px solid var(--primary-color);outline-offset:2px;box-shadow:0 0 0 4px var(--bg-color)}
-
-#testimonios,#galeria,#cta{
-  background:var(--surface-color);
-  padding:3rem 2rem;
-  border-radius:20px;
-  box-shadow:0 18px 36px rgba(0,0,0,.08);
-  margin:3.5rem auto;
-  max-width:var(--max-width);
-}
-#testimonios h2,#galeria h2,#cta h2{
-  text-align:center;
-  margin-top:0;
-  margin-bottom:2rem;
-}
-#testimonios .grid{
-  display:grid;
-  grid-template-columns:repeat(auto-fit,minmax(260px,1fr));
-  gap:2rem;
-}
-#testimonios blockquote{
-  background:var(--bg-color);
-  padding:1.75rem;
-  border-radius:16px;
-  box-shadow:0 12px 28px rgba(0,0,0,.05);
-  margin:0;
-  font-style:italic;
-}
-#testimonios cite{
-  display:block;
-  margin-top:1.25rem;
-  font-style:normal;
-  font-weight:600;
-  color:var(--secondary-color);
-}
-#galeria .gallery-grid{
-  display:grid;
-  grid-template-columns:repeat(auto-fit,minmax(220px,1fr));
-  gap:1.5rem;
-}
-#galeria img{
-  width:100%;
-  display:block;
-  border-radius:16px;
-  box-shadow:0 16px 32px rgba(0,0,0,.12);
-  object-fit:cover;
-}
-#cta{
-  text-align:center;
-  display:grid;
-  place-items:center;
-  gap:1.5rem;
-}
-#cta .btn{
-  padding:.875rem 2.5rem;
-  font-weight:600;
-  border-radius:999px;
-  box-shadow:0 12px 24px rgba(166,39,0,.35);
+:root {
+  color-scheme: dark;
+  font-family: 'Poppins', sans-serif;
+  line-height: 1.6;
+  --color-primario: #161616;
+  --color-secundario: #1f1f1f;
+  --color-superficie: #221b1f;
+  --color-superficie-alt: #291f24;
+  --color-texto: #f5efe6;
+  --color-texto-suave: #d5c6b0;
+  --color-dorado: #d4af37;
+  --color-ambar: #fb923c;
+  --color-enfasis: #9e1f1f;
+  --color-borde: rgba(212, 175, 55, 0.35);
+  --color-borde-intenso: rgba(212, 175, 55, 0.65);
+  --sombra-suave: 0 18px 40px rgba(0, 0, 0, 0.45);
+  --sombra-profunda: 0 25px 60px rgba(0, 0, 0, 0.55);
+  --max-width: 1100px;
 }
 
-.hero.hero-disponibles{
-  position:relative;
-  display:flex;
-  flex-direction:column;
-  justify-content:center;
-  align-items:center;
-  min-height:100vh;
-  padding:0 1.5rem;
-  text-align:center;
-  background-image:linear-gradient(120deg,rgba(166,39,0,.75),rgba(50,50,50,.85)),url('../img/hero/ceremonia.svg');
-  background-size:cover;
-  background-position:center;
-  background-repeat:no-repeat;
-  background-attachment:fixed;
+* {
+  box-sizing: border-box;
 }
 
+body {
+  margin: 0;
+  background: radial-gradient(circle at top, rgba(47, 33, 23, 0.35), transparent 60%), var(--color-primario);
+  color: var(--color-texto);
+  font-family: 'Poppins', sans-serif;
+  line-height: 1.6;
+}
 
-.parallax{background-attachment:fixed;background-position:center;background-size:cover;background-repeat:no-repeat;position:relative;isolation:isolate;color:var(--text-color);}
-.parallax::before{content:"";position:absolute;inset:0;background:rgba(0,0,0,0.55);z-index:0;pointer-events:none;}
-.parallax>*{position:relative;z-index:1;}
-.como-reservar.parallax{background-image:linear-gradient(180deg,rgba(19,19,19,0.6),rgba(19,19,19,0.9)),url('../img/xolos/1.webp');}
-.politica-reserva.parallax{background-image:linear-gradient(180deg,rgba(19,19,19,0.6),rgba(19,19,19,0.9)),url('../img/xolos/2.webp');}
+h1,
+h2,
+h3,
+h4,
+h5,
+h6 {
+  color: var(--color-dorado);
+  text-shadow: 0 6px 18px rgba(0, 0, 0, 0.55);
+  font-family: 'Marcellus', serif;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+}
+
+a {
+  color: var(--color-ambar);
+  text-decoration: none;
+  transition: color 0.3s ease, text-shadow 0.3s ease;
+}
+
+a:focus,
+a:hover {
+  color: var(--color-dorado);
+  text-shadow: 0 0 16px rgba(251, 146, 60, 0.6);
+}
+
+.btn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.5rem;
+  background: linear-gradient(135deg, var(--color-dorado), var(--color-ambar));
+  color: #080808;
+  padding: 0.85rem 1.75rem;
+  border-radius: 999px;
+  border: 1px solid var(--color-borde-intenso);
+  cursor: pointer;
+  font-weight: 600;
+  letter-spacing: 0.05em;
+  text-transform: uppercase;
+  transition: transform 0.25s ease, box-shadow 0.25s ease, filter 0.25s ease;
+  box-shadow: 0 15px 35px rgba(251, 146, 60, 0.35);
+}
+
+.btn:focus,
+.btn:hover {
+  transform: translateY(-2px) scale(1.02);
+  box-shadow: 0 18px 45px rgba(212, 175, 55, 0.4);
+  filter: saturate(1.1);
+}
+
+.btn:focus-visible {
+  outline: 3px solid rgba(251, 146, 60, 0.55);
+  outline-offset: 3px;
+}
+
+header {
+  background: linear-gradient(135deg, rgba(20, 18, 18, 0.95), rgba(41, 26, 18, 0.9));
+  color: var(--color-texto);
+  position: sticky;
+  top: 0;
+  z-index: 10;
+  backdrop-filter: blur(8px);
+  border-bottom: 1px solid var(--color-borde);
+}
+
+.site-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  max-width: var(--max-width);
+  margin: 0 auto;
+  padding: 1rem;
+}
+
+.brand {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.75rem;
+  font-weight: 700;
+  font-size: 1.1rem;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+  color: var(--color-dorado);
+}
+
+.brand img {
+  width: 44px;
+  height: 44px;
+  border-radius: 50%;
+  object-fit: cover;
+  box-shadow: 0 6px 20px rgba(0, 0, 0, 0.45);
+  background: var(--color-superficie);
+  padding: 0.25rem;
+  border: 1px solid var(--color-borde);
+}
+
+nav ul {
+  list-style: none;
+  display: flex;
+  gap: 1rem;
+  margin: 0;
+  padding: 0;
+}
+
+nav a {
+  font-weight: 600;
+  color: var(--color-texto);
+  padding: 0.35rem 0.5rem;
+  border-radius: 999px;
+  transition: color 0.3s ease, background 0.3s ease, box-shadow 0.3s ease;
+}
+
+nav a:focus,
+nav a:hover {
+  color: #090909;
+  background: linear-gradient(135deg, rgba(212, 175, 55, 0.95), rgba(251, 146, 60, 0.9));
+  box-shadow: 0 12px 28px rgba(0, 0, 0, 0.35);
+}
+
+.hero {
+  background-image: linear-gradient(120deg, rgba(14, 11, 11, 0.85), rgba(68, 27, 18, 0.85)), url('../img/hero/hero-placeholder.svg');
+  background-position: center;
+  background-size: cover;
+  background-repeat: no-repeat;
+  color: var(--color-texto);
+  padding: clamp(4rem, 8vw, 6rem) 1rem;
+  text-align: center;
+  box-shadow: var(--sombra-suave);
+}
+
+.hero h1 {
+  font-size: clamp(2.5rem, 6vw, 3.5rem);
+  margin-bottom: 1rem;
+}
+
+.hero p {
+  max-width: 45ch;
+  margin: 0 auto;
+  color: var(--color-texto-suave);
+}
+
+main {
+  max-width: var(--max-width);
+  margin: 0 auto;
+  padding: 2rem 1rem 4rem;
+  display: grid;
+  gap: 2rem;
+}
+
+section {
+  background: linear-gradient(160deg, rgba(34, 27, 31, 0.95), rgba(25, 20, 25, 0.85));
+  padding: 3rem 1rem;
+  border-radius: 0.85rem;
+  box-shadow: var(--sombra-suave);
+  border: 1px solid rgba(255, 255, 255, 0.02);
+}
+
+section h2 {
+  margin-top: 0;
+  color: var(--color-dorado);
+}
+
+.grid {
+  display: grid;
+  gap: 1.5rem;
+}
+
+.grid-2 {
+  grid-template-columns: repeat(auto-fit, minmax(250px, 1fr));
+}
+
+.card {
+  background: linear-gradient(145deg, rgba(24, 20, 18, 0.9), rgba(40, 28, 26, 0.9));
+  border: 1px solid var(--color-borde);
+  border-radius: 0.85rem;
+  padding: 1.5rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.85rem;
+  color: var(--color-texto);
+  box-shadow: var(--sombra-suave);
+  transition: transform 0.25s ease, box-shadow 0.25s ease, border-color 0.25s ease;
+}
+
+.card:hover {
+  transform: translateY(-6px);
+  box-shadow: var(--sombra-profunda);
+  border-color: var(--color-borde-intenso);
+}
+
+.card img {
+  width: 100%;
+  height: 200px;
+  object-fit: cover;
+  border-radius: 0.65rem;
+  box-shadow: 0 15px 35px rgba(0, 0, 0, 0.35);
+}
+
+blockquote {
+  margin: 0;
+  padding-left: 1.25rem;
+  border-left: 4px solid var(--color-dorado);
+  color: var(--color-texto-suave);
+}
+
+.callout {
+  background: rgba(251, 146, 60, 0.08);
+  border-left: 4px solid var(--color-ambar);
+  padding: 1rem 1.25rem;
+  border-radius: 0.65rem;
+}
+
+footer {
+  background: linear-gradient(135deg, rgba(12, 11, 11, 0.95), rgba(35, 17, 17, 0.95));
+  color: var(--color-texto);
+  border-top: 1px solid var(--color-borde);
+}
+
+.footer-grid {
+  max-width: var(--max-width);
+  margin: 0 auto;
+  padding: 2.5rem 1rem;
+  display: grid;
+  gap: 1.75rem;
+}
+
+.footer-grid div {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.footer-grid h3,
+.footer-grid h4 {
+  margin: 0;
+  font-weight: 600;
+  color: var(--color-dorado);
+}
+
+.footer-grid p {
+  margin: 0;
+  line-height: 1.6;
+  color: var(--color-texto-suave);
+}
+
+.footer-grid ul {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  display: grid;
+  gap: 0.5rem;
+}
+
+.footer-grid a {
+  color: var(--color-texto);
+  position: relative;
+  padding-left: 0.75rem;
+}
+
+.footer-grid a::before {
+  content: '';
+  position: absolute;
+  left: 0;
+  top: 0.6em;
+  width: 6px;
+  height: 6px;
+  border-radius: 50%;
+  background: var(--color-ambar);
+  box-shadow: 0 0 12px rgba(251, 146, 60, 0.6);
+}
+
+.footer-grid a:focus,
+.footer-grid a:hover {
+  color: var(--color-dorado);
+}
+
+.copyright {
+  text-align: center;
+  padding: 1.5rem 1rem;
+  border-top: 1px solid rgba(255, 255, 255, 0.06);
+  color: var(--color-texto-suave);
+}
+
+@media (min-width: 768px) {
+  .footer-grid {
+    grid-template-columns: repeat(3, minmax(0, 1fr));
+  }
+
+  .footer-grid div:nth-child(1) {
+    grid-column: span 2;
+  }
+}
+
+small {
+  color: var(--color-texto-suave);
+}
+
+form {
+  display: grid;
+  gap: 1rem;
+  background: var(--color-superficie);
+  padding: 2rem;
+  border-radius: 0.85rem;
+  box-shadow: var(--sombra-suave);
+  border: 1px solid rgba(255, 255, 255, 0.04);
+}
+
+label {
+  font-weight: 600;
+  color: var(--color-dorado);
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+}
+
+input,
+select,
+textarea {
+  width: 100%;
+  padding: 0.9rem 1rem;
+  border-radius: 0.65rem;
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  background: rgba(10, 10, 10, 0.65);
+  color: var(--color-texto);
+  transition: border-color 0.3s ease, box-shadow 0.3s ease;
+}
+
+input:focus,
+select:focus,
+textarea:focus {
+  border-color: var(--color-ambar);
+  box-shadow: 0 0 0 3px rgba(251, 146, 60, 0.25);
+  outline: none;
+}
+
+button {
+  background: linear-gradient(135deg, var(--color-dorado), var(--color-ambar));
+  color: #080808;
+  padding: 0.85rem 1.75rem;
+  border-radius: 999px;
+  border: 1px solid var(--color-borde-intenso);
+  cursor: pointer;
+  font-weight: 600;
+  letter-spacing: 0.05em;
+  text-transform: uppercase;
+  transition: transform 0.25s ease, box-shadow 0.25s ease, filter 0.25s ease;
+  box-shadow: 0 15px 35px rgba(251, 146, 60, 0.35);
+}
+
+button:focus,
+button:hover {
+  transform: translateY(-2px) scale(1.02);
+  box-shadow: 0 18px 45px rgba(212, 175, 55, 0.4);
+  filter: saturate(1.1);
+}
+
+button:focus-visible {
+  outline: 3px solid rgba(251, 146, 60, 0.55);
+  outline-offset: 3px;
+}
+
+.table {
+  width: 100%;
+  border-collapse: collapse;
+  background: rgba(17, 17, 17, 0.85);
+  border: 1px solid rgba(255, 255, 255, 0.04);
+  box-shadow: var(--sombra-suave);
+}
+
+.table td,
+.table th {
+  padding: 0.85rem 1rem;
+  border-bottom: 1px solid rgba(255, 255, 255, 0.06);
+  color: var(--color-texto-suave);
+}
+
+.table th {
+  color: var(--color-dorado);
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  font-size: 0.9rem;
+}
+
+img {
+  max-width: 100%;
+  display: block;
+}
+
+.visually-hidden {
+  border: 0;
+  clip: rect(0 0 0 0);
+  height: 1px;
+  margin: -1px;
+  overflow: hidden;
+  padding: 0;
+  position: absolute;
+  width: 1px;
+}
+
+@media (max-width: 768px) {
+  nav ul {
+    position: absolute;
+    inset: 100% 0 auto 0;
+    background: rgba(15, 12, 12, 0.96);
+    flex-direction: column;
+    align-items: stretch;
+    padding: 1.5rem;
+    transform: translateY(-10px);
+    opacity: 0;
+    pointer-events: none;
+    transition: opacity 0.3s ease, transform 0.3s ease;
+  }
+
+  nav ul[data-open='true'] {
+    opacity: 1;
+    transform: translateY(0);
+    pointer-events: auto;
+  }
+
+  .menu-toggle {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    padding: 0.65rem;
+    border-radius: 999px;
+    background: rgba(251, 146, 60, 0.18);
+    border: 1px solid rgba(251, 146, 60, 0.35);
+    color: var(--color-texto);
+  }
+}
+
+@media (min-width: 769px) {
+  .menu-toggle {
+    display: none;
+  }
+}
+
+.blog-hero {
+  background: linear-gradient(160deg, rgba(14, 11, 11, 0.85), rgba(58, 26, 18, 0.75));
+  padding: 6rem 1rem 3rem;
+  text-align: center;
+  box-shadow: var(--sombra-suave);
+}
+
+.article {
+  display: grid;
+  gap: 2rem;
+}
+
+.article header {
+  position: static;
+  background: transparent;
+  color: inherit;
+}
+
+.article figure {
+  margin: 0;
+}
+
+.article img {
+  width: 100%;
+  border-radius: 0.85rem;
+  box-shadow: var(--sombra-suave);
+}
+
+.article footer {
+  background: transparent;
+  color: inherit;
+}
+
+.skip-link {
+  position: absolute;
+  left: 0;
+  top: -200px;
+  background: linear-gradient(135deg, var(--color-dorado), var(--color-ambar));
+  color: #080808;
+  padding: 0.75rem 1.5rem;
+  font-weight: 600;
+  border-radius: 0 0 0.75rem 0.75rem;
+  transition: top 0.3s ease;
+  z-index: 100;
+}
+
+.skip-link:focus-visible {
+  top: 0;
+}
+
+body :focus-visible {
+  outline: 3px solid rgba(251, 146, 60, 0.5);
+  outline-offset: 3px;
+  box-shadow: 0 0 0 4px rgba(0, 0, 0, 0.45);
+}
+
+#testimonios,
+#galeria,
+#cta {
+  background: linear-gradient(160deg, rgba(34, 27, 31, 0.9), rgba(20, 18, 22, 0.85));
+  padding: 3rem 2rem;
+  border-radius: 1.1rem;
+  box-shadow: var(--sombra-profunda);
+  margin: 3.5rem auto;
+  max-width: var(--max-width);
+  border: 1px solid rgba(255, 255, 255, 0.05);
+}
+
+#testimonios h2,
+#galeria h2,
+#cta h2 {
+  text-align: center;
+  margin-top: 0;
+  margin-bottom: 2rem;
+}
+
+#testimonios .grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+  gap: 2rem;
+}
+
+#testimonios blockquote {
+  background: rgba(16, 14, 14, 0.85);
+  padding: 1.75rem;
+  border-radius: 1rem;
+  box-shadow: var(--sombra-suave);
+  margin: 0;
+  font-style: italic;
+}
+
+#testimonios cite {
+  display: block;
+  margin-top: 1.25rem;
+  font-style: normal;
+  font-weight: 600;
+  color: var(--color-ambar);
+}
+
+#galeria .gallery-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  gap: 1.5rem;
+}
+
+#galeria img {
+  width: 100%;
+  display: block;
+  border-radius: 1rem;
+  box-shadow: var(--sombra-profunda);
+  object-fit: cover;
+}
+
+#cta {
+  text-align: center;
+  display: grid;
+  place-items: center;
+  gap: 1.5rem;
+}
+
+#cta .btn {
+  padding: 0.9rem 2.75rem;
+  box-shadow: 0 22px 45px rgba(251, 146, 60, 0.4);
+}
+
+.hero.hero-disponibles {
+  position: relative;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+  min-height: 100vh;
+  padding: 0 1.5rem;
+  text-align: center;
+  background-image: linear-gradient(120deg, rgba(158, 31, 31, 0.75), rgba(20, 13, 13, 0.9)), url('../img/hero/ceremonia.svg');
+  background-size: cover;
+  background-position: center;
+  background-repeat: no-repeat;
+  background-attachment: fixed;
+}
+
+.parallax {
+  background-attachment: fixed;
+  background-position: center;
+  background-size: cover;
+  background-repeat: no-repeat;
+  position: relative;
+  isolation: isolate;
+  color: var(--color-texto);
+}
+
+.parallax::before {
+  content: '';
+  position: absolute;
+  inset: 0;
+  background: linear-gradient(160deg, rgba(0, 0, 0, 0.75), rgba(69, 28, 24, 0.55));
+  z-index: 0;
+  pointer-events: none;
+}
+
+.parallax > * {
+  position: relative;
+  z-index: 1;
+}
+
+.como-reservar.parallax {
+  background-image: linear-gradient(180deg, rgba(15, 14, 14, 0.6), rgba(15, 14, 14, 0.9)), url('../img/xolos/1.webp');
+}
+
+.politica-reserva.parallax {
+  background-image: linear-gradient(180deg, rgba(15, 14, 14, 0.6), rgba(15, 14, 14, 0.9)), url('../img/xolos/2.webp');
+}


### PR DESCRIPTION
## Summary
- Introduced a cinematic dark palette through new CSS variables and global defaults
- Updated layout sections such as the hero, header, footer, and cards to use noir-inspired gradients and contrasts
- Refreshed buttons, forms, and highlighted sections with dramatic gold and amber accents for consistency

## Testing
- Not run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68f25d2517448332ad641a214f5da589