### PR TITLE
Make hero and CTA sections use full-screen parallax backgrounds

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -150,14 +150,25 @@ nav a:hover {
 }
 
 .hero {
-  background-image: linear-gradient(120deg, rgba(14, 11, 11, 0.85), rgba(68, 27, 18, 0.85)), url('../img/hero/hero-placeholder.svg');
-  background-position: center;
-  background-size: cover;
-  background-repeat: no-repeat;
-  color: var(--color-texto);
-  padding: clamp(4rem, 8vw, 6rem) 1rem;
+  position: relative;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+  gap: clamp(1rem, 3vw, 1.75rem);
+  margin-inline: calc(50% - 50vw);
+  width: 100vw;
+  min-height: 100vh;
+  padding: clamp(4rem, 6vw, 6rem) 1.5rem;
   text-align: center;
+  color: #fff;
+  text-shadow: 2px 2px 8px rgba(0, 0, 0, 0.7);
+  background:
+    linear-gradient(120deg, rgba(12, 10, 10, 0.75), rgba(65, 24, 19, 0.65)),
+    url('../img/hero/ceremonia.svg') center/cover no-repeat;
+  background-attachment: fixed;
   box-shadow: var(--sombra-suave);
+  isolation: isolate;
 }
 
 .hero h1 {
@@ -168,7 +179,7 @@ nav a:hover {
 .hero p {
   max-width: 45ch;
   margin: 0 auto;
-  color: var(--color-texto-suave);
+  color: rgba(245, 239, 230, 0.9);
 }
 
 main {
@@ -466,11 +477,11 @@ img {
   }
 }
 
-.blog-hero {
-  background: linear-gradient(160deg, rgba(14, 11, 11, 0.85), rgba(58, 26, 18, 0.75));
-  padding: 6rem 1rem 3rem;
-  text-align: center;
-  box-shadow: var(--sombra-suave);
+.hero.blog-hero {
+  background:
+    linear-gradient(120deg, rgba(10, 9, 9, 0.78), rgba(68, 34, 24, 0.62)),
+    url('../img/hero/hero-placeholder.svg') center/cover no-repeat;
+  background-attachment: fixed;
 }
 
 .article {
@@ -523,8 +534,7 @@ body :focus-visible {
 }
 
 #testimonios,
-#galeria,
-#cta {
+#galeria {
   background: linear-gradient(160deg, rgba(34, 27, 31, 0.9), rgba(20, 18, 22, 0.85));
   padding: 3rem 2rem;
   border-radius: 1.1rem;
@@ -535,8 +545,7 @@ body :focus-visible {
 }
 
 #testimonios h2,
-#galeria h2,
-#cta h2 {
+#galeria h2 {
   text-align: center;
   margin-top: 0;
   margin-bottom: 2rem;
@@ -580,10 +589,30 @@ body :focus-visible {
 }
 
 #cta {
+  position: relative;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+  gap: clamp(1rem, 2.5vw, 2rem);
+  margin-inline: calc(50% - 50vw);
+  width: 100vw;
+  min-height: 100vh;
+  padding: clamp(4rem, 6vw, 6rem) 1.5rem;
   text-align: center;
-  display: grid;
-  place-items: center;
-  gap: 1.5rem;
+  color: #fff;
+  text-shadow: 2px 2px 8px rgba(0, 0, 0, 0.7);
+  background:
+    linear-gradient(135deg, rgba(12, 10, 9, 0.75), rgba(68, 34, 24, 0.65)),
+    url('../img/hero/ceremonia.svg') center/cover no-repeat;
+  background-attachment: fixed;
+  box-shadow: var(--sombra-profunda);
+  isolation: isolate;
+}
+
+#cta h2 {
+  margin: 0;
+  max-width: 20ch;
 }
 
 #cta .btn {
@@ -638,10 +667,10 @@ body :focus-visible {
 .politica-reserva.parallax {
   background-image: linear-gradient(180deg, rgba(15, 14, 14, 0.6), rgba(15, 14, 14, 0.9)), url('../img/xolos/2.webp');
 }
-:root{color-scheme:dark;font-family:Poppins,sans-serif;line-height:1.6;--primary-color:#cba135;--secondary-color:#8c6a3b;--bg-color:#111111;--text-color:#f1e6d6;--accent-color:#bfa87a;--dark-accent:#cba135;--surface-color:#1c1c1c;--muted-text:#d1c6b5;--max-width:1100px}*{box-sizing:border-box}body{margin:0;background-color:#111111;color:#f1e6d6;font-family:'Poppins',sans-serif;line-height:1.6}h1,h2,h3,h4,h5,h6{color:#cba135;text-shadow:2px 2px 8px rgba(0,0,0,0.7);font-family:'Marcellus',serif;text-transform:uppercase;letter-spacing:1px}a{color:#cba135;text-decoration:none}a:focus,a:hover{text-decoration:underline}.btn{display:inline-flex;align-items:center;justify-content:center;gap:.5rem;background-color:var(--primary-color);color:#fff;padding:.8rem 1.6rem;border-radius:.5rem;border:none;cursor:pointer;font-weight:600;transition:background-color .3s ease,transform .2s ease}.btn:focus,.btn:hover{background-color:#872000}.btn:focus-visible{outline:3px solid rgba(50,50,50,.35);outline-offset:2px}header{background:var(--dark-accent);color:var(--bg-color);position:sticky;top:0;z-index:10}.site-header{display:flex;align-items:center;justify-content:space-between;max-width:var(--max-width);margin:0 auto;padding:1rem}.brand{display:inline-flex;align-items:center;gap:.75rem;font-weight:700;font-size:1.1rem;letter-spacing:.08em;text-transform:uppercase;color:var(--bg-color)}.brand img{width:44px;height:44px;border-radius:50%;object-fit:cover;box-shadow:0 4px 12px rgba(0,0,0,.15);background:#fff;padding:.25rem}nav ul{list-style:none;display:flex;gap:1rem;margin:0;padding:0}nav a{font-weight:600;color:var(--bg-color);transition:color .2s ease}nav a:focus,nav a:hover{color:var(--accent-color)}.hero{background-image:linear-gradient(120deg,rgba(166,39,0,.9),rgba(50,50,50,.85)),url('../img/hero/hero-placeholder.svg');background-position:center;background-size:cover;background-repeat:no-repeat;color:#fff;padding:clamp(4rem,8vw,6rem) 1rem;text-align:center}.hero{background-image:linear-gradient(120deg,rgba(166,39,0,.9),rgba(50,50,50,.85)),url('../img/hero/hero-placeholder.svg')}.hero h1{font-size:clamp(2.5rem, 6vw, 3.5rem);margin-bottom:1rem}.hero p{max-width:45ch;margin:0 auto}main{max-width:var(--max-width);margin:0 auto;padding:2rem 1rem 4rem;display:grid;gap:2rem}section{background:var(--surface-color);padding:3rem 1rem;border-radius:.75rem;box-shadow:0 10px 30px rgba(50,50,50,.08)}section h2{margin-top:0;color:var(--dark-accent)}.grid{display:grid;gap:1.5rem}.grid-2{grid-template-columns:repeat(auto-fit,minmax(250px,1fr))}.card{background:rgba(0,0,0,.6);border:2px solid #d4af37;border-radius:.75rem;padding:1.25rem;display:flex;flex-direction:column;gap:.75rem;color:#fdf6d8;box-shadow:0 10px 30px rgba(0,0,0,.15);transition:transform .25s ease,box-shadow .25s ease}.card:hover{transform:translateY(-4px);box-shadow:0 16px 40px rgba(0,0,0,.25)}.card img{width:100%;height:auto;display:block;border-radius:.5rem}blockquote{margin:0;padding-left:1.25rem;border-left:4px solid var(--secondary-color);color:var(--muted-text)}.callout{background:rgba(107,112,92,.15);border-left:4px solid var(--secondary-color);padding:1rem 1.25rem;border-radius:.5rem}footer{background:var(--dark-accent);color:var(--bg-color)}.footer-grid{max-width:var(--max-width);margin:0 auto;padding:2rem 1rem;display:grid;gap:1.5rem}.footer-grid div{display:flex;flex-direction:column;gap:.75rem}.footer-grid h3,.footer-grid h4{margin:0;font-weight:600}.footer-grid p{margin:0;line-height:1.6}.footer-grid ul{list-style:none;margin:0;padding:0;display:flex;flex-direction:column;gap:.5rem}.footer-grid a{color:var(--bg-color);text-decoration:none}.footer-grid a:focus,.footer-grid a:hover{text-decoration:underline}.copyright{text-align:center;margin:0;padding:1.5rem 1rem;border-top:1px solid rgba(253,248,240,.15);font-size:.875rem;color:rgba(253,248,240,.8)}@media (min-width:768px){.footer-grid{grid-template-columns:repeat(3,minmax(0,1fr));align-items:flex-start}.footer-grid div:nth-child(1){max-width:22rem}}small{color:rgba(253,248,240,.8)}form{display:grid;gap:1rem}label{font-weight:600;color:var(--dark-accent)}input,select,textarea{width:100%;padding:.75rem;border-radius:.5rem;border:1px solid rgba(50,50,50,.15);font-size:1rem;font-family:inherit;background:#fff;color:var(--text-color)}input:focus,select:focus,textarea:focus{outline:3px solid rgba(166,39,0,.35);outline-offset:2px}button{background:var(--primary-color);color:#fff;border:none;padding:.75rem 1.5rem;border-radius:999px;font-size:1rem;font-weight:600;cursor:pointer;transition:background-color .3s ease}button:focus,button:hover{background:#872000}button:focus-visible{outline:3px solid rgba(50,50,50,.35);outline-offset:2px}.table{width:100%;border-collapse:collapse}.table td,.table th{padding:.75rem;border-bottom:1px solid rgba(50,50,50,.15);text-align:left}.table th{color:var(--primary-color);font-size:.95rem;text-transform:uppercase;letter-spacing:.05em}img{max-width:100%;border-radius:8px;display:block}.visually-hidden{position:absolute;clip:rect(1px,1px,1px,1px);padding:0;border:0;height:1px;width:1px;overflow:hidden}@media (max-width:768px){nav ul{flex-direction:column;background:var(--dark-accent);position:absolute;right:1rem;top:72px;padding:1rem;border-radius:.75rem;box-shadow:0 15px 30px rgba(0,0,0,.25);transform:scale(0);transform-origin:top right;transition:transform .2s ease}nav ul[data-open=true]{transform:scale(1)}.menu-toggle{display:inline-flex;background:0 0;border:2px solid var(--bg-color);color:var(--bg-color);padding:.25rem .75rem;border-radius:999px;font-weight:600}}@media (min-width:769px){.menu-toggle{display:none}}.blog-hero{background:linear-gradient(120deg,rgba(166,39,0,.85),rgba(50,50,50,.9))}.article{display:grid;gap:1.5rem}.article header{position:static;background:0 0;color:inherit}.article figure{margin:0}.article img{width:100%;border-radius:.75rem}.article footer{background:0 0;color:inherit}
+:root{color-scheme:dark;font-family:Poppins,sans-serif;line-height:1.6;--primary-color:#cba135;--secondary-color:#8c6a3b;--bg-color:#111111;--text-color:#f1e6d6;--accent-color:#bfa87a;--dark-accent:#cba135;--surface-color:#1c1c1c;--muted-text:#d1c6b5;--max-width:1100px}*{box-sizing:border-box}body{margin:0;background-color:#111111;color:#f1e6d6;font-family:'Poppins',sans-serif;line-height:1.6}h1,h2,h3,h4,h5,h6{color:#cba135;text-shadow:2px 2px 8px rgba(0,0,0,0.7);font-family:'Marcellus',serif;text-transform:uppercase;letter-spacing:1px}a{color:#cba135;text-decoration:none}a:focus,a:hover{text-decoration:underline}.btn{display:inline-flex;align-items:center;justify-content:center;gap:.5rem;background-color:var(--primary-color);color:#fff;padding:.8rem 1.6rem;border-radius:.5rem;border:none;cursor:pointer;font-weight:600;transition:background-color .3s ease,transform .2s ease}.btn:focus,.btn:hover{background-color:#872000}.btn:focus-visible{outline:3px solid rgba(50,50,50,.35);outline-offset:2px}header{background:var(--dark-accent);color:var(--bg-color);position:sticky;top:0;z-index:10}.site-header{display:flex;align-items:center;justify-content:space-between;max-width:var(--max-width);margin:0 auto;padding:1rem}.brand{display:inline-flex;align-items:center;gap:.75rem;font-weight:700;font-size:1.1rem;letter-spacing:.08em;text-transform:uppercase;color:var(--bg-color)}.brand img{width:44px;height:44px;border-radius:50%;object-fit:cover;box-shadow:0 4px 12px rgba(0,0,0,.15);background:#fff;padding:.25rem}nav ul{list-style:none;display:flex;gap:1rem;margin:0;padding:0}nav a{font-weight:600;color:var(--bg-color);transition:color .2s ease}nav a:focus,nav a:hover{color:var(--accent-color)}.hero{position:relative;display:flex;flex-direction:column;justify-content:center;align-items:center;gap:clamp(1rem,3vw,1.75rem);margin-inline:calc(50% - 50vw);width:100vw;min-height:100vh;padding:clamp(4rem,6vw,6rem) 1.5rem;text-align:center;color:#fff;text-shadow:2px 2px 8px rgba(0,0,0,.7);background:linear-gradient(120deg,rgba(12,10,10,.75),rgba(65,24,19,.65)),url('../img/hero/ceremonia.svg') center/cover no-repeat;background-attachment:fixed;box-shadow:var(--sombra-suave);isolation:isolate}.hero{background-image:linear-gradient(120deg,rgba(166,39,0,.9),rgba(50,50,50,.85)),url('../img/hero/hero-placeholder.svg')}.hero h1{font-size:clamp(2.5rem, 6vw, 3.5rem);margin-bottom:1rem}.hero p{max-width:45ch;margin:0 auto;color:rgba(245,239,230,.9)}main{max-width:var(--max-width);margin:0 auto;padding:2rem 1rem 4rem;display:grid;gap:2rem}section{background:var(--surface-color);padding:3rem 1rem;border-radius:.75rem;box-shadow:0 10px 30px rgba(50,50,50,.08)}section h2{margin-top:0;color:var(--dark-accent)}.grid{display:grid;gap:1.5rem}.grid-2{grid-template-columns:repeat(auto-fit,minmax(250px,1fr))}.card{background:rgba(0,0,0,.6);border:2px solid #d4af37;border-radius:.75rem;padding:1.25rem;display:flex;flex-direction:column;gap:.75rem;color:#fdf6d8;box-shadow:0 10px 30px rgba(0,0,0,.15);transition:transform .25s ease,box-shadow .25s ease}.card:hover{transform:translateY(-4px);box-shadow:0 16px 40px rgba(0,0,0,.25)}.card img{width:100%;height:auto;display:block;border-radius:.5rem}blockquote{margin:0;padding-left:1.25rem;border-left:4px solid var(--secondary-color);color:var(--muted-text)}.callout{background:rgba(107,112,92,.15);border-left:4px solid var(--secondary-color);padding:1rem 1.25rem;border-radius:.5rem}footer{background:var(--dark-accent);color:var(--bg-color)}.footer-grid{max-width:var(--max-width);margin:0 auto;padding:2rem 1rem;display:grid;gap:1.5rem}.footer-grid div{display:flex;flex-direction:column;gap:.75rem}.footer-grid h3,.footer-grid h4{margin:0;font-weight:600}.footer-grid p{margin:0;line-height:1.6}.footer-grid ul{list-style:none;margin:0;padding:0;display:flex;flex-direction:column;gap:.5rem}.footer-grid a{color:var(--bg-color);text-decoration:none}.footer-grid a:focus,.footer-grid a:hover{text-decoration:underline}.copyright{text-align:center;margin:0;padding:1.5rem 1rem;border-top:1px solid rgba(253,248,240,.15);font-size:.875rem;color:rgba(253,248,240,.8)}@media (min-width:768px){.footer-grid{grid-template-columns:repeat(3,minmax(0,1fr));align-items:flex-start}.footer-grid div:nth-child(1){max-width:22rem}}small{color:rgba(253,248,240,.8)}form{display:grid;gap:1rem}label{font-weight:600;color:var(--dark-accent)}input,select,textarea{width:100%;padding:.75rem;border-radius:.5rem;border:1px solid rgba(50,50,50,.15);font-size:1rem;font-family:inherit;background:#fff;color:var(--text-color)}input:focus,select:focus,textarea:focus{outline:3px solid rgba(166,39,0,.35);outline-offset:2px}button{background:var(--primary-color);color:#fff;border:none;padding:.75rem 1.5rem;border-radius:999px;font-size:1rem;font-weight:600;cursor:pointer;transition:background-color .3s ease}button:focus,button:hover{background:#872000}button:focus-visible{outline:3px solid rgba(50,50,50,.35);outline-offset:2px}.table{width:100%;border-collapse:collapse}.table td,.table th{padding:.75rem;border-bottom:1px solid rgba(50,50,50,.15);text-align:left}.table th{color:var(--primary-color);font-size:.95rem;text-transform:uppercase;letter-spacing:.05em}img{max-width:100%;border-radius:8px;display:block}.visually-hidden{position:absolute;clip:rect(1px,1px,1px,1px);padding:0;border:0;height:1px;width:1px;overflow:hidden}@media (max-width:768px){nav ul{flex-direction:column;background:var(--dark-accent);position:absolute;right:1rem;top:72px;padding:1rem;border-radius:.75rem;box-shadow:0 15px 30px rgba(0,0,0,.25);transform:scale(0);transform-origin:top right;transition:transform .2s ease}nav ul[data-open=true]{transform:scale(1)}.menu-toggle{display:inline-flex;background:0 0;border:2px solid var(--bg-color);color:var(--bg-color);padding:.25rem .75rem;border-radius:999px;font-weight:600}}@media (min-width:769px){.menu-toggle{display:none}}.hero.blog-hero{background:linear-gradient(120deg,rgba(10,9,9,.78),rgba(68,34,24,.62)),url('../img/hero/hero-placeholder.svg') center/cover no-repeat;background-attachment:fixed}.article{display:grid;gap:1.5rem}.article header{position:static;background:0 0;color:inherit}.article figure{margin:0}.article img{width:100%;border-radius:.75rem}.article footer{background:0 0;color:inherit}
 .skip-link{position:absolute;left:0;top:-200px;background:var(--primary-color);color:#ffffff;padding:.75rem 1.5rem;font-weight:600;border-radius:0 0 .75rem .75rem;transition:top .3s ease;z-index:100}.skip-link:focus-visible{top:0}body :focus-visible{outline:3px solid var(--primary-color);outline-offset:2px;box-shadow:0 0 0 4px var(--bg-color)}
 
-#testimonios,#galeria,#cta{
+#testimonios,#galeria{
   background:var(--surface-color);
   padding:3rem 2rem;
   border-radius:20px;
@@ -649,7 +678,7 @@ body :focus-visible {
   margin:3.5rem auto;
   max-width:var(--max-width);
 }
-#testimonios h2,#galeria h2,#cta h2{
+#testimonios h2,#galeria h2{
   text-align:center;
   margin-top:0;
   margin-bottom:2rem;
@@ -687,10 +716,23 @@ body :focus-visible {
   object-fit:cover;
 }
 #cta{
+  position:relative;
+  display:flex;
+  flex-direction:column;
+  justify-content:center;
+  align-items:center;
+  gap:clamp(1rem,2.5vw,2rem);
+  margin-inline:calc(50% - 50vw);
+  width:100vw;
+  min-height:100vh;
+  padding:clamp(4rem,6vw,6rem) 1.5rem;
   text-align:center;
-  display:grid;
-  place-items:center;
-  gap:1.5rem;
+  color:#fff;
+  text-shadow:2px 2px 8px rgba(0,0,0,.7);
+  background:linear-gradient(135deg,rgba(12,10,9,.75),rgba(68,34,24,.65)),url('../img/hero/ceremonia.svg') center/cover no-repeat;
+  background-attachment:fixed;
+  box-shadow:var(--sombra-profunda);
+  isolation:isolate;
 }
 #cta .btn{
   padding:.875rem 2.5rem;


### PR DESCRIPTION
## Summary
- update the main hero to use a full-screen background image with centered content and a parallax feel
- apply the parallax background treatment to blog hero and call-to-action sections for consistency

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68f25fc8df188332873858f85a32cde1