### PR TITLE
Add mailto callout link for newsletter subscription

### DIFF
--- a/index.html
+++ b/index.html
@@ -213,8 +213,11 @@
             encuentros familiares donde los xolos son protagonistas.
           </p>
           <p class="callout">
-            Suscríbete al boletín para recibir invitaciones y contenido exclusivo
-            de la comunidad.
+            <a href="mailto:contacto@xolosarmy.xyz?subject=Suscripción al Boletín&body=Hola, me gustaría suscribirme a su lista de correos electrónicos para recibir noticias sobre los xolos." 
+               style="color: var(--accent-color); text-underline-offset: 4px;">
+               Suscríbete al boletín por email
+            </a> 
+            para recibir invitaciones y contenido exclusivo de la comunidad.
           </p>
         </article>
         <article class="card" data-aos="zoom-in" data-aos-delay="300">


### PR DESCRIPTION
## Summary
- replace the activities callout copy with a mailto link for newsletter subscription
- keep the callout styling while highlighting the accent-colored link
- prefill subject and body text to simplify sending the email

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69544f7a8ab8833295a518e12ae2ac04)