### PR TITLE
Add responsive overflow rule for mobile layout

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -884,3 +884,7 @@ h1,h2,h3,.site-header .brand span{font-family:'Cinzel',serif;text-transform:uppe
 @media (max-width: 600px){
   .footer-grid{ grid-template-columns: 1fr; text-align:center; }
 }
+
+@media (max-width: 768px){
+  html, body{ overflow-x:hidden; width:100%; }
+}


### PR DESCRIPTION
## Summary
- add a max-width 768px media query to hide horizontal overflow on html and body for small screens

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68f27eca18e083328e3c2931134b07a7