### PR TITLE
Add cinematic Cinzel font styling to site headings

### DIFF
--- a/blog/cuidados-basicos.html
+++ b/blog/cuidados-basicos.html
@@ -17,6 +17,10 @@
       crossorigin
     />
     <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Poppins:wght@400;600;700&display=swap" />
+    <link
+      rel="stylesheet"
+      href="https://fonts.googleapis.com/css2?family=Cinzel:wght@400;700&display=swap"
+    />
     <link rel="stylesheet" href="../css/styles.css" />
     <link rel="icon" type="image/svg+xml" href="../img/favicon.svg" />
     <script type="application/ld+json">

--- a/blog/cultura-mexicana.html
+++ b/blog/cultura-mexicana.html
@@ -17,6 +17,10 @@
       crossorigin
     />
     <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Poppins:wght@400;600;700&display=swap" />
+    <link
+      rel="stylesheet"
+      href="https://fonts.googleapis.com/css2?family=Cinzel:wght@400;700&display=swap"
+    />
     <link rel="stylesheet" href="../css/styles.css" />
     <link rel="icon" type="image/svg+xml" href="../img/favicon.svg" />
     <script type="application/ld+json">

--- a/blog/entrada-1.html
+++ b/blog/entrada-1.html
@@ -17,6 +17,10 @@
       crossorigin
     />
     <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Poppins:wght@400;600;700&display=swap" />
+    <link
+      rel="stylesheet"
+      href="https://fonts.googleapis.com/css2?family=Cinzel:wght@400;700&display=swap"
+    />
     <link rel="stylesheet" href="../css/styles.css" />
     <link rel="icon" type="image/svg+xml" href="../img/favicon.svg" />
     <script type="application/ld+json">

--- a/blog/entrada-2.html
+++ b/blog/entrada-2.html
@@ -17,6 +17,10 @@
       crossorigin
     />
     <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Poppins:wght@400;600;700&display=swap" />
+    <link
+      rel="stylesheet"
+      href="https://fonts.googleapis.com/css2?family=Cinzel:wght@400;700&display=swap"
+    />
     <link rel="stylesheet" href="../css/styles.css" />
     <link rel="icon" type="image/svg+xml" href="../img/favicon.svg" />
     <script type="application/ld+json">

--- a/blog/historia-xoloitzcuintle.html
+++ b/blog/historia-xoloitzcuintle.html
@@ -17,6 +17,10 @@
       crossorigin
     />
     <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Poppins:wght@400;600;700&display=swap" />
+    <link
+      rel="stylesheet"
+      href="https://fonts.googleapis.com/css2?family=Cinzel:wght@400;700&display=swap"
+    />
     <link rel="stylesheet" href="../css/styles.css" />
     <link rel="icon" type="image/svg+xml" href="../img/favicon.svg" />
     <script type="application/ld+json">

--- a/blog/index.html
+++ b/blog/index.html
@@ -17,6 +17,10 @@
       crossorigin
     />
     <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Poppins:wght@400;600;700&display=swap" />
+    <link
+      rel="stylesheet"
+      href="https://fonts.googleapis.com/css2?family=Cinzel:wght@400;700&display=swap"
+    />
     <link rel="stylesheet" href="../css/styles.css" />
     <link rel="icon" type="image/svg+xml" href="../img/favicon.svg" />
   </head>

--- a/contacto.html
+++ b/contacto.html
@@ -17,6 +17,10 @@
       crossorigin
     />
     <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Poppins:wght@400;600;700&display=swap" />
+    <link
+      rel="stylesheet"
+      href="https://fonts.googleapis.com/css2?family=Cinzel:wght@400;700&display=swap"
+    />
     <link rel="stylesheet" href="css/styles.css" />
     <link rel="icon" type="image/svg+xml" href="img/favicon.svg" />
   </head>

--- a/css/styles.css
+++ b/css/styles.css
@@ -81,3 +81,6 @@
 .parallax>*{position:relative;z-index:1;}
 .como-reservar.parallax{background-image:linear-gradient(180deg,rgba(19,19,19,0.6),rgba(19,19,19,0.9)),url('../img/xolos/1.webp');}
 .politica-reserva.parallax{background-image:linear-gradient(180deg,rgba(19,19,19,0.6),rgba(19,19,19,0.9)),url('../img/xolos/2.webp');}
+
+
+h1,h2,h3,.site-header .brand span{font-family:'Cinzel',serif;text-transform:uppercase;letter-spacing:2px;}

--- a/galeria.html
+++ b/galeria.html
@@ -17,6 +17,10 @@
       crossorigin
     />
     <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Poppins:wght@400;600;700&display=swap" />
+    <link
+      rel="stylesheet"
+      href="https://fonts.googleapis.com/css2?family=Cinzel:wght@400;700&display=swap"
+    />
     <link rel="stylesheet" href="css/styles.css" />
     <link rel="icon" type="image/svg+xml" href="img/favicon.svg" />
   </head>

--- a/index.html
+++ b/index.html
@@ -17,6 +17,10 @@
       crossorigin
     />
     <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Poppins:wght@400;600;700&display=swap" />
+    <link
+      rel="stylesheet"
+      href="https://fonts.googleapis.com/css2?family=Cinzel:wght@400;700&display=swap"
+    />
     <link rel="stylesheet" href="css/styles.css" />
     <link rel="icon" type="image/svg+xml" href="img/favicon.svg" />
   </head>

--- a/public/xolos-disponibles.html
+++ b/public/xolos-disponibles.html
@@ -9,6 +9,7 @@
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/css2?family=Poppins:wght@400;600;700&display=swap" rel="stylesheet">
+  <link href="https://fonts.googleapis.com/css2?family=Cinzel:wght@400;700&display=swap" rel="stylesheet">
   <link rel="stylesheet" href="css/styles.css" />
   <!-- Favicon -->
   <link rel="icon" type="image/svg+xml" href="img/favicon.svg" />

--- a/testimonios.html
+++ b/testimonios.html
@@ -17,6 +17,10 @@
       crossorigin
     />
     <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Poppins:wght@400;600;700&display=swap" />
+    <link
+      rel="stylesheet"
+      href="https://fonts.googleapis.com/css2?family=Cinzel:wght@400;700&display=swap"
+    />
     <link rel="stylesheet" href="css/styles.css" />
     <link rel="icon" type="image/svg+xml" href="img/favicon.svg" />
   </head>

--- a/xolos-disponibles.html
+++ b/xolos-disponibles.html
@@ -17,6 +17,10 @@
       crossorigin
     />
     <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Poppins:wght@400;600;700&display=swap" />
+    <link
+      rel="stylesheet"
+      href="https://fonts.googleapis.com/css2?family=Cinzel:wght@400;700&display=swap"
+    />
     <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Marcellus&display=swap" />
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/aos@2.3.4/dist/aos.css" />
     <link rel="stylesheet" href="css/styles.css" />


### PR DESCRIPTION
## Summary
- add the Cinzel Google Font link to each page head so cinematic typography is consistently available
- update the shared stylesheet to apply Cinzel to headings and the brand mark while keeping body text in the existing font

## Testing
- not run (static changes)


------
https://chatgpt.com/codex/tasks/task_e_68f25e7d56fc833282b1842bcb7ca92b