### PR TITLE
Add hero background images to key pages

### DIFF
--- a/index.html
+++ b/index.html
@@ -56,13 +56,20 @@
     </header>
 
     <main id="contenido-principal">
-      <section class="hero" data-aos="fade-in" data-aos-duration="1200">
-        <h1>Xolos Ramirez</h1>
-        <p>
-          Celebramos al xoloitzcuintle, el perro nacional de México. Descubre su
-          legado histórico, conoce ejemplares disponibles para adopción
-          responsable y únete a nuestra comunidad.
-        </p>
+      <section
+        class="hero"
+        style="background-image: url('img/hero/site-hero.webp')"
+        data-aos="fade-in"
+        data-aos-duration="1200"
+      >
+        <div class="container">
+          <h1>Xolos Ramirez</h1>
+          <p>
+            Celebramos al xoloitzcuintle, el perro nacional de México. Descubre
+            su legado histórico, conoce ejemplares disponibles para adopción
+            responsable y únete a nuestra comunidad.
+          </p>
+        </div>
       </section>
 
       <section data-aos="fade-up" data-aos-duration="1000">

--- a/xolos-disponibles.html
+++ b/xolos-disponibles.html
@@ -57,12 +57,19 @@
     </header>
 
     <main id="contenido-principal">
-      <section class="hero hero-disponibles" data-aos="fade-in" data-aos-duration="1200">
-        <h1>Xolos disponibles</h1>
-        <p>
-          Conoce a los xolositzcuintles que buscan un hogar. Cada ficha incluye
-          edad, tamaño, personalidad y requisitos de adopción.
-        </p>
+      <section
+        class="hero hero-disponibles"
+        style="background-image: url('img/hero/disponibles-hero.webp')"
+        data-aos="fade-in"
+        data-aos-duration="1200"
+      >
+        <div class="container">
+          <h1>Xolos disponibles</h1>
+          <p>
+            Conoce a los xolositzcuintles que buscan un hogar. Cada ficha incluye
+            edad, tamaño, personalidad y requisitos de adopción.
+          </p>
+        </div>
       </section>
 
       <section data-aos="fade-up" data-aos-duration="1000">


### PR DESCRIPTION
## Summary
- add inline background images to the hero sections on the home and available xolos pages
- wrap hero text content in a container for consistent layout spacing

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68f27723ee908332ada219cd68f99389