### PR TITLE
Add autoplaying YouTube story to testimonios page

### DIFF
--- a/testimonios.html
+++ b/testimonios.html
@@ -473,6 +473,24 @@
             </div>
           </article>
 
+          <article class="post-card" data-aos="zoom-in">
+            <div class="video-container" style="position: relative; padding-bottom: 56.25%; height: 0; overflow: hidden;">
+              <iframe 
+                src="https://www.youtube.com/embed/fg5EhvJcti4?si=PWjfFqrH0Iy7WiPy&autoplay=1&mute=1&loop=1&playlist=fg5EhvJcti4" 
+                style="position: absolute; top: 0; left: 0; width: 100%; height: 100%; border: 0;" 
+                allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" 
+                allowfullscreen>
+              </iframe>
+            </div>
+            <div class="post-card__body">
+              <blockquote style="font-style: italic; margin-bottom: 1rem;">
+                <p>"¡Añade aquí la frase o testimonio que desees destacar de este video!"</p>
+              </blockquote>
+              <cite>— Xolos Ramírez Comunidad</cite>
+              <a href="blog/nueva-historia.html" class="btn btn--sm" style="display: block; margin-top: 1rem;">Leer historia completa</a>
+            </div>
+          </article>
+
         </div>
       </section>
 


### PR DESCRIPTION
## Summary
- add an autoplaying, looping YouTube video card to the Historias Reales grid on testimonios.html
- include placeholder testimonial quote, citation, and link to the full story page

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6955a11a4c408332af6ac978a492d038)