### PR TITLE
Fix mobile nav visibility

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -262,6 +262,11 @@ a:hover {
   .nav-menu ul {
     flex-direction: column;
     gap: 2rem;
+    transform: none;
+    background: transparent;
+    position: static;
+    padding: 0;
+    box-shadow: none;
   }
 }
 


### PR DESCRIPTION
## Summary
- override mobile `.nav-menu ul` styles to prevent inherited scaling/position that hid the menu

## Testing
- not run

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6956d85636008332801be99030236268)