### PR TITLE
Style filter controls for single column layout on mobile

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -821,3 +821,41 @@ body :focus-visible {
 
 
 h1,h2,h3,.site-header .brand span{font-family:'Cinzel',serif;text-transform:uppercase;letter-spacing:2px;}
+/* Filtros de Xolos disponibles */
+.filtros{
+  background:#000;
+  border:1px solid var(--border);
+  border-radius:.85rem;
+  padding:1rem;
+  margin-bottom:1rem;
+}
+
+.filtro-categoria{
+  display:flex;
+  flex-wrap:wrap;
+  gap:.75rem 1rem;
+  align-items:center;
+}
+
+.filtro-categoria span{
+  font-weight:600;
+  color:var(--accent);
+  margin-right:.5rem;
+}
+
+.filtro-categoria label{
+  display:flex;
+  align-items:center;
+  gap:.35rem;
+}
+
+@media (max-width: 768px){
+  .filtros{
+    padding:.85rem;
+  }
+
+  .filtro-categoria{
+    flex-direction:column;
+    align-items:flex-start;
+  }
+}


### PR DESCRIPTION
## Summary
- add desktop filter styling with accent headings and spacing
- ensure filters collapse into a single column on small screens

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68f27af568f483329a2ac399c14c373d