### PR TITLE
Configure AOS animations across pages

### DIFF
--- a/blog/cuidados-basicos.html
+++ b/blog/cuidados-basicos.html
@@ -157,7 +157,7 @@
     <script src="../js/main.js" defer></script>
     <script src="https://unpkg.com/aos@2.3.1/dist/aos.js"></script>
     <script>
-      AOS.init();
+      AOS.init({ once: true, duration: 700, offset: 60, easing: 'ease-out' });
     </script>
   </body>
 </html>

--- a/blog/cultura-mexicana.html
+++ b/blog/cultura-mexicana.html
@@ -149,7 +149,7 @@
     <script src="../js/main.js" defer></script>
     <script src="https://unpkg.com/aos@2.3.1/dist/aos.js"></script>
     <script>
-      AOS.init();
+      AOS.init({ once: true, duration: 700, offset: 60, easing: 'ease-out' });
     </script>
   </body>
 </html>

--- a/blog/entrada-1.html
+++ b/blog/entrada-1.html
@@ -157,7 +157,7 @@
     <script src="../js/main.js" defer></script>
     <script src="https://unpkg.com/aos@2.3.1/dist/aos.js"></script>
     <script>
-      AOS.init();
+      AOS.init({ once: true, duration: 700, offset: 60, easing: 'ease-out' });
     </script>
   </body>
 </html>

--- a/blog/entrada-2.html
+++ b/blog/entrada-2.html
@@ -157,7 +157,7 @@
     <script src="../js/main.js" defer></script>
     <script src="https://unpkg.com/aos@2.3.1/dist/aos.js"></script>
     <script>
-      AOS.init();
+      AOS.init({ once: true, duration: 700, offset: 60, easing: 'ease-out' });
     </script>
   </body>
 </html>

--- a/blog/historia-xoloitzcuintle.html
+++ b/blog/historia-xoloitzcuintle.html
@@ -162,7 +162,7 @@
     <script src="../js/main.js" defer></script>
     <script src="https://unpkg.com/aos@2.3.1/dist/aos.js"></script>
     <script>
-      AOS.init();
+      AOS.init({ once: true, duration: 700, offset: 60, easing: 'ease-out' });
     </script>
   </body>
 </html>

--- a/blog/index.html
+++ b/blog/index.html
@@ -59,7 +59,7 @@
       </section>
 
       <section class="grid" aria-label="Listado de artículos del blog" data-aos="fade-up" data-aos-duration="1000">
-        <article class="card blog-card" data-aos="fade-up" data-aos-delay="150">
+        <article class="card blog-card" data-aos="zoom-in" data-aos-delay="150">
           <img
             src="../img/blog/historia.svg"
             alt="Ilustración histórica de un xoloitzcuintle"
@@ -79,7 +79,7 @@
             >Leer más</a
           >
         </article>
-        <article class="card blog-card" data-aos="fade-up" data-aos-delay="250">
+        <article class="card blog-card" data-aos="zoom-in" data-aos-delay="250">
           <img
             src="../img/xolos/ejemplar-1.svg"
             alt="Xoloitzcuintle oscuro en pose de pie"
@@ -99,7 +99,7 @@
             >Leer más</a
           >
         </article>
-        <article class="card blog-card" data-aos="fade-up" data-aos-delay="350">
+        <article class="card blog-card" data-aos="zoom-in" data-aos-delay="350">
           <img
             src="../img/blog/artesania.svg"
             alt="Artesanías mexicanas inspiradas en el xoloitzcuintle"
@@ -119,7 +119,7 @@
             >Leer más</a
           >
         </article>
-        <article class="card blog-card" data-aos="fade-up" data-aos-delay="450">
+        <article class="card blog-card" data-aos="zoom-in" data-aos-delay="450">
           <img
             src="../img/xolos/pareja.svg"
             alt="Pareja paseando con un xoloitzcuintle"
@@ -139,7 +139,7 @@
             >Leer más</a
           >
         </article>
-        <article class="card blog-card" data-aos="fade-up" data-aos-delay="550">
+        <article class="card blog-card" data-aos="zoom-in" data-aos-delay="550">
           <img
             src="../img/xolos/familia.svg"
             alt="Familia entrenando a su xoloitzcuintle"
@@ -188,7 +188,7 @@
     <script src="../js/main.js" defer></script>
     <script src="https://unpkg.com/aos@2.3.1/dist/aos.js"></script>
     <script>
-      AOS.init();
+      AOS.init({ once: true, duration: 700, offset: 60, easing: 'ease-out' });
     </script>
   </body>
 </html>

--- a/contacto.html
+++ b/contacto.html
@@ -90,12 +90,12 @@
       <section data-aos="fade-up" data-aos-duration="1000" data-aos-offset="120">
         <h2>Información adicional</h2>
         <div class="grid grid-2">
-          <article class="card" data-aos="fade-up" data-aos-delay="150">
+          <article class="card" data-aos="zoom-in" data-aos-delay="150">
             <h3>Visítanos</h3>
             <p>Calle del Xolo 123, Colonia Historia Viva, Ciudad de México.</p>
             <p><strong>Horario:</strong> Lunes a sábado de 10:00 a 18:00 h.</p>
           </article>
-          <article class="card" data-aos="fade-up" data-aos-delay="250">
+          <article class="card" data-aos="zoom-in" data-aos-delay="250">
             <h3>Contacto directo</h3>
             <p><strong>Teléfono:</strong> +52 55 1234 5678</p>
             <p><strong>Correo:</strong> hola@xolosramirez.mx</p>
@@ -130,7 +130,7 @@
     <script src="js/main.js" defer></script>
     <script src="https://unpkg.com/aos@2.3.1/dist/aos.js"></script>
     <script>
-      AOS.init();
+      AOS.init({ once: true, duration: 700, offset: 60, easing: 'ease-out' });
     </script>
   </body>
 </html>

--- a/galeria.html
+++ b/galeria.html
@@ -137,7 +137,7 @@
     <script src="js/main.js" defer></script>
     <script src="https://unpkg.com/aos@2.3.1/dist/aos.js"></script>
     <script>
-      AOS.init();
+      AOS.init({ once: true, duration: 700, offset: 60, easing: 'ease-out' });
     </script>
   </body>
 </html>

--- a/index.html
+++ b/index.html
@@ -108,7 +108,7 @@
       </section>
 
       <section class="grid grid-2" data-aos="fade-up" data-aos-duration="1000" data-aos-delay="150">
-        <article class="card" data-aos="fade-up" data-aos-delay="200">
+        <article class="card" data-aos="zoom-in" data-aos-delay="200">
           <h3>Actividades comunitarias</h3>
           <p>
             Organizamos recorridos culturales, charlas con especialistas y
@@ -119,7 +119,7 @@
             de la comunidad.
           </p>
         </article>
-        <article class="card" data-aos="fade-up" data-aos-delay="300">
+        <article class="card" data-aos="zoom-in" data-aos-delay="300">
           <h3>Últimas publicaciones del blog</h3>
           <ul>
             <li><a href="blog/cultura-mexicana.html">El xoloitzcuintle en la cultura mexicana</a></li>
@@ -197,7 +197,7 @@
     <script src="js/main.js" defer></script>
     <script src="https://unpkg.com/aos@2.3.1/dist/aos.js"></script>
     <script>
-      AOS.init();
+      AOS.init({ once: true, duration: 700, offset: 60, easing: 'ease-out' });
     </script>
   </body>
 </html>

--- a/public/xolos-disponibles.html
+++ b/public/xolos-disponibles.html
@@ -9,6 +9,7 @@
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/css2?family=Cinzel:wght@400;700&family=Poppins:wght@400;600&display=swap" rel="stylesheet">
+  <link href="https://unpkg.com/aos@2.3.1/dist/aos.css" rel="stylesheet">
   <link rel="stylesheet" href="css/styles.css" />
   <!-- Favicon -->
   <link rel="icon" type="image/svg+xml" href="img/favicon.svg" />
@@ -39,13 +40,13 @@
   <!-- Contenido principal -->
   <main id="contenido-principal">
     <!-- Hero Section -->
-    <section class="hero hero-disponibles">
+    <section class="hero hero-disponibles" data-aos="fade-in">
       <h1>Xoloitzcuintles disponibles</h1>
       <p>Conoce a nuestros cachorros Xoloitzcuintle disponibles. Aquí encontrarás su talla, color, sexo, edad y estado. ¡El guardián de tu historia te espera!</p>
     </section>
 
     <!-- Filtros -->
-    <section class="filtros">
+    <section class="filtros" data-aos="fade-up">
       <h2>Filtrar por</h2>
       <div class="filtro-categoria">
         <span><strong>Talla:</strong></span>
@@ -71,7 +72,7 @@
       <h2>Cachorros disponibles</h2>
       <div class="grid grid-2">  <!-- grid flexible para las tarjetas -->
         <!-- Tarjeta 1: Ejemplo Disponible -->
-        <article class="card" data-talla="intermedia" data-sexo="macho" data-estado="disponible">
+        <article class="card" data-talla="intermedia" data-sexo="macho" data-estado="disponible" data-aos="zoom-in">
           <picture>
             <source type="image/webp" srcset="img/cachorros/tliltic.webp">
             <source type="image/jpeg" srcset="img/cachorros/tliltic.jpg">
@@ -90,7 +91,7 @@
         </article>
 
         <!-- Tarjeta 2: Ejemplo Reservado -->
-        <article class="card" data-talla="estándar" data-sexo="hembra" data-estado="reservado">
+        <article class="card" data-talla="estándar" data-sexo="hembra" data-estado="reservado" data-aos="zoom-in">
           <picture>
             <source type="image/webp" srcset="img/cachorros/nikte.webp">
             <source type="image/jpeg" srcset="img/cachorros/nikte.jpg">
@@ -109,7 +110,7 @@
         </article>
 
         <!-- Tarjeta 3: Ejemplo Lista de espera -->
-        <article class="card" data-talla="miniatura" data-sexo="macho" data-estado="lista-espera">
+        <article class="card" data-talla="miniatura" data-sexo="macho" data-estado="lista-espera" data-aos="zoom-in">
           <picture>
             <source type="image/webp" srcset="img/cachorros/xolotl.webp">
             <source type="image/jpeg" srcset="img/cachorros/xolotl.jpg">
@@ -219,6 +220,10 @@
         });
       });
     });
+  </script>
+  <script src="https://unpkg.com/aos@2.3.1/dist/aos.js"></script>
+  <script>
+    AOS.init({ once: true, duration: 700, offset: 60, easing: 'ease-out' });
   </script>
 
 </body>

--- a/testimonios.html
+++ b/testimonios.html
@@ -59,7 +59,7 @@
       </section>
 
       <section class="grid" data-aos="fade-up" data-aos-duration="1000">
-        <article class="card" data-aos="fade-up" data-aos-delay="150">
+        <article class="card" data-aos="zoom-in" data-aos-delay="150">
           <h2>Familia Hernández — Ciudad de México</h2>
           <blockquote>
             “Adoptar a Malinalli ha sido transformar nuestro hogar. Recibimos
@@ -67,21 +67,21 @@
             mensuales.”
           </blockquote>
         </article>
-        <article class="card" data-aos="fade-up" data-aos-delay="250">
+        <article class="card" data-aos="zoom-in" data-aos-delay="250">
           <h2>Dra. Camila Ríos — Médica veterinaria</h2>
           <blockquote>
             “Xolos Ramirez fomenta protocolos de salud integrales. Cada adopción
             incluye un plan preventivo dermatológico y charlas sobre nutrición.”
           </blockquote>
         </article>
-        <article class="card" data-aos="fade-up" data-aos-delay="350">
+        <article class="card" data-aos="zoom-in" data-aos-delay="350">
           <h2>César y Nayeli — Querétaro</h2>
           <blockquote>
             “Nos unimos para apadrinar a Huehue. A través del programa de
             voluntariado aprendimos rutinas de enriquecimiento para xolos senior.”
           </blockquote>
         </article>
-        <article class="card" data-aos="fade-up" data-aos-delay="450">
+        <article class="card" data-aos="zoom-in" data-aos-delay="450">
           <h2>Laura Martínez — Artesana</h2>
           <blockquote>
             “El xoloitzcuintle es un símbolo ancestral que inspira mi trabajo. En
@@ -128,7 +128,7 @@
     <script src="js/main.js" defer></script>
     <script src="https://unpkg.com/aos@2.3.1/dist/aos.js"></script>
     <script>
-      AOS.init();
+      AOS.init({ once: true, duration: 700, offset: 60, easing: 'ease-out' });
     </script>
   </body>
 </html>

--- a/xolos-disponibles.html
+++ b/xolos-disponibles.html
@@ -79,7 +79,7 @@
       <section data-aos="fade-up" data-aos-duration="1000" data-aos-delay="100">
         <h2>Perfiles destacados</h2>
         <div class="grid grid-2">
-          <article class="card" data-aos="fade-up" data-aos-duration="900">
+          <article class="card" data-aos="zoom-in" data-aos-duration="900">
             <img
               src="img/xolos/tonatiuh.svg"
               alt="Xoloitzcuintle joven llamado Tonatiuh"
@@ -109,7 +109,7 @@
             <p><strong>Salud:</strong> Chequeo dental reciente, esterilizada.</p>
             <a href="contacto.html">Concertar visita</a>
           </article>
-          <article class="card" data-aos="fade-up" data-aos-duration="900" data-aos-delay="200">
+          <article class="card" data-aos="zoom-in" data-aos-duration="900" data-aos-delay="200">
             <img
               src="img/xolos/xolo-mini.svg"
               alt="Xoloitzcuintle miniatura en adopción"
@@ -199,7 +199,7 @@
     <script src="js/main.js" defer></script>
     <script src="https://unpkg.com/aos@2.3.1/dist/aos.js"></script>
     <script>
-      AOS.init();
+      AOS.init({ once: true, duration: 700, offset: 60, easing: 'ease-out' });
     </script>
   </body>
 </html>


### PR DESCRIPTION
## Summary
- update hero, card, and filter sections to use AOS fade and zoom effects across site templates
- standardize the AOS initialization settings for consistent animation timing
- add the same animation resources and attributes to the legacy public/xolos-disponibles page

## Testing
- not run (static files)

------
https://chatgpt.com/codex/tasks/task_e_68f27d4c2a108332a45f3461493dd5ba