### PR TITLE
Add trust/guarantee sections, improve image loading and accessibility

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -170,6 +170,30 @@ a:hover {
   grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
 }
 
+.trust-grid{
+  display:grid;
+  gap: clamp(1rem, 3vw, 1.5rem);
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+}
+
+.trust-card{
+  padding: clamp(1.25rem, 2.5vw, 1.75rem);
+  text-align:center;
+}
+
+.trust-card h4{
+  margin: .75rem 0 .5rem;
+}
+
+.trust-icon{
+  font-size: clamp(1.6rem, 3vw, 2.4rem);
+  color: var(--accent-2);
+}
+
+@media (max-width: 640px){
+  .trust-grid{ grid-template-columns: 1fr; }
+}
+
 .card{
   background: var(--card);
   border:1px solid var(--border);

--- a/en/available-xolos.html
+++ b/en/available-xolos.html
@@ -136,6 +136,36 @@
         </p>
       </section>
 
+      <section class="trust" data-aos="fade-up" data-aos-duration="1000" data-aos-delay="80">
+        <h2>Confianza y garantías</h2>
+        <div class="trust-grid">
+          <article class="card trust-card">
+            <span class="trust-icon" aria-hidden="true">💉🩺</span>
+            <h4>Garantía de salud</h4>
+            <p>
+              Certificado veterinario, vacunas, desparasitación, microchip y
+              pedigree incluidos en cada entrega.
+            </p>
+          </article>
+          <article class="card trust-card">
+            <span class="trust-icon" aria-hidden="true">🔒💳</span>
+            <h4>Pago seguro</h4>
+            <p>
+              Métodos seguros con comprobante (transferencia bancaria, OXXO o
+              efectivo) y acompañamiento continuo.
+            </p>
+          </article>
+          <article class="card trust-card">
+            <span class="trust-icon" aria-hidden="true">✈️🌎</span>
+            <h4>Envíos nacionales e internacionales</h4>
+            <p>
+              Envíos a todo México y al extranjero cumpliendo requisitos
+              veterinarios y de viaje.
+            </p>
+          </article>
+        </div>
+      </section>
+
       <section data-aos="fade-up" data-aos-duration="1000" data-aos-delay="100">
         <h2>Perfiles destacados</h2>
         <div class="grid grid-2">
@@ -292,15 +322,15 @@
         <h2>¿Cómo reservo?</h2>
         <div class="pasos-reserva">
           <div class="paso">
-            <img src="img/icono-eleccion.svg" alt="" width="50" height="50" />
+            <img src="img/icono-eleccion.svg" alt="" width="50" height="50" loading="lazy" />
             <p><strong>1. Elige a tu Xolo:</strong> Revisa los perfiles y selecciona el que mejor se adapte a tu familia.</p>
           </div>
           <div class="paso">
-            <img src="img/icono-contacto.svg" alt="" width="50" height="50" />
+            <img src="img/icono-contacto.svg" alt="" width="50" height="50" loading="lazy" />
             <p><strong>2. Escríbenos:</strong> Haz clic en WhatsApp o envíanos un correo para iniciar la reserva.</p>
           </div>
           <div class="paso">
-            <img src="img/icono-reserva.svg" alt="" width="50" height="50" />
+            <img src="img/icono-reserva.svg" alt="" width="50" height="50" loading="lazy" />
             <p><strong>3. Reserva:</strong> Confirma el anticipo y coordinamos la entrega contigo.</p>
           </div>
         </div>

--- a/en/index.html
+++ b/en/index.html
@@ -105,9 +105,9 @@
     src="../img/hero/site-hero.jpg"
     width="1600"
     height="900"
-    loading="lazy"
+    loading="eager"
     decoding="async"
-    alt="A xoloitzcuintle at a ceremony"
+    alt="Xoloitzcuintle standing at a traditional Mexican ceremony"
   />
 </picture>
         <div class="container">
@@ -134,6 +134,36 @@
           and lovers of Mexican culture to provide trusted information and
           promote responsible guardianship.
         </p>
+      </section>
+
+      <section class="trust" data-aos="fade-up" data-aos-duration="1000" data-aos-delay="80">
+        <h2>Trust and guarantees</h2>
+        <div class="trust-grid">
+          <article class="card trust-card">
+            <span class="trust-icon" aria-hidden="true">💉🩺</span>
+            <h4>Health guarantee</h4>
+            <p>
+              Every Xolo goes home with a veterinary health certificate,
+              up-to-date vaccines, deworming, microchip, and pedigree.
+            </p>
+          </article>
+          <article class="card trust-card">
+            <span class="trust-icon" aria-hidden="true">🔒💳</span>
+            <h4>Secure payments</h4>
+            <p>
+              Secure payment methods with receipts (bank transfer, OXXO, or
+              cash) and guidance throughout the process.
+            </p>
+          </article>
+          <article class="card trust-card">
+            <span class="trust-icon" aria-hidden="true">✈️🌎</span>
+            <h4>National & international shipping</h4>
+            <p>
+              We ship across Mexico and abroad, meeting all veterinary and
+              travel requirements.
+            </p>
+          </article>
+        </div>
       </section>
 
       <section id="adopciones" class="grid grid-2" data-aos="fade-up" data-aos-duration="1000" data-aos-delay="100">

--- a/index.html
+++ b/index.html
@@ -105,9 +105,9 @@
     src="img/hero/site-hero.jpg"
     width="1600"
     height="900"
-    loading="lazy"
+    loading="eager"
     decoding="async"
-    alt="Un xoloitzcuintle en una ceremonia [¡Actualiza esto!]"
+    alt="Xoloitzcuintle parado en una ceremonia tradicional mexicana"
   />
 </picture>
         <div class="container">
@@ -134,6 +134,36 @@
           historiadores y amantes de la cultura mexicana para brindar información
           confiable y promover la tenencia responsable.
         </p>
+      </section>
+
+      <section class="trust" data-aos="fade-up" data-aos-duration="1000" data-aos-delay="80">
+        <h2>Confianza y garantías</h2>
+        <div class="trust-grid">
+          <article class="card trust-card">
+            <span class="trust-icon" aria-hidden="true">💉🩺</span>
+            <h4>Garantía de salud</h4>
+            <p>
+              Entregamos a cada Xolo con certificado de salud, vacunas,
+              desparasitación, microchip y pedigree al día.
+            </p>
+          </article>
+          <article class="card trust-card">
+            <span class="trust-icon" aria-hidden="true">🔒💳</span>
+            <h4>Pago seguro</h4>
+            <p>
+              Métodos de pago seguros con comprobante (transferencia bancaria,
+              OXXO o efectivo) y acompañamiento en el proceso.
+            </p>
+          </article>
+          <article class="card trust-card">
+            <span class="trust-icon" aria-hidden="true">✈️🌎</span>
+            <h4>Envíos nacionales e internacionales</h4>
+            <p>
+              Enviamos a todo México y al extranjero cumpliendo los requisitos
+              veterinarios y de viaje.
+            </p>
+          </article>
+        </div>
       </section>
 
       <section id="adopciones" class="grid grid-2" data-aos="fade-up" data-aos-duration="1000" data-aos-delay="100">

--- a/xolos-disponibles.html
+++ b/xolos-disponibles.html
@@ -136,6 +136,36 @@
         </p>
       </section>
 
+      <section class="trust" data-aos="fade-up" data-aos-duration="1000" data-aos-delay="80">
+        <h2>Confianza y garantías</h2>
+        <div class="trust-grid">
+          <article class="card trust-card">
+            <span class="trust-icon" aria-hidden="true">💉🩺</span>
+            <h4>Garantía de salud</h4>
+            <p>
+              Certificado veterinario, vacunas, desparasitación, microchip y
+              pedigree incluidos en cada entrega.
+            </p>
+          </article>
+          <article class="card trust-card">
+            <span class="trust-icon" aria-hidden="true">🔒💳</span>
+            <h4>Pago seguro</h4>
+            <p>
+              Métodos seguros con comprobante (transferencia bancaria, OXXO o
+              efectivo) y acompañamiento continuo.
+            </p>
+          </article>
+          <article class="card trust-card">
+            <span class="trust-icon" aria-hidden="true">✈️🌎</span>
+            <h4>Envíos nacionales e internacionales</h4>
+            <p>
+              Envíos a todo México y al extranjero cumpliendo requisitos
+              veterinarios y de viaje.
+            </p>
+          </article>
+        </div>
+      </section>
+
       <section data-aos="fade-up" data-aos-duration="1000" data-aos-delay="100">
         <h2>Perfiles destacados</h2>
         <div class="grid grid-2">
@@ -292,15 +322,15 @@
         <h2>¿Cómo reservo?</h2>
         <div class="pasos-reserva">
           <div class="paso">
-            <img src="img/icono-eleccion.svg" alt="" width="50" height="50" />
+            <img src="img/icono-eleccion.svg" alt="" width="50" height="50" loading="lazy" />
             <p><strong>1. Elige a tu Xolo:</strong> Revisa los perfiles y selecciona el que mejor se adapte a tu familia.</p>
           </div>
           <div class="paso">
-            <img src="img/icono-contacto.svg" alt="" width="50" height="50" />
+            <img src="img/icono-contacto.svg" alt="" width="50" height="50" loading="lazy" />
             <p><strong>2. Escríbenos:</strong> Haz clic en WhatsApp o envíanos un correo para iniciar la reserva.</p>
           </div>
           <div class="paso">
-            <img src="img/icono-reserva.svg" alt="" width="50" height="50" />
+            <img src="img/icono-reserva.svg" alt="" width="50" height="50" loading="lazy" />
             <p><strong>3. Reserva:</strong> Confirma el anticipo y coordinamos la entrega contigo.</p>
           </div>
         </div>


### PR DESCRIPTION
### Motivation
- Surface trust signals (health guarantee, secure payments, shipping) so visitors see guarantees before deciding to adopt. 
- Improve accessibility and SEO by replacing placeholder `alt` text for hero images with descriptive text. 
- Improve performance by ensuring above-the-fold hero images load eagerly and non-critical imagery/icons use `loading="lazy"`.
- Keep the site responsive and consistent by adding small, mobile-first styles for the new trust cards.

### Description
- Added a three-card trust/guarantees section to the home and available pages in Spanish and English (`index.html`, `en/index.html`, `xolos-disponibles.html`, `en/available-xolos.html`).
- Implemented responsive styles for the new section in `css/styles.css` (`.trust-grid`, `.trust-card`, `.trust-icon`) and a mobile rule to stack cards in one column.
- Improved image handling: updated hero `alt` text and changed hero images to `loading="eager"` for above-the-fold content, and added `loading="lazy"` to small icons and other non-critical images.
- Minor HTML updates to ensure icons and step images include `loading` attributes and ARIA/alt updates for better accessibility.

### Testing
- Ran a small analysis script to detect `<img>` tags missing a `loading` attribute and fixed all cases; the script reported zero files missing the attribute (success).
- Served the site locally with `python -m http.server 8000` and produced a full-page screenshot with a Playwright script to visually verify the new trust section (screenshot captured successfully).
- Performed a local commit of the changes and verified the repository status (changes staged and committed successfully).
- No automated Lighthouse run was requested; only the static checks and a visual smoke test were executed and succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6949c63afcf48332a99ee078f0999bf6)