### PR TITLE
Remove English switch from non-home pages

### DIFF
--- a/blog/index.html
+++ b/blog/index.html
@@ -92,18 +92,13 @@
         Blog
        </a>
       </li>
-      <li>
+     <li>
        <a href="../contacto.html">
         Contacto
        </a>
-      </li>
-     </ul>
-    </nav>
-    <div class="lang-switch">
-     <a aria-label="View blog in English" href="../en/blog/index.html" lang="en">
-      EN
-     </a>
-    </div>
+     </li>
+    </ul>
+   </nav>
    </div>
   </header>
    <main id="contenido-principal">

--- a/contacto.html
+++ b/contacto.html
@@ -92,9 +92,6 @@
             <li><a href="contacto.html">Contacto</a></li>
           </ul>
         </nav>
-        <div class="lang-switch">
-          <a href="en/contact.html" lang="en" aria-label="View site in English">EN</a>
-        </div>
       </div>
     </header>
 

--- a/galeria.html
+++ b/galeria.html
@@ -92,9 +92,6 @@
             <li><a href="contacto.html">Contacto</a></li>
           </ul>
         </nav>
-        <div class="lang-switch">
-          <a href="en/gallery.html" lang="en" aria-label="View page in English">EN</a>
-        </div>
       </div>
     </header>
 

--- a/testimonios.html
+++ b/testimonios.html
@@ -92,9 +92,6 @@
             <li><a href="contacto.html">Contacto</a></li>
           </ul>
         </nav>
-        <div class="lang-switch">
-          <a href="en/testimonials.html" lang="en" aria-label="View page in English">EN</a>
-        </div>
       </div>
     </header>
 

--- a/xolos-disponibles.html
+++ b/xolos-disponibles.html
@@ -97,9 +97,6 @@
             <li><a href="contacto.html">Contacto</a></li>
           </ul>
         </nav>
-        <div class="lang-switch">
-          <a href="en/available-xolos.html" lang="en" aria-label="View page in English">EN</a>
-        </div>
       </div>
     </header>
 


### PR DESCRIPTION
## Summary
- remove the EN language switch from Spanish subpages so the translation button only appears on the home page
- avoid broken navigation to English pages that are not ready

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69571662a84c8332b7d57d501aab31ef)