### PR TITLE
Update Google Tag Manager container to GTM-MGTMWN7T

### DIFF
--- a/blog/2025-10-10-xolotl-fuego-cosmico.html
+++ b/blog/2025-10-10-xolotl-fuego-cosmico.html
@@ -13,7 +13,7 @@
         j.async = true;
         j.src = 'https://www.googletagmanager.com/gtm.js?id=' + i + dl;
         f.parentNode.insertBefore(j, f);
-      })(window, document, 'script', 'dataLayer', 'GTM-WWH7XHCN');
+      })(window, document, 'script', 'dataLayer', 'GTM-MGTMWN7T');
     </script>
     <!-- End Google Tag Manager -->
     <meta charset="UTF-8" />
@@ -94,7 +94,7 @@
     <!-- Google Tag Manager (noscript) -->
     <noscript>
       <iframe
-        src="https://www.googletagmanager.com/ns.html?id=GTM-WWH7XHCN"
+        src="https://www.googletagmanager.com/ns.html?id=GTM-MGTMWN7T"
         height="0"
         width="0"
         style="display: none; visibility: hidden"

--- a/blog/2025-10-21-malva-ramirez-xoloitzcuintle-viajera.html
+++ b/blog/2025-10-21-malva-ramirez-xoloitzcuintle-viajera.html
@@ -13,7 +13,7 @@
         j.async = true;
         j.src = 'https://www.googletagmanager.com/gtm.js?id=' + i + dl;
         f.parentNode.insertBefore(j, f);
-      })(window, document, 'script', 'dataLayer', 'GTM-WWH7XHCN');
+      })(window, document, 'script', 'dataLayer', 'GTM-MGTMWN7T');
     </script>
     <!-- End Google Tag Manager -->
   <meta charset="utf-8" />
@@ -102,7 +102,7 @@
     <!-- Google Tag Manager (noscript) -->
     <noscript>
       <iframe
-        src="https://www.googletagmanager.com/ns.html?id=GTM-WWH7XHCN"
+        src="https://www.googletagmanager.com/ns.html?id=GTM-MGTMWN7T"
         height="0"
         width="0"
         style="display: none; visibility: hidden"

--- a/blog/2025-10-22-orejas-antenas-xoloitzcuintle-5g.html
+++ b/blog/2025-10-22-orejas-antenas-xoloitzcuintle-5g.html
@@ -13,7 +13,7 @@
         j.async = true;
         j.src = 'https://www.googletagmanager.com/gtm.js?id=' + i + dl;
         f.parentNode.insertBefore(j, f);
-      })(window, document, 'script', 'dataLayer', 'GTM-WWH7XHCN');
+      })(window, document, 'script', 'dataLayer', 'GTM-MGTMWN7T');
     </script>
     <!-- End Google Tag Manager -->
   <meta charset="utf-8" />
@@ -83,7 +83,7 @@
     <!-- Google Tag Manager (noscript) -->
     <noscript>
       <iframe
-        src="https://www.googletagmanager.com/ns.html?id=GTM-WWH7XHCN"
+        src="https://www.googletagmanager.com/ns.html?id=GTM-MGTMWN7T"
         height="0"
         width="0"
         style="display: none; visibility: hidden"

--- a/blog/2025-11-17-xolos-army-weekly-update-tliltik-ramirez-y-el-futuro-digital-del-xoloitzcuintle.html
+++ b/blog/2025-11-17-xolos-army-weekly-update-tliltik-ramirez-y-el-futuro-digital-del-xoloitzcuintle.html
@@ -15,7 +15,7 @@
         j.async = true;
         j.src = 'https://www.googletagmanager.com/gtm.js?id=' + i + dl;
         f.parentNode.insertBefore(j, f);
-      })(window, document, 'script', 'dataLayer', 'GTM-WWH7XHCN');
+      })(window, document, 'script', 'dataLayer', 'GTM-MGTMWN7T');
   </script>
   <!-- End Google Tag Manager -->
   <meta charset="utf-8"/>
@@ -35,7 +35,7 @@
  <body>
   <!-- Google Tag Manager (noscript) -->
   <noscript>
-   <iframe height="0" src="https://www.googletagmanager.com/ns.html?id=GTM-WWH7XHCN" style="display: none; visibility: hidden" width="0">
+   <iframe height="0" src="https://www.googletagmanager.com/ns.html?id=GTM-MGTMWN7T" style="display: none; visibility: hidden" width="0">
    </iframe>
   </noscript>
   <!-- End Google Tag Manager (noscript) -->

--- a/blog/2025-11-19-reportaje-informativo-desde-atenas-grecia-para-xolos-ramirez.html
+++ b/blog/2025-11-19-reportaje-informativo-desde-atenas-grecia-para-xolos-ramirez.html
@@ -15,7 +15,7 @@
         j.async = true;
         j.src = 'https://www.googletagmanager.com/gtm.js?id=' + i + dl;
         f.parentNode.insertBefore(j, f);
-      })(window, document, 'script', 'dataLayer', 'GTM-WWH7XHCN');
+      })(window, document, 'script', 'dataLayer', 'GTM-MGTMWN7T');
   </script>
   <!-- End Google Tag Manager -->
   <meta charset="utf-8"/>
@@ -35,7 +35,7 @@
  <body>
   <!-- Google Tag Manager (noscript) -->
   <noscript>
-   <iframe height="0" src="https://www.googletagmanager.com/ns.html?id=GTM-WWH7XHCN" style="display: none; visibility: hidden" width="0">
+   <iframe height="0" src="https://www.googletagmanager.com/ns.html?id=GTM-MGTMWN7T" style="display: none; visibility: hidden" width="0">
    </iframe>
   </noscript>
   <!-- End Google Tag Manager (noscript) -->

--- a/blog/2025-11-19-vanguard-plus-5-cv-l-un-paso-clave-en-la-salud-de-tzontli-y-piltzin-ramirez.html
+++ b/blog/2025-11-19-vanguard-plus-5-cv-l-un-paso-clave-en-la-salud-de-tzontli-y-piltzin-ramirez.html
@@ -15,7 +15,7 @@
         j.async = true;
         j.src = 'https://www.googletagmanager.com/gtm.js?id=' + i + dl;
         f.parentNode.insertBefore(j, f);
-      })(window, document, 'script', 'dataLayer', 'GTM-WWH7XHCN');
+      })(window, document, 'script', 'dataLayer', 'GTM-MGTMWN7T');
   </script>
   <!-- End Google Tag Manager -->
   <meta charset="utf-8"/>
@@ -35,7 +35,7 @@
  <body>
   <!-- Google Tag Manager (noscript) -->
   <noscript>
-   <iframe height="0" src="https://www.googletagmanager.com/ns.html?id=GTM-WWH7XHCN" style="display: none; visibility: hidden" width="0">
+   <iframe height="0" src="https://www.googletagmanager.com/ns.html?id=GTM-MGTMWN7T" style="display: none; visibility: hidden" width="0">
    </iframe>
   </noscript>
   <!-- End Google Tag Manager (noscript) -->

--- a/blog/2025-11-21-bienvenida-a-casa-xochimani-una-nueva-entrega-exitosa-en-monterrey.html
+++ b/blog/2025-11-21-bienvenida-a-casa-xochimani-una-nueva-entrega-exitosa-en-monterrey.html
@@ -15,7 +15,7 @@
         j.async = true;
         j.src = 'https://www.googletagmanager.com/gtm.js?id=' + i + dl;
         f.parentNode.insertBefore(j, f);
-      })(window, document, 'script', 'dataLayer', 'GTM-WWH7XHCN');
+      })(window, document, 'script', 'dataLayer', 'GTM-MGTMWN7T');
   </script>
   <!-- End Google Tag Manager -->
   <meta charset="utf-8"/>
@@ -35,7 +35,7 @@
  <body>
   <!-- Google Tag Manager (noscript) -->
   <noscript>
-   <iframe height="0" src="https://www.googletagmanager.com/ns.html?id=GTM-WWH7XHCN" style="display: none; visibility: hidden" width="0">
+   <iframe height="0" src="https://www.googletagmanager.com/ns.html?id=GTM-MGTMWN7T" style="display: none; visibility: hidden" width="0">
    </iframe>
   </noscript>
   <!-- End Google Tag Manager (noscript) -->

--- a/blog/2025-11-23-pepe-ramirez-de-cruzar-fronteras-a-conquistar-podios-en-venezuela.html
+++ b/blog/2025-11-23-pepe-ramirez-de-cruzar-fronteras-a-conquistar-podios-en-venezuela.html
@@ -15,7 +15,7 @@
         j.async = true;
         j.src = 'https://www.googletagmanager.com/gtm.js?id=' + i + dl;
         f.parentNode.insertBefore(j, f);
-      })(window, document, 'script', 'dataLayer', 'GTM-WWH7XHCN');
+      })(window, document, 'script', 'dataLayer', 'GTM-MGTMWN7T');
   </script>
   <!-- End Google Tag Manager -->
   <meta charset="utf-8"/>
@@ -35,7 +35,7 @@
  <body>
   <!-- Google Tag Manager (noscript) -->
   <noscript>
-   <iframe height="0" src="https://www.googletagmanager.com/ns.html?id=GTM-WWH7XHCN" style="display: none; visibility: hidden" width="0">
+   <iframe height="0" src="https://www.googletagmanager.com/ns.html?id=GTM-MGTMWN7T" style="display: none; visibility: hidden" width="0">
    </iframe>
   </noscript>
   <!-- End Google Tag Manager (noscript) -->

--- a/blog/2025-11-26-el-secreto-del-calor-del-xoloitzcuintle-tonalli-y-medicina-ancestral.html
+++ b/blog/2025-11-26-el-secreto-del-calor-del-xoloitzcuintle-tonalli-y-medicina-ancestral.html
@@ -15,7 +15,7 @@
         j.async = true;
         j.src = 'https://www.googletagmanager.com/gtm.js?id=' + i + dl;
         f.parentNode.insertBefore(j, f);
-      })(window, document, 'script', 'dataLayer', 'GTM-WWH7XHCN');
+      })(window, document, 'script', 'dataLayer', 'GTM-MGTMWN7T');
   </script>
   <!-- End Google Tag Manager -->
   <meta charset="utf-8"/>
@@ -35,7 +35,7 @@
  <body>
   <!-- Google Tag Manager (noscript) -->
   <noscript>
-   <iframe height="0" src="https://www.googletagmanager.com/ns.html?id=GTM-WWH7XHCN" style="display: none; visibility: hidden" width="0">
+   <iframe height="0" src="https://www.googletagmanager.com/ns.html?id=GTM-MGTMWN7T" style="display: none; visibility: hidden" width="0">
    </iframe>
   </noscript>
   <!-- End Google Tag Manager (noscript) -->

--- a/blog/2025-11-26-vacunacion-puppy-en-xolos-ramirez-un-paso-clave-en-la-salud-de-ceniza-humo-y-otun-ir-ramirez.html
+++ b/blog/2025-11-26-vacunacion-puppy-en-xolos-ramirez-un-paso-clave-en-la-salud-de-ceniza-humo-y-otun-ir-ramirez.html
@@ -15,7 +15,7 @@
         j.async = true;
         j.src = 'https://www.googletagmanager.com/gtm.js?id=' + i + dl;
         f.parentNode.insertBefore(j, f);
-      })(window, document, 'script', 'dataLayer', 'GTM-WWH7XHCN');
+      })(window, document, 'script', 'dataLayer', 'GTM-MGTMWN7T');
   </script>
   <!-- End Google Tag Manager -->
   <meta charset="utf-8"/>
@@ -35,7 +35,7 @@
  <body>
   <!-- Google Tag Manager (noscript) -->
   <noscript>
-   <iframe height="0" src="https://www.googletagmanager.com/ns.html?id=GTM-WWH7XHCN" style="display: none; visibility: hidden" width="0">
+   <iframe height="0" src="https://www.googletagmanager.com/ns.html?id=GTM-MGTMWN7T" style="display: none; visibility: hidden" width="0">
    </iframe>
   </noscript>
   <!-- End Google Tag Manager (noscript) -->

--- a/blog/2025-12-01-xolos-criptos-y-cosmovision-nuestro-ultimo-weekly-update-con-ehecatl-ramirez.html
+++ b/blog/2025-12-01-xolos-criptos-y-cosmovision-nuestro-ultimo-weekly-update-con-ehecatl-ramirez.html
@@ -15,7 +15,7 @@
         j.async = true;
         j.src = 'https://www.googletagmanager.com/gtm.js?id=' + i + dl;
         f.parentNode.insertBefore(j, f);
-      })(window, document, 'script', 'dataLayer', 'GTM-WWH7XHCN');
+      })(window, document, 'script', 'dataLayer', 'GTM-MGTMWN7T');
   </script>
   <!-- End Google Tag Manager -->
   <meta charset="utf-8"/>
@@ -35,7 +35,7 @@
  <body>
   <!-- Google Tag Manager (noscript) -->
   <noscript>
-   <iframe height="0" src="https://www.googletagmanager.com/ns.html?id=GTM-WWH7XHCN" style="display: none; visibility: hidden" width="0">
+   <iframe height="0" src="https://www.googletagmanager.com/ns.html?id=GTM-MGTMWN7T" style="display: none; visibility: hidden" width="0">
    </iframe>
   </noscript>
   <!-- End Google Tag Manager (noscript) -->

--- a/blog/2025-12-05-tacto-ancestral-el-xoloitzcuintle-el-puente-viviente-entre-el-inframundo-y-el-futuro-de-mexico.html
+++ b/blog/2025-12-05-tacto-ancestral-el-xoloitzcuintle-el-puente-viviente-entre-el-inframundo-y-el-futuro-de-mexico.html
@@ -15,7 +15,7 @@
         j.async = true;
         j.src = 'https://www.googletagmanager.com/gtm.js?id=' + i + dl;
         f.parentNode.insertBefore(j, f);
-      })(window, document, 'script', 'dataLayer', 'GTM-WWH7XHCN');
+      })(window, document, 'script', 'dataLayer', 'GTM-MGTMWN7T');
   </script>
   <!-- End Google Tag Manager -->
   <meta charset="utf-8"/>
@@ -35,7 +35,7 @@
  <body>
   <!-- Google Tag Manager (noscript) -->
   <noscript>
-   <iframe height="0" src="https://www.googletagmanager.com/ns.html?id=GTM-WWH7XHCN" style="display: none; visibility: hidden" width="0">
+   <iframe height="0" src="https://www.googletagmanager.com/ns.html?id=GTM-MGTMWN7T" style="display: none; visibility: hidden" width="0">
    </iframe>
   </noscript>
   <!-- End Google Tag Manager (noscript) -->

--- a/blog/2025-12-07-reportaje-documental-k-aay-y-michelle-la-conexion-xolo-que-trasciende-el-hogar.html
+++ b/blog/2025-12-07-reportaje-documental-k-aay-y-michelle-la-conexion-xolo-que-trasciende-el-hogar.html
@@ -15,7 +15,7 @@
         j.async = true;
         j.src = 'https://www.googletagmanager.com/gtm.js?id=' + i + dl;
         f.parentNode.insertBefore(j, f);
-      })(window, document, 'script', 'dataLayer', 'GTM-WWH7XHCN');
+      })(window, document, 'script', 'dataLayer', 'GTM-MGTMWN7T');
   </script>
   <!-- End Google Tag Manager -->
   <meta charset="utf-8"/>
@@ -35,7 +35,7 @@
  <body>
   <!-- Google Tag Manager (noscript) -->
   <noscript>
-   <iframe height="0" src="https://www.googletagmanager.com/ns.html?id=GTM-WWH7XHCN" style="display: none; visibility: hidden" width="0">
+   <iframe height="0" src="https://www.googletagmanager.com/ns.html?id=GTM-MGTMWN7T" style="display: none; visibility: hidden" width="0">
    </iframe>
   </noscript>
   <!-- End Google Tag Manager (noscript) -->

--- a/blog/2025-12-12-piltzin-ramirez-emprende-el-vuelo-a-su-nuevo-hogar-en-ee-uu.html
+++ b/blog/2025-12-12-piltzin-ramirez-emprende-el-vuelo-a-su-nuevo-hogar-en-ee-uu.html
@@ -15,7 +15,7 @@
         j.async = true;
         j.src = 'https://www.googletagmanager.com/gtm.js?id=' + i + dl;
         f.parentNode.insertBefore(j, f);
-      })(window, document, 'script', 'dataLayer', 'GTM-WWH7XHCN');
+      })(window, document, 'script', 'dataLayer', 'GTM-MGTMWN7T');
   </script>
   <!-- End Google Tag Manager -->
   <meta charset="utf-8"/>
@@ -35,7 +35,7 @@
  <body>
   <!-- Google Tag Manager (noscript) -->
   <noscript>
-   <iframe height="0" src="https://www.googletagmanager.com/ns.html?id=GTM-WWH7XHCN" style="display: none; visibility: hidden" width="0">
+   <iframe height="0" src="https://www.googletagmanager.com/ns.html?id=GTM-MGTMWN7T" style="display: none; visibility: hidden" width="0">
    </iframe>
   </noscript>
   <!-- End Google Tag Manager (noscript) -->

--- a/blog/2025-12-14-dia-de-vacunacion-en-xolos-ramirez-segunda-dosis-para-nuestros-xoloitzcuintles.html
+++ b/blog/2025-12-14-dia-de-vacunacion-en-xolos-ramirez-segunda-dosis-para-nuestros-xoloitzcuintles.html
@@ -15,7 +15,7 @@
         j.async = true;
         j.src = 'https://www.googletagmanager.com/gtm.js?id=' + i + dl;
         f.parentNode.insertBefore(j, f);
-      })(window, document, 'script', 'dataLayer', 'GTM-WWH7XHCN');
+      })(window, document, 'script', 'dataLayer', 'GTM-MGTMWN7T');
   </script>
   <!-- End Google Tag Manager -->
   <meta charset="utf-8"/>
@@ -35,7 +35,7 @@
  <body>
   <!-- Google Tag Manager (noscript) -->
   <noscript>
-   <iframe height="0" src="https://www.googletagmanager.com/ns.html?id=GTM-WWH7XHCN" style="display: none; visibility: hidden" width="0">
+   <iframe height="0" src="https://www.googletagmanager.com/ns.html?id=GTM-MGTMWN7T" style="display: none; visibility: hidden" width="0">
    </iframe>
   </noscript>
   <!-- End Google Tag Manager (noscript) -->

--- a/blog/2025-12-18-xolos-ramirez-registra-nuevos-xoloitzcuintles-ante-la-federacion-canofila-mexicana.html
+++ b/blog/2025-12-18-xolos-ramirez-registra-nuevos-xoloitzcuintles-ante-la-federacion-canofila-mexicana.html
@@ -15,7 +15,7 @@
         j.async = true;
         j.src = 'https://www.googletagmanager.com/gtm.js?id=' + i + dl;
         f.parentNode.insertBefore(j, f);
-      })(window, document, 'script', 'dataLayer', 'GTM-WWH7XHCN');
+      })(window, document, 'script', 'dataLayer', 'GTM-MGTMWN7T');
   </script>
   <!-- End Google Tag Manager -->
   <meta charset="utf-8"/>
@@ -35,7 +35,7 @@
  <body>
   <!-- Google Tag Manager (noscript) -->
   <noscript>
-   <iframe height="0" src="https://www.googletagmanager.com/ns.html?id=GTM-WWH7XHCN" style="display: none; visibility: hidden" width="0">
+   <iframe height="0" src="https://www.googletagmanager.com/ns.html?id=GTM-MGTMWN7T" style="display: none; visibility: hidden" width="0">
    </iframe>
   </noscript>
   <!-- End Google Tag Manager (noscript) -->

--- a/blog/2025-12-19-un-nuevo-guardian-en-la-ciudad-la-historia-de-tizoc-ramirez-y-su-nuevo-hogar-con-fonzi.html
+++ b/blog/2025-12-19-un-nuevo-guardian-en-la-ciudad-la-historia-de-tizoc-ramirez-y-su-nuevo-hogar-con-fonzi.html
@@ -15,7 +15,7 @@
         j.async = true;
         j.src = 'https://www.googletagmanager.com/gtm.js?id=' + i + dl;
         f.parentNode.insertBefore(j, f);
-      })(window, document, 'script', 'dataLayer', 'GTM-WWH7XHCN');
+      })(window, document, 'script', 'dataLayer', 'GTM-MGTMWN7T');
   </script>
   <!-- End Google Tag Manager -->
   <meta charset="utf-8"/>
@@ -35,7 +35,7 @@
  <body>
   <!-- Google Tag Manager (noscript) -->
   <noscript>
-   <iframe height="0" src="https://www.googletagmanager.com/ns.html?id=GTM-WWH7XHCN" style="display: none; visibility: hidden" width="0">
+   <iframe height="0" src="https://www.googletagmanager.com/ns.html?id=GTM-MGTMWN7T" style="display: none; visibility: hidden" width="0">
    </iframe>
   </noscript>
   <!-- End Google Tag Manager (noscript) -->

--- a/blog/2025-12-22-el-xoloitzcuintle-mucho-mas-que-un-perro-una-herencia-de-biotecnologia-y-espiritu.html
+++ b/blog/2025-12-22-el-xoloitzcuintle-mucho-mas-que-un-perro-una-herencia-de-biotecnologia-y-espiritu.html
@@ -15,7 +15,7 @@
         j.async = true;
         j.src = 'https://www.googletagmanager.com/gtm.js?id=' + i + dl;
         f.parentNode.insertBefore(j, f);
-      })(window, document, 'script', 'dataLayer', 'GTM-WWH7XHCN');
+      })(window, document, 'script', 'dataLayer', 'GTM-MGTMWN7T');
   </script>
   <!-- End Google Tag Manager -->
   <meta charset="utf-8"/>
@@ -35,7 +35,7 @@
  <body>
   <!-- Google Tag Manager (noscript) -->
   <noscript>
-   <iframe height="0" src="https://www.googletagmanager.com/ns.html?id=GTM-WWH7XHCN" style="display: none; visibility: hidden" width="0">
+   <iframe height="0" src="https://www.googletagmanager.com/ns.html?id=GTM-MGTMWN7T" style="display: none; visibility: hidden" width="0">
    </iframe>
   </noscript>
   <!-- End Google Tag Manager (noscript) -->

--- a/blog/2025-12-26-rmzwallet-tonalli-se-actualiza-mas-control-mas-estabilidad-y-mensajes-en-la-cadena-de-ecash.html
+++ b/blog/2025-12-26-rmzwallet-tonalli-se-actualiza-mas-control-mas-estabilidad-y-mensajes-en-la-cadena-de-ecash.html
@@ -15,7 +15,7 @@
         j.async = true;
         j.src = 'https://www.googletagmanager.com/gtm.js?id=' + i + dl;
         f.parentNode.insertBefore(j, f);
-      })(window, document, 'script', 'dataLayer', 'GTM-WWH7XHCN');
+      })(window, document, 'script', 'dataLayer', 'GTM-MGTMWN7T');
   </script>
   <!-- End Google Tag Manager -->
   <meta charset="utf-8"/>
@@ -35,7 +35,7 @@
  <body>
   <!-- Google Tag Manager (noscript) -->
   <noscript>
-   <iframe height="0" src="https://www.googletagmanager.com/ns.html?id=GTM-WWH7XHCN" style="display: none; visibility: hidden" width="0">
+   <iframe height="0" src="https://www.googletagmanager.com/ns.html?id=GTM-MGTMWN7T" style="display: none; visibility: hidden" width="0">
    </iframe>
   </noscript>
   <!-- End Google Tag Manager (noscript) -->

--- a/blog/2025-12-27-el-xoloitzcuintle-de-la-zootecnia-imperial-de-moctezuma-a-simbolo-de-identidad-nacional.html
+++ b/blog/2025-12-27-el-xoloitzcuintle-de-la-zootecnia-imperial-de-moctezuma-a-simbolo-de-identidad-nacional.html
@@ -15,7 +15,7 @@
         j.async = true;
         j.src = 'https://www.googletagmanager.com/gtm.js?id=' + i + dl;
         f.parentNode.insertBefore(j, f);
-      })(window, document, 'script', 'dataLayer', 'GTM-WWH7XHCN');
+      })(window, document, 'script', 'dataLayer', 'GTM-MGTMWN7T');
   </script>
   <!-- End Google Tag Manager -->
   <meta charset="utf-8"/>
@@ -35,7 +35,7 @@
  <body>
   <!-- Google Tag Manager (noscript) -->
   <noscript>
-   <iframe height="0" src="https://www.googletagmanager.com/ns.html?id=GTM-WWH7XHCN" style="display: none; visibility: hidden" width="0">
+   <iframe height="0" src="https://www.googletagmanager.com/ns.html?id=GTM-MGTMWN7T" style="display: none; visibility: hidden" width="0">
    </iframe>
   </noscript>
   <!-- End Google Tag Manager (noscript) -->

--- a/blog/2025-12-28-xolosarmy-weekly-update-chichiltic-ramirez-y-el-salto-tecnologico-de-la-comunidad-xolos-ramirez-con-rmzwallet-tonalli.html
+++ b/blog/2025-12-28-xolosarmy-weekly-update-chichiltic-ramirez-y-el-salto-tecnologico-de-la-comunidad-xolos-ramirez-con-rmzwallet-tonalli.html
@@ -15,7 +15,7 @@
         j.async = true;
         j.src = 'https://www.googletagmanager.com/gtm.js?id=' + i + dl;
         f.parentNode.insertBefore(j, f);
-      })(window, document, 'script', 'dataLayer', 'GTM-WWH7XHCN');
+      })(window, document, 'script', 'dataLayer', 'GTM-MGTMWN7T');
   </script>
   <!-- End Google Tag Manager -->
   <meta charset="utf-8"/>
@@ -35,7 +35,7 @@
  <body>
   <!-- Google Tag Manager (noscript) -->
   <noscript>
-   <iframe height="0" src="https://www.googletagmanager.com/ns.html?id=GTM-WWH7XHCN" style="display: none; visibility: hidden" width="0">
+   <iframe height="0" src="https://www.googletagmanager.com/ns.html?id=GTM-MGTMWN7T" style="display: none; visibility: hidden" width="0">
    </iframe>
   </noscript>
   <!-- End Google Tag Manager (noscript) -->

--- a/blog/alergias-en-el-xoloitzcuintle.html
+++ b/blog/alergias-en-el-xoloitzcuintle.html
@@ -13,7 +13,7 @@
         j.async = true;
         j.src = 'https://www.googletagmanager.com/gtm.js?id=' + i + dl;
         f.parentNode.insertBefore(j, f);
-      })(window, document, 'script', 'dataLayer', 'GTM-WWH7XHCN');
+      })(window, document, 'script', 'dataLayer', 'GTM-MGTMWN7T');
     </script>
     <!-- End Google Tag Manager -->
   <meta charset="utf-8" />
@@ -142,7 +142,7 @@
     <!-- Google Tag Manager (noscript) -->
     <noscript>
       <iframe
-        src="https://www.googletagmanager.com/ns.html?id=GTM-WWH7XHCN"
+        src="https://www.googletagmanager.com/ns.html?id=GTM-MGTMWN7T"
         height="0"
         width="0"
         style="display: none; visibility: hidden"

--- a/blog/cuidados-basicos.html
+++ b/blog/cuidados-basicos.html
@@ -13,7 +13,7 @@
         j.async = true;
         j.src = 'https://www.googletagmanager.com/gtm.js?id=' + i + dl;
         f.parentNode.insertBefore(j, f);
-      })(window, document, 'script', 'dataLayer', 'GTM-WWH7XHCN');
+      })(window, document, 'script', 'dataLayer', 'GTM-MGTMWN7T');
     </script>
     <!-- End Google Tag Manager -->
     <meta charset="UTF-8" />
@@ -64,7 +64,7 @@
     <!-- Google Tag Manager (noscript) -->
     <noscript>
       <iframe
-        src="https://www.googletagmanager.com/ns.html?id=GTM-WWH7XHCN"
+        src="https://www.googletagmanager.com/ns.html?id=GTM-MGTMWN7T"
         height="0"
         width="0"
         style="display: none; visibility: hidden"

--- a/blog/cultura-mexicana.html
+++ b/blog/cultura-mexicana.html
@@ -13,7 +13,7 @@
         j.async = true;
         j.src = 'https://www.googletagmanager.com/gtm.js?id=' + i + dl;
         f.parentNode.insertBefore(j, f);
-      })(window, document, 'script', 'dataLayer', 'GTM-WWH7XHCN');
+      })(window, document, 'script', 'dataLayer', 'GTM-MGTMWN7T');
     </script>
     <!-- End Google Tag Manager -->
     <meta charset="UTF-8" />
@@ -64,7 +64,7 @@
     <!-- Google Tag Manager (noscript) -->
     <noscript>
       <iframe
-        src="https://www.googletagmanager.com/ns.html?id=GTM-WWH7XHCN"
+        src="https://www.googletagmanager.com/ns.html?id=GTM-MGTMWN7T"
         height="0"
         width="0"
         style="display: none; visibility: hidden"

--- a/blog/entrada-1.html
+++ b/blog/entrada-1.html
@@ -13,7 +13,7 @@
         j.async = true;
         j.src = 'https://www.googletagmanager.com/gtm.js?id=' + i + dl;
         f.parentNode.insertBefore(j, f);
-      })(window, document, 'script', 'dataLayer', 'GTM-WWH7XHCN');
+      })(window, document, 'script', 'dataLayer', 'GTM-MGTMWN7T');
     </script>
     <!-- End Google Tag Manager -->
     <meta charset="UTF-8" />
@@ -64,7 +64,7 @@
     <!-- Google Tag Manager (noscript) -->
     <noscript>
       <iframe
-        src="https://www.googletagmanager.com/ns.html?id=GTM-WWH7XHCN"
+        src="https://www.googletagmanager.com/ns.html?id=GTM-MGTMWN7T"
         height="0"
         width="0"
         style="display: none; visibility: hidden"

--- a/blog/entrada-2.html
+++ b/blog/entrada-2.html
@@ -13,7 +13,7 @@
         j.async = true;
         j.src = 'https://www.googletagmanager.com/gtm.js?id=' + i + dl;
         f.parentNode.insertBefore(j, f);
-      })(window, document, 'script', 'dataLayer', 'GTM-WWH7XHCN');
+      })(window, document, 'script', 'dataLayer', 'GTM-MGTMWN7T');
     </script>
     <!-- End Google Tag Manager -->
     <meta charset="UTF-8" />
@@ -64,7 +64,7 @@
     <!-- Google Tag Manager (noscript) -->
     <noscript>
       <iframe
-        src="https://www.googletagmanager.com/ns.html?id=GTM-WWH7XHCN"
+        src="https://www.googletagmanager.com/ns.html?id=GTM-MGTMWN7T"
         height="0"
         width="0"
         style="display: none; visibility: hidden"

--- a/blog/guia-tallas-xoloitzcuintle.html
+++ b/blog/guia-tallas-xoloitzcuintle.html
@@ -1,6 +1,11 @@
 <!DOCTYPE html>
 <html lang="es">
 <head>
+    <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
+new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
+j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
+'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
+})(window,document,'script','dataLayer','GTM-MGTMWN7T');</script>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Guía de Tallas del Xoloitzcuintle</title>
@@ -75,6 +80,8 @@
     </style>
 </head>
 <body class="bg-xolo-100 text-xolo-800 font-sans selection:bg-amber-800 selection:text-white">
+    <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-MGTMWN7T"
+height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
 
     <!-- Navbar -->
     <nav class="bg-xolo-900 text-xolo-100 shadow-lg">

--- a/blog/historia-xoloitzcuintle.html
+++ b/blog/historia-xoloitzcuintle.html
@@ -13,7 +13,7 @@
         j.async = true;
         j.src = 'https://www.googletagmanager.com/gtm.js?id=' + i + dl;
         f.parentNode.insertBefore(j, f);
-      })(window, document, 'script', 'dataLayer', 'GTM-WWH7XHCN');
+      })(window, document, 'script', 'dataLayer', 'GTM-MGTMWN7T');
     </script>
     <!-- End Google Tag Manager -->
     <meta charset="UTF-8" />
@@ -64,7 +64,7 @@
     <!-- Google Tag Manager (noscript) -->
     <noscript>
       <iframe
-        src="https://www.googletagmanager.com/ns.html?id=GTM-WWH7XHCN"
+        src="https://www.googletagmanager.com/ns.html?id=GTM-MGTMWN7T"
         height="0"
         width="0"
         style="display: none; visibility: hidden"

--- a/blog/index.html
+++ b/blog/index.html
@@ -16,7 +16,7 @@
         j.async = true;
         j.src = 'https://www.googletagmanager.com/gtm.js?id=' + i + dl;
         f.parentNode.insertBefore(j, f);
-      })(window, document, 'script', 'dataLayer', 'GTM-WWH7XHCN');
+      })(window, document, 'script', 'dataLayer', 'GTM-MGTMWN7T');
   </script>
   <!-- End Google Tag Manager -->
   <meta charset="utf-8"/>
@@ -47,7 +47,7 @@
  <body>
   <!-- Google Tag Manager (noscript) -->
   <noscript>
-   <iframe height="0" src="https://www.googletagmanager.com/ns.html?id=GTM-WWH7XHCN" style="display: none; visibility: hidden" width="0">
+   <iframe height="0" src="https://www.googletagmanager.com/ns.html?id=GTM-MGTMWN7T" style="display: none; visibility: hidden" width="0">
    </iframe>
   </noscript>
   <!-- End Google Tag Manager (noscript) -->

--- a/blog/plantilla-entrada.html
+++ b/blog/plantilla-entrada.html
@@ -13,7 +13,7 @@
         j.async = true;
         j.src = 'https://www.googletagmanager.com/gtm.js?id=' + i + dl;
         f.parentNode.insertBefore(j, f);
-      })(window, document, 'script', 'dataLayer', 'GTM-WWH7XHCN');
+      })(window, document, 'script', 'dataLayer', 'GTM-MGTMWN7T');
     </script>
     <!-- End Google Tag Manager -->
     <meta charset="UTF-8" />
@@ -34,7 +34,7 @@
     <!-- Google Tag Manager (noscript) -->
     <noscript>
       <iframe
-        src="https://www.googletagmanager.com/ns.html?id=GTM-WWH7XHCN"
+        src="https://www.googletagmanager.com/ns.html?id=GTM-MGTMWN7T"
         height="0"
         width="0"
         style="display: none; visibility: hidden"

--- a/contacto.html
+++ b/contacto.html
@@ -13,7 +13,7 @@
         j.async = true;
         j.src = 'https://www.googletagmanager.com/gtm.js?id=' + i + dl;
         f.parentNode.insertBefore(j, f);
-      })(window, document, 'script', 'dataLayer', 'GTM-WWH7XHCN');
+      })(window, document, 'script', 'dataLayer', 'GTM-MGTMWN7T');
     </script>
     <!-- End Google Tag Manager -->
     <meta charset="UTF-8" />
@@ -58,7 +58,7 @@
     <!-- Google Tag Manager (noscript) -->
     <noscript>
       <iframe
-        src="https://www.googletagmanager.com/ns.html?id=GTM-WWH7XHCN"
+        src="https://www.googletagmanager.com/ns.html?id=GTM-MGTMWN7T"
         height="0"
         width="0"
         style="display: none; visibility: hidden"

--- a/en/available-xolos.html
+++ b/en/available-xolos.html
@@ -13,7 +13,7 @@
       j.async = true;
       j.src = 'https://www.googletagmanager.com/gtm.js?id=' + i + dl;
       f.parentNode.insertBefore(j, f);
-    })(window, document, 'script', 'dataLayer', 'GTM-WWH7XHCN');
+    })(window, document, 'script', 'dataLayer', 'GTM-MGTMWN7T');
   </script>
   <!-- End Google Tag Manager -->
   <meta charset="UTF-8">
@@ -26,7 +26,7 @@
   <!-- Google Tag Manager (noscript) -->
   <noscript>
     <iframe
-      src="https://www.googletagmanager.com/ns.html?id=GTM-WWH7XHCN"
+      src="https://www.googletagmanager.com/ns.html?id=GTM-MGTMWN7T"
       height="0"
       width="0"
       style="display: none; visibility: hidden"

--- a/en/blog/index.html
+++ b/en/blog/index.html
@@ -13,7 +13,7 @@
         j.async = true;
         j.src = 'https://www.googletagmanager.com/gtm.js?id=' + i + dl;
         f.parentNode.insertBefore(j, f);
-      })(window, document, 'script', 'dataLayer', 'GTM-WWH7XHCN');
+      })(window, document, 'script', 'dataLayer', 'GTM-MGTMWN7T');
     </script>
     <!-- End Google Tag Manager -->
     <meta charset="UTF-8" />
@@ -58,7 +58,7 @@
     <!-- Google Tag Manager (noscript) -->
     <noscript>
       <iframe
-        src="https://www.googletagmanager.com/ns.html?id=GTM-WWH7XHCN"
+        src="https://www.googletagmanager.com/ns.html?id=GTM-MGTMWN7T"
         height="0"
         width="0"
         style="display: none; visibility: hidden"

--- a/en/contact.html
+++ b/en/contact.html
@@ -13,7 +13,7 @@
         j.async = true;
         j.src = 'https://www.googletagmanager.com/gtm.js?id=' + i + dl;
         f.parentNode.insertBefore(j, f);
-      })(window, document, 'script', 'dataLayer', 'GTM-WWH7XHCN');
+      })(window, document, 'script', 'dataLayer', 'GTM-MGTMWN7T');
     </script>
     <!-- End Google Tag Manager -->
     <meta charset="UTF-8" />
@@ -58,7 +58,7 @@
     <!-- Google Tag Manager (noscript) -->
     <noscript>
       <iframe
-        src="https://www.googletagmanager.com/ns.html?id=GTM-WWH7XHCN"
+        src="https://www.googletagmanager.com/ns.html?id=GTM-MGTMWN7T"
         height="0"
         width="0"
         style="display: none; visibility: hidden"

--- a/en/gallery.html
+++ b/en/gallery.html
@@ -13,7 +13,7 @@
         j.async = true;
         j.src = 'https://www.googletagmanager.com/gtm.js?id=' + i + dl;
         f.parentNode.insertBefore(j, f);
-      })(window, document, 'script', 'dataLayer', 'GTM-WWH7XHCN');
+      })(window, document, 'script', 'dataLayer', 'GTM-MGTMWN7T');
     </script>
     <!-- End Google Tag Manager -->
     <meta charset="UTF-8" />
@@ -58,7 +58,7 @@
     <!-- Google Tag Manager (noscript) -->
     <noscript>
       <iframe
-        src="https://www.googletagmanager.com/ns.html?id=GTM-WWH7XHCN"
+        src="https://www.googletagmanager.com/ns.html?id=GTM-MGTMWN7T"
         height="0"
         width="0"
         style="display: none; visibility: hidden"

--- a/en/index.html
+++ b/en/index.html
@@ -13,7 +13,7 @@
         j.async = true;
         j.src = 'https://www.googletagmanager.com/gtm.js?id=' + i + dl;
         f.parentNode.insertBefore(j, f);
-      })(window, document, 'script', 'dataLayer', 'GTM-WWH7XHCN');
+      })(window, document, 'script', 'dataLayer', 'GTM-MGTMWN7T');
     </script>
     <!-- End Google Tag Manager -->
     <meta charset="UTF-8" />
@@ -58,7 +58,7 @@
     <!-- Google Tag Manager (noscript) -->
     <noscript>
       <iframe
-        src="https://www.googletagmanager.com/ns.html?id=GTM-WWH7XHCN"
+        src="https://www.googletagmanager.com/ns.html?id=GTM-MGTMWN7T"
         height="0"
         width="0"
         style="display: none; visibility: hidden"

--- a/en/testimonials.html
+++ b/en/testimonials.html
@@ -13,7 +13,7 @@
         j.async = true;
         j.src = 'https://www.googletagmanager.com/gtm.js?id=' + i + dl;
         f.parentNode.insertBefore(j, f);
-      })(window, document, 'script', 'dataLayer', 'GTM-WWH7XHCN');
+      })(window, document, 'script', 'dataLayer', 'GTM-MGTMWN7T');
     </script>
     <!-- End Google Tag Manager -->
     <meta charset="UTF-8" />
@@ -58,7 +58,7 @@
     <!-- Google Tag Manager (noscript) -->
     <noscript>
       <iframe
-        src="https://www.googletagmanager.com/ns.html?id=GTM-WWH7XHCN"
+        src="https://www.googletagmanager.com/ns.html?id=GTM-MGTMWN7T"
         height="0"
         width="0"
         style="display: none; visibility: hidden"

--- a/galeria.html
+++ b/galeria.html
@@ -13,7 +13,7 @@
         j.async = true;
         j.src = 'https://www.googletagmanager.com/gtm.js?id=' + i + dl;
         f.parentNode.insertBefore(j, f);
-      })(window, document, 'script', 'dataLayer', 'GTM-WWH7XHCN');
+      })(window, document, 'script', 'dataLayer', 'GTM-MGTMWN7T');
     </script>
     <!-- End Google Tag Manager -->
     <meta charset="UTF-8" />
@@ -58,7 +58,7 @@
     <!-- Google Tag Manager (noscript) -->
     <noscript>
       <iframe
-        src="https://www.googletagmanager.com/ns.html?id=GTM-WWH7XHCN"
+        src="https://www.googletagmanager.com/ns.html?id=GTM-MGTMWN7T"
         height="0"
         width="0"
         style="display: none; visibility: hidden"

--- a/import/jimdo-sitemap.html
+++ b/import/jimdo-sitemap.html
@@ -60,7 +60,7 @@ onloadCSS(loadCss('https://assets.jimstatic.com/web.css.d9361b6586f0098197fdc233
 new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
 j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
 'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
-})(window,document,'script','dataLayer','GTM-WWH7XHCN');
+})(window,document,'script','dataLayer','GTM-MGTMWN7T');
 //]]>
 </script>
 

--- a/index.html
+++ b/index.html
@@ -13,7 +13,7 @@
         j.async = true;
         j.src = 'https://www.googletagmanager.com/gtm.js?id=' + i + dl;
         f.parentNode.insertBefore(j, f);
-      })(window, document, 'script', 'dataLayer', 'GTM-WWH7XHCN');
+      })(window, document, 'script', 'dataLayer', 'GTM-MGTMWN7T');
     </script>
     <!-- End Google Tag Manager -->
     <meta charset="UTF-8" />
@@ -58,7 +58,7 @@
     <!-- Google Tag Manager (noscript) -->
     <noscript>
       <iframe
-        src="https://www.googletagmanager.com/ns.html?id=GTM-WWH7XHCN"
+        src="https://www.googletagmanager.com/ns.html?id=GTM-MGTMWN7T"
         height="0"
         width="0"
         style="display: none; visibility: hidden"

--- a/public/xolos-disponibles.html
+++ b/public/xolos-disponibles.html
@@ -13,7 +13,7 @@
         j.async = true;
         j.src = 'https://www.googletagmanager.com/gtm.js?id=' + i + dl;
         f.parentNode.insertBefore(j, f);
-      })(window, document, 'script', 'dataLayer', 'GTM-WWH7XHCN');
+      })(window, document, 'script', 'dataLayer', 'GTM-MGTMWN7T');
     </script>
     <!-- End Google Tag Manager -->
   <meta charset="UTF-8" />
@@ -33,7 +33,7 @@
     <!-- Google Tag Manager (noscript) -->
     <noscript>
       <iframe
-        src="https://www.googletagmanager.com/ns.html?id=GTM-WWH7XHCN"
+        src="https://www.googletagmanager.com/ns.html?id=GTM-MGTMWN7T"
         height="0"
         width="0"
         style="display: none; visibility: hidden"

--- a/testimonios.html
+++ b/testimonios.html
@@ -13,7 +13,7 @@
         j.async = true;
         j.src = 'https://www.googletagmanager.com/gtm.js?id=' + i + dl;
         f.parentNode.insertBefore(j, f);
-      })(window, document, 'script', 'dataLayer', 'GTM-WWH7XHCN');
+      })(window, document, 'script', 'dataLayer', 'GTM-MGTMWN7T');
     </script>
     <!-- End Google Tag Manager -->
     <meta charset="UTF-8" />
@@ -58,7 +58,7 @@
     <!-- Google Tag Manager (noscript) -->
     <noscript>
       <iframe
-        src="https://www.googletagmanager.com/ns.html?id=GTM-WWH7XHCN"
+        src="https://www.googletagmanager.com/ns.html?id=GTM-MGTMWN7T"
         height="0"
         width="0"
         style="display: none; visibility: hidden"

--- a/xolos-disponibles.html
+++ b/xolos-disponibles.html
@@ -13,7 +13,7 @@
         j.async = true;
         j.src = 'https://www.googletagmanager.com/gtm.js?id=' + i + dl;
         f.parentNode.insertBefore(j, f);
-      })(window, document, 'script', 'dataLayer', 'GTM-WWH7XHCN');
+      })(window, document, 'script', 'dataLayer', 'GTM-MGTMWN7T');
     </script>
     <!-- End Google Tag Manager -->
     <meta charset="UTF-8" />
@@ -63,7 +63,7 @@
     <!-- Google Tag Manager (noscript) -->
     <noscript>
       <iframe
-        src="https://www.googletagmanager.com/ns.html?id=GTM-WWH7XHCN"
+        src="https://www.googletagmanager.com/ns.html?id=GTM-MGTMWN7T"
         height="0"
         width="0"
         style="display: none; visibility: hidden"


### PR DESCRIPTION
## Summary
- update all site and blog HTML files to use the new GTM container GTM-MGTMWN7T
- ensure English and Spanish pages, including December 2025 blog posts and sitemap import, load the updated GTM script and noscript tags
- add the GTM container to the talla guide article to keep tracking consistent

## Testing
- not run (static content change)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695bbd1608088332a547f8b875050cf5)