### PR TITLE
Add hero CTA, adoption anchor, and update testimonials heading

### DIFF
--- a/index.html
+++ b/index.html
@@ -68,6 +68,7 @@
             su legado histórico, conoce ejemplares disponibles para adopción
             responsable y únete a nuestra comunidad.
           </p>
+          <a class="btn" href="#adopciones">Adopta un Xolo</a>
         </div>
       </section>
 
@@ -81,7 +82,7 @@
         </p>
       </section>
 
-      <section class="grid grid-2" data-aos="fade-up" data-aos-duration="1000" data-aos-delay="100">
+      <section id="adopciones" class="grid grid-2" data-aos="fade-up" data-aos-duration="1000" data-aos-delay="100">
         <article class="card" data-aos="zoom-in" data-aos-delay="150">
           <picture class="card__media">
            <img
@@ -153,7 +154,7 @@
 
 
       <section id="testimonios" data-aos="fade-up" data-aos-duration="1000">
-        <h2>Testimonios</h2>
+        <h2>Qué dicen nuestros adoptantes</h2>
         <div class="grid">
           <blockquote data-aos="fade-right" data-aos-delay="150">
             <p>“Mi Xoloitzcuintle cambió mi vida. Gracias a Xolos Ramírez.”</p>


### PR DESCRIPTION
### Motivation
- Make the home page hero include a clear call-to-action that points users to the adoption listings. 
- Provide an anchor so the CTA can scroll directly to the adoption cards. 
- Increase credibility by emphasizing adopter feedback in the testimonials section. 

### Description
- Added a hero CTA button `<a class="btn" href="#adopciones">Adopta un Xolo</a>` inside `index.html` using the existing `.btn` styles. 
- Added `id="adopciones"` to the adoption cards section so the CTA target is reachable via `#adopciones`. 
- Updated the testimonials section heading from `Testimonios` to `Qué dicen nuestros adoptantes` in `index.html`. 
- No CSS changes were required because the site reuses the existing `.btn` class and current theme. 

### Testing
- Launched a local HTTP server with `python -m http.server` and verified the page loads successfully. 
- Ran a headless Playwright script to render the updated home page and capture a full-page screenshot (`artifacts/home-cta-testimonios.png`). 
- The Playwright screenshot run completed successfully and the artifact was produced. 
- This change is a static content update and no unit tests were applicable.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6949b760d7f88332bfb94ee2b050c4e5)