### PR TITLE
Ajusta comportamiento parallax en móviles

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -694,12 +694,18 @@ body :focus-visible {
 
 .parallax {
   background-attachment: fixed;
-  background-position: center;
   background-size: cover;
+  background-position: center;
   background-repeat: no-repeat;
   position: relative;
   isolation: isolate;
   color: var(--color-texto);
+}
+
+@media (max-width: 768px) {
+  .parallax {
+    background-attachment: scroll;
+  }
 }
 
 .parallax::before {


### PR DESCRIPTION
## Summary
- garantiza que las secciones con clase `parallax` utilicen fondo fijo con cobertura y centrado por defecto
- desactiva el efecto parallax en pantallas de hasta 768px para mejorar la experiencia móvil

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68f27bbe37508332acc778221301b3e6