### PR TITLE
Add language preference persistence

### DIFF
--- a/js/main.js
+++ b/js/main.js
@@ -50,3 +50,26 @@ if (navMenu) {
     }
   });
 }
+
+document.addEventListener('DOMContentLoaded', () => {
+  const langLinks = document.querySelectorAll('.lang-switch a');
+
+  langLinks.forEach((link) => {
+    link.addEventListener('click', () => {
+      const selectedLang = link.getAttribute('lang');
+      if (!selectedLang) return;
+
+      localStorage.setItem('preferredLang', selectedLang);
+    });
+  });
+
+  const savedLang = localStorage.getItem('preferredLang');
+  const pageLang = document.documentElement.getAttribute('lang');
+
+  if (savedLang && savedLang !== pageLang) {
+    const preferredLink = document.querySelector(`.lang-switch a[lang="${savedLang}"]`);
+    if (preferredLink) {
+      window.location.href = preferredLink.href;
+    }
+  }
+});


### PR DESCRIPTION
## Summary
- store the selected language when visitors use the language switch links
- automatically redirect to the preferred language version when landing on a page with a different locale

## Testing
- not run (not requested)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695710f57874833294086189c7d2c857)