### PR TITLE
Update adoption CTA links to available Xolos pages

### DIFF
--- a/en/index.html
+++ b/en/index.html
@@ -118,8 +118,8 @@
             community.
           </p>
           <a
-            class="btn"
-            href="#adopciones"
+            class="btn btn--primary"
+            href="available-xolos.html"
             data-gtm="cta-home"
             onclick="dataLayer.push({ event: 'click_home_cta', label: 'hero_adopta_xolo' })"
           >Adopt a Xolo</a>

--- a/index.html
+++ b/index.html
@@ -111,14 +111,11 @@
           />
         </picture>
         <div class="container">
-          <h1>Xolos Ramirez</h1>
-          <p>Registro de Pedigrees de el Linaje Ramirez en la Federación Canofila Mexicana</p>
-          <a
-            class="btn"
-            href="#adopciones"
-            data-gtm="cta-home"
-            onclick="dataLayer.push({ event: 'click_home_cta', label: 'hero_adopta_xolo' })"
-          >Adopta un Xolo</a>
+          <div class="hero__content">
+            <h1>Criadero Xolos Ramírez</h1>
+            <p>Guardianes ancestrales de la cultura mexicana.</p>
+            <a href="xolos-disponibles.html" class="btn btn--primary">Adopta un Xolo</a>
+          </div>
         </div>
       </section>
 
@@ -284,9 +281,11 @@ Selección de Ejemplares de Calidad: Seleccionamos cuidadosamente a los perros q
         </div>
       </section>
 
-      <section id="cta" data-aos="fade-up" data-aos-duration="1000">
-        <h2>¿Listo para conocer a tu Xoloitzcuintle?</h2>
-        <a href="contacto.html" class="btn">Contáctanos</a>
+      <section class="cta-section">
+        <div class="container">
+          <h2>¿Listo para recibir a un compañero ancestral?</h2>
+          <a href="http://xolosramirez.com/xolos-disponibles.html" class="btn">Adopta un Xolo</a>
+        </div>
       </section>
     </main>
 


### PR DESCRIPTION
## Summary
- update the Spanish hero CTA copy and link to point to the available Xolos page
- replace the homepage CTA section with the new adoption-focused block and absolute link
- align the English hero button to link to the available Xolos page with primary styling

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6957ec54bb448332ae5ef31727c3b307)