### PR TITLE
feat: actualizar encabezado sticky y menú responsive

### DIFF
--- a/blog/cuidados-basicos.html
+++ b/blog/cuidados-basicos.html
@@ -47,30 +47,24 @@
   </head>
   <body>
     <a class="skip-link" href="#contenido-principal">Saltar al contenido principal</a>
-    <header>
-      <div class="site-header">
+    <header class="site-header">
+      <div class="container header-row">
         <a class="brand" href="../index.html">
           <img
-            src="../img/logo-xolos-ramirez.svg"
-            alt="Logo de Xolos Ramirez"
+            src="../img/brand/logo-xolos-ramirez.svg"
+            alt="Xolos Ramírez"
             width="44"
             height="44"
             loading="eager"
             decoding="async"
           />
-          <span>Xolos Ramirez</span>
+          <span>Xolos Ramírez</span>
         </a>
-        <button
-          class="menu-toggle"
-          type="button"
-          data-menu-toggle
-          aria-expanded="false"
-          aria-controls="menu-principal"
-        >
-          Menú
-        </button>
-        <nav role="navigation" aria-label="Navegación principal">
-          <ul id="menu-principal" data-menu-list data-open="false">
+
+        <button class="hamburger" aria-expanded="false" aria-controls="menu">☰</button>
+
+        <nav id="menu" class="nav-menu">
+          <ul>
             <li><a href="../index.html">Inicio</a></li>
             <li><a href="../xolos-disponibles.html">Xolos disponibles</a></li>
             <li><a href="../galeria.html">Galería</a></li>

--- a/blog/cultura-mexicana.html
+++ b/blog/cultura-mexicana.html
@@ -47,30 +47,24 @@
   </head>
   <body>
     <a class="skip-link" href="#contenido-principal">Saltar al contenido principal</a>
-    <header>
-      <div class="site-header">
+    <header class="site-header">
+      <div class="container header-row">
         <a class="brand" href="../index.html">
           <img
-            src="../img/logo-xolos-ramirez.svg"
-            alt="Logo de Xolos Ramirez"
+            src="../img/brand/logo-xolos-ramirez.svg"
+            alt="Xolos Ramírez"
             width="44"
             height="44"
             loading="eager"
             decoding="async"
           />
-          <span>Xolos Ramirez</span>
+          <span>Xolos Ramírez</span>
         </a>
-        <button
-          class="menu-toggle"
-          type="button"
-          data-menu-toggle
-          aria-expanded="false"
-          aria-controls="menu-principal"
-        >
-          Menú
-        </button>
-        <nav role="navigation" aria-label="Navegación principal">
-          <ul id="menu-principal" data-menu-list data-open="false">
+
+        <button class="hamburger" aria-expanded="false" aria-controls="menu">☰</button>
+
+        <nav id="menu" class="nav-menu">
+          <ul>
             <li><a href="../index.html">Inicio</a></li>
             <li><a href="../xolos-disponibles.html">Xolos disponibles</a></li>
             <li><a href="../galeria.html">Galería</a></li>

--- a/blog/entrada-1.html
+++ b/blog/entrada-1.html
@@ -47,30 +47,24 @@
   </head>
   <body>
     <a class="skip-link" href="#contenido-principal">Saltar al contenido principal</a>
-    <header>
-      <div class="site-header">
+    <header class="site-header">
+      <div class="container header-row">
         <a class="brand" href="../index.html">
           <img
-            src="../img/logo-xolos-ramirez.svg"
-            alt="Logo de Xolos Ramirez"
+            src="../img/brand/logo-xolos-ramirez.svg"
+            alt="Xolos Ramírez"
             width="44"
             height="44"
             loading="eager"
             decoding="async"
           />
-          <span>Xolos Ramirez</span>
+          <span>Xolos Ramírez</span>
         </a>
-        <button
-          class="menu-toggle"
-          type="button"
-          data-menu-toggle
-          aria-expanded="false"
-          aria-controls="menu-principal"
-        >
-          Menú
-        </button>
-        <nav role="navigation" aria-label="Navegación principal">
-          <ul id="menu-principal" data-menu-list data-open="false">
+
+        <button class="hamburger" aria-expanded="false" aria-controls="menu">☰</button>
+
+        <nav id="menu" class="nav-menu">
+          <ul>
             <li><a href="../index.html">Inicio</a></li>
             <li><a href="../xolos-disponibles.html">Xolos disponibles</a></li>
             <li><a href="../galeria.html">Galería</a></li>

--- a/blog/entrada-2.html
+++ b/blog/entrada-2.html
@@ -47,30 +47,24 @@
   </head>
   <body>
     <a class="skip-link" href="#contenido-principal">Saltar al contenido principal</a>
-    <header>
-      <div class="site-header">
+    <header class="site-header">
+      <div class="container header-row">
         <a class="brand" href="../index.html">
           <img
-            src="../img/logo-xolos-ramirez.svg"
-            alt="Logo de Xolos Ramirez"
+            src="../img/brand/logo-xolos-ramirez.svg"
+            alt="Xolos Ramírez"
             width="44"
             height="44"
             loading="eager"
             decoding="async"
           />
-          <span>Xolos Ramirez</span>
+          <span>Xolos Ramírez</span>
         </a>
-        <button
-          class="menu-toggle"
-          type="button"
-          data-menu-toggle
-          aria-expanded="false"
-          aria-controls="menu-principal"
-        >
-          Menú
-        </button>
-        <nav role="navigation" aria-label="Navegación principal">
-          <ul id="menu-principal" data-menu-list data-open="false">
+
+        <button class="hamburger" aria-expanded="false" aria-controls="menu">☰</button>
+
+        <nav id="menu" class="nav-menu">
+          <ul>
             <li><a href="../index.html">Inicio</a></li>
             <li><a href="../xolos-disponibles.html">Xolos disponibles</a></li>
             <li><a href="../galeria.html">Galería</a></li>

--- a/blog/historia-xoloitzcuintle.html
+++ b/blog/historia-xoloitzcuintle.html
@@ -47,30 +47,24 @@
   </head>
   <body>
     <a class="skip-link" href="#contenido-principal">Saltar al contenido principal</a>
-    <header>
-      <div class="site-header">
+    <header class="site-header">
+      <div class="container header-row">
         <a class="brand" href="../index.html">
           <img
-            src="../img/logo-xolos-ramirez.svg"
-            alt="Logo de Xolos Ramirez"
+            src="../img/brand/logo-xolos-ramirez.svg"
+            alt="Xolos Ramírez"
             width="44"
             height="44"
             loading="eager"
             decoding="async"
           />
-          <span>Xolos Ramirez</span>
+          <span>Xolos Ramírez</span>
         </a>
-        <button
-          class="menu-toggle"
-          type="button"
-          data-menu-toggle
-          aria-expanded="false"
-          aria-controls="menu-principal"
-        >
-          Menú
-        </button>
-        <nav role="navigation" aria-label="Navegación principal">
-          <ul id="menu-principal" data-menu-list data-open="false">
+
+        <button class="hamburger" aria-expanded="false" aria-controls="menu">☰</button>
+
+        <nav id="menu" class="nav-menu">
+          <ul>
             <li><a href="../index.html">Inicio</a></li>
             <li><a href="../xolos-disponibles.html">Xolos disponibles</a></li>
             <li><a href="../galeria.html">Galería</a></li>

--- a/blog/index.html
+++ b/blog/index.html
@@ -20,30 +20,24 @@
   </head>
   <body>
     <a class="skip-link" href="#contenido-principal">Saltar al contenido principal</a>
-    <header>
-      <div class="site-header">
+    <header class="site-header">
+      <div class="container header-row">
         <a class="brand" href="../index.html">
           <img
-            src="../img/logo-xolos-ramirez.svg"
-            alt="Logo de Xolos Ramirez"
+            src="../img/brand/logo-xolos-ramirez.svg"
+            alt="Xolos Ramírez"
             width="44"
             height="44"
             loading="eager"
             decoding="async"
           />
-          <span>Xolos Ramirez</span>
+          <span>Xolos Ramírez</span>
         </a>
-        <button
-          class="menu-toggle"
-          type="button"
-          data-menu-toggle
-          aria-expanded="false"
-          aria-controls="menu-principal"
-        >
-          Menú
-        </button>
-        <nav role="navigation" aria-label="Navegación principal">
-          <ul id="menu-principal" data-menu-list data-open="false">
+
+        <button class="hamburger" aria-expanded="false" aria-controls="menu">☰</button>
+
+        <nav id="menu" class="nav-menu">
+          <ul>
             <li><a href="../index.html">Inicio</a></li>
             <li><a href="../xolos-disponibles.html">Xolos disponibles</a></li>
             <li><a href="../galeria.html">Galería</a></li>

--- a/contacto.html
+++ b/contacto.html
@@ -20,30 +20,24 @@
   </head>
   <body>
     <a class="skip-link" href="#contenido-principal">Saltar al contenido principal</a>
-    <header>
-      <div class="site-header">
+    <header class="site-header">
+      <div class="container header-row">
         <a class="brand" href="index.html">
           <img
-            src="img/logo-xolos-ramirez.svg"
-            alt="Logo de Xolos Ramirez"
+            src="img/brand/logo-xolos-ramirez.svg"
+            alt="Xolos Ramírez"
             width="44"
             height="44"
             loading="eager"
             decoding="async"
           />
-          <span>Xolos Ramirez</span>
+          <span>Xolos Ramírez</span>
         </a>
-        <button
-          class="menu-toggle"
-          type="button"
-          data-menu-toggle
-          aria-expanded="false"
-          aria-controls="menu-principal"
-        >
-          Menú
-        </button>
-        <nav role="navigation" aria-label="Navegación principal">
-          <ul id="menu-principal" data-menu-list data-open="false">
+
+        <button class="hamburger" aria-expanded="false" aria-controls="menu">☰</button>
+
+        <nav id="menu" class="nav-menu">
+          <ul>
             <li><a href="index.html">Inicio</a></li>
             <li><a href="xolos-disponibles.html">Xolos disponibles</a></li>
             <li><a href="galeria.html">Galería</a></li>

--- a/css/styles.css
+++ b/css/styles.css
@@ -148,68 +148,21 @@ a:hover {
   outline-offset: 3px;
 }
 
-header {
-  background: linear-gradient(135deg, rgba(20, 18, 18, 0.95), rgba(41, 26, 18, 0.9));
-  color: var(--color-texto);
-  position: sticky;
-  top: 0;
-  z-index: 10;
-  backdrop-filter: blur(8px);
-  border-bottom: 1px solid var(--color-borde);
-}
+.site-header{ position:sticky; top:0; z-index:50; background:#000; border-bottom:1px solid var(--border); }
+.header-row{ display:flex; align-items:center; justify-content:space-between; gap:1rem; padding:.75rem 0; }
+.brand{ display:flex; align-items:center; gap:.5rem; color:var(--text); font-weight:600; }
+.nav-menu ul{ display:flex; gap:1rem; list-style:none; margin:0; padding:0; }
+.nav-menu a{ color:var(--text); padding:.5rem .75rem; border-radius:.5rem; }
+.nav-menu a:hover{ background:var(--card); }
 
-.site-header {
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  max-width: var(--max-width);
-  margin: 0 auto;
-  padding: 1rem;
-}
+.hamburger{ display:none; background:transparent; border:1px solid var(--border); color:var(--text); padding:.35rem .6rem; border-radius:.5rem; }
 
-.brand {
-  display: inline-flex;
-  align-items: center;
-  gap: 0.75rem;
-  font-weight: 700;
-  font-size: 1.1rem;
-  letter-spacing: 0.1em;
-  text-transform: uppercase;
-  color: var(--color-dorado);
-}
-
-.brand img {
-  width: 44px;
-  height: 44px;
-  border-radius: 50%;
-  object-fit: cover;
-  box-shadow: 0 6px 20px rgba(0, 0, 0, 0.45);
-  background: var(--color-superficie);
-  padding: 0.25rem;
-  border: 1px solid var(--color-borde);
-}
-
-nav ul {
-  list-style: none;
-  display: flex;
-  gap: 1rem;
-  margin: 0;
-  padding: 0;
-}
-
-nav a {
-  font-weight: 600;
-  color: var(--color-texto);
-  padding: 0.35rem 0.5rem;
-  border-radius: 999px;
-  transition: color 0.3s ease, background 0.3s ease, box-shadow 0.3s ease;
-}
-
-nav a:focus,
-nav a:hover {
-  color: #090909;
-  background: linear-gradient(135deg, rgba(212, 175, 55, 0.95), rgba(251, 146, 60, 0.9));
-  box-shadow: 0 12px 28px rgba(0, 0, 0, 0.35);
+@media (max-width: 900px){
+  .hamburger{ display:block; }
+  .nav-menu{ display:none; position:absolute; right:1rem; top: calc(100% + .5rem); background:#000; border:1px solid var(--border); border-radius:.75rem; padding:.5rem; }
+  .nav-menu ul{ flex-direction:column; width: min(80vw, 320px); }
+  .nav-menu a{ display:block; }
+  .nav-menu.is-open{ display:block; }
 }
 
 .hero {

--- a/galeria.html
+++ b/galeria.html
@@ -20,30 +20,24 @@
   </head>
   <body>
     <a class="skip-link" href="#contenido-principal">Saltar al contenido principal</a>
-    <header>
-      <div class="site-header">
+    <header class="site-header">
+      <div class="container header-row">
         <a class="brand" href="index.html">
           <img
-            src="img/logo-xolos-ramirez.svg"
-            alt="Logo de Xolos Ramirez"
+            src="img/brand/logo-xolos-ramirez.svg"
+            alt="Xolos Ramírez"
             width="44"
             height="44"
             loading="eager"
             decoding="async"
           />
-          <span>Xolos Ramirez</span>
+          <span>Xolos Ramírez</span>
         </a>
-        <button
-          class="menu-toggle"
-          type="button"
-          data-menu-toggle
-          aria-expanded="false"
-          aria-controls="menu-principal"
-        >
-          Menú
-        </button>
-        <nav role="navigation" aria-label="Navegación principal">
-          <ul id="menu-principal" data-menu-list data-open="false">
+
+        <button class="hamburger" aria-expanded="false" aria-controls="menu">☰</button>
+
+        <nav id="menu" class="nav-menu">
+          <ul>
             <li><a href="index.html">Inicio</a></li>
             <li><a href="xolos-disponibles.html">Xolos disponibles</a></li>
             <li><a href="galeria.html">Galería</a></li>

--- a/img/brand/logo-xolos-ramirez.svg
+++ b/img/brand/logo-xolos-ramirez.svg
@@ -1,0 +1,23 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 240 80">
+  <defs>
+    <linearGradient id="grad" x1="0%" x2="100%" y1="0%" y2="100%">
+      <stop offset="0%" stop-color="#f97316" />
+      <stop offset="100%" stop-color="#a21caf" />
+    </linearGradient>
+  </defs>
+  <rect width="240" height="80" rx="12" fill="#0f172a" />
+  <circle cx="48" cy="40" r="28" fill="url(#grad)" />
+  <path
+    d="M40 54c6-2 8-6 8-10s-3-8-3-12c0-8 7-14 15-14 8 0 15 6 15 14 0 12-12 20-23 26"
+    fill="none"
+    stroke="#f8fafc"
+    stroke-width="3"
+    stroke-linecap="round"
+  />
+  <text x="98" y="46" font-family="'Trebuchet MS', 'Segoe UI', sans-serif" font-size="26" fill="#f8fafc" font-weight="700">
+    Xolos
+  </text>
+  <text x="98" y="66" font-family="'Trebuchet MS', 'Segoe UI', sans-serif" font-size="18" fill="#f97316" font-weight="600">
+    Ramirez
+  </text>
+</svg>

--- a/index.html
+++ b/index.html
@@ -20,30 +20,24 @@
   </head>
   <body>
     <a class="skip-link" href="#contenido-principal">Saltar al contenido principal</a>
-    <header>
-      <div class="site-header">
+    <header class="site-header">
+      <div class="container header-row">
         <a class="brand" href="index.html">
           <img
-            src="https://i.imgur.com/Ix0CyN1.jpeg"
-            alt="Logo de Xolos Ramirez"
+            src="img/brand/logo-xolos-ramirez.svg"
+            alt="Xolos Ramírez"
             width="44"
             height="44"
             loading="eager"
             decoding="async"
           />
-          <span>Xolos Ramirez</span>
+          <span>Xolos Ramírez</span>
         </a>
-        <button
-          class="menu-toggle"
-          type="button"
-          data-menu-toggle
-          aria-expanded="false"
-          aria-controls="menu-principal"
-        >
-          Menú
-        </button>
-        <nav role="navigation" aria-label="Navegación principal">
-          <ul id="menu-principal" data-menu-list data-open="false">
+
+        <button class="hamburger" aria-expanded="false" aria-controls="menu">☰</button>
+
+        <nav id="menu" class="nav-menu">
+          <ul>
             <li><a href="index.html">Inicio</a></li>
             <li><a href="xolos-disponibles.html">Xolos disponibles</a></li>
             <li><a href="galeria.html">Galería</a></li>

--- a/js/main.js
+++ b/js/main.js
@@ -1,46 +1,10 @@
-const menuToggle = document.querySelector('[data-menu-toggle]');
-const menuList = document.querySelector('[data-menu-list]');
-
-const setMenuState = (isOpen) => {
-  if (!menuList) return;
-  menuList.setAttribute('data-open', String(isOpen));
-  menuList.setAttribute('aria-hidden', isOpen ? 'false' : 'true');
-  if (menuToggle) {
-    menuToggle.setAttribute('aria-expanded', String(isOpen));
-  }
-};
-
-const syncMenuWithViewport = (mediaQuery) => {
-  if (!menuList) return;
-  if (mediaQuery.matches) {
-    setMenuState(true);
-    return;
-  }
-  const expanded =
-    menuToggle && menuToggle.getAttribute('aria-expanded') === 'true';
-  setMenuState(Boolean(expanded));
-};
-
-if (menuToggle && menuList) {
-  menuToggle.addEventListener('click', () => {
-    const isOpen = menuList.getAttribute('data-open') === 'true';
-    setMenuState(!isOpen);
+const btn = document.querySelector('.hamburger');
+const menu = document.querySelector('#menu');
+if (btn && menu) {
+  btn.addEventListener('click', () => {
+    const open = menu.classList.toggle('is-open');
+    btn.setAttribute('aria-expanded', open ? 'true' : 'false');
   });
-
-  const mediaQuery = window.matchMedia('(min-width: 769px)');
-  syncMenuWithViewport(mediaQuery);
-
-  const handleViewportChange = (event) => {
-    syncMenuWithViewport(event);
-  };
-
-  if (typeof mediaQuery.addEventListener === 'function') {
-    mediaQuery.addEventListener('change', handleViewportChange);
-  } else if (typeof mediaQuery.addListener === 'function') {
-    mediaQuery.addListener(handleViewportChange);
-  }
-} else if (menuList) {
-  setMenuState(true);
 }
 
 const yearElement = document.getElementById('year');
@@ -50,8 +14,8 @@ if (yearElement) {
 
 const currentPath = window.location.pathname.replace(/\/index\.html$/, '/');
 
-if (menuList) {
-  const links = menuList.querySelectorAll('a');
+if (menu) {
+  const links = menu.querySelectorAll('a');
   links.forEach((link) => {
     const href = link.getAttribute('href');
     if (!href) return;

--- a/testimonios.html
+++ b/testimonios.html
@@ -20,30 +20,24 @@
   </head>
   <body>
     <a class="skip-link" href="#contenido-principal">Saltar al contenido principal</a>
-    <header>
-      <div class="site-header">
+    <header class="site-header">
+      <div class="container header-row">
         <a class="brand" href="index.html">
           <img
-            src="img/logo-xolos-ramirez.svg"
-            alt="Logo de Xolos Ramirez"
+            src="img/brand/logo-xolos-ramirez.svg"
+            alt="Xolos Ramírez"
             width="44"
             height="44"
             loading="eager"
             decoding="async"
           />
-          <span>Xolos Ramirez</span>
+          <span>Xolos Ramírez</span>
         </a>
-        <button
-          class="menu-toggle"
-          type="button"
-          data-menu-toggle
-          aria-expanded="false"
-          aria-controls="menu-principal"
-        >
-          Menú
-        </button>
-        <nav role="navigation" aria-label="Navegación principal">
-          <ul id="menu-principal" data-menu-list data-open="false">
+
+        <button class="hamburger" aria-expanded="false" aria-controls="menu">☰</button>
+
+        <nav id="menu" class="nav-menu">
+          <ul>
             <li><a href="index.html">Inicio</a></li>
             <li><a href="xolos-disponibles.html">Xolos disponibles</a></li>
             <li><a href="galeria.html">Galería</a></li>

--- a/xolos-disponibles.html
+++ b/xolos-disponibles.html
@@ -21,30 +21,24 @@
   </head>
   <body>
     <a class="skip-link" href="#contenido-principal">Saltar al contenido principal</a>
-    <header>
-      <div class="site-header">
+    <header class="site-header">
+      <div class="container header-row">
         <a class="brand" href="index.html">
           <img
-            src="img/logo-xolos-ramirez.svg"
-            alt="Logo de Xolos Ramirez"
+            src="img/brand/logo-xolos-ramirez.svg"
+            alt="Xolos Ramírez"
             width="44"
             height="44"
             loading="eager"
             decoding="async"
           />
-          <span>Xolos Ramirez</span>
+          <span>Xolos Ramírez</span>
         </a>
-        <button
-          class="menu-toggle"
-          type="button"
-          data-menu-toggle
-          aria-expanded="false"
-          aria-controls="menu-principal"
-        >
-          Menú
-        </button>
-        <nav role="navigation" aria-label="Navegación principal">
-          <ul id="menu-principal" data-menu-list data-open="false">
+
+        <button class="hamburger" aria-expanded="false" aria-controls="menu">☰</button>
+
+        <nav id="menu" class="nav-menu">
+          <ul>
             <li><a href="index.html">Inicio</a></li>
             <li><a href="xolos-disponibles.html">Xolos disponibles</a></li>
             <li><a href="galeria.html">Galería</a></li>


### PR DESCRIPTION
## Summary
- reemplazar el encabezado en todas las páginas con la nueva estructura sticky y el botón hamburguesa
- actualizar los estilos globales para el menú responsive y añadir el recurso del logotipo en la nueva ruta
- simplificar el script principal para gestionar la apertura del menú y conservar el resaltado de la página activa

## Testing
- No se ejecutaron pruebas (sitio estático)


------
https://chatgpt.com/codex/tasks/task_e_68f277c6fc388332b8c2672ee8ca54e1