### PR TITLE
Agregar actualización de Calixto a la entrada de CDMX

### DIFF
--- a/blog/2026-01-05-entrega-xoloitzcuintle-miniatura-cdmx.html
+++ b/blog/2026-01-05-entrega-xoloitzcuintle-miniatura-cdmx.html
@@ -97,6 +97,31 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
         <blockquote>
             "Ver la emoción en los ojos de la nueva familia es lo que da sentido a nuestra labor diaria en el criadero."
         </blockquote>
+
+        <hr style="margin: 3rem 0; border: 0; border-top: 2px dashed #8b4513; opacity: 0.3;">
+        
+        <div class="article-update" data-aos="fade-up">
+            <h2 style="color: #8b4513; font-family: 'Cinzel', serif;">Actualización: Calixto en San Luis Potosí</h2>
+            
+            <p>
+                Recibimos noticias maravillosas desde su nuevo hogar. Rosalinda nos cuenta con mucha emoción que 
+                <strong>Calixto la eligió a ella como su mamá</strong> desde el primer momento, creando un vínculo 
+                mágico e inseparable.
+            </p>
+
+            <figure style="margin: 2rem 0; text-align: center;">
+                <img src="https://i.imgur.com/BkejOEQ.jpeg" alt="Calixto Ramírez en su nuevo hogar" 
+                     style="width: 100%; max-width: 600px; border-radius: 12px; box-shadow: 0 4px 15px rgba(0,0,0,0.2);">
+                <figcaption style="margin-top: 0.8rem; font-style: italic; color: #666;">Calixto disfrutando de la calidez de su familia.</figcaption>
+            </figure>
+
+            <p>
+                Para consentirlo y cuidar su piel, Rosalinda ya lo preparó con un <strong>Paquete Bienestar Xoloitzcuintle</strong> 
+                de nuestra línea <em>xolosArmy Naturals</em>. Además, Calixto ya estrenó su ropa especial para el frío, 
+                esencial para mantenerse protegido y cómodo en el clima de <strong>San Luis Potosí</strong>. 
+                ¡Nos hace muy felices ver a nuestros ejemplares tan bien cuidados y amados!
+            </p>
+        </div>
     </div>
    </section>
   </main>


### PR DESCRIPTION
### Motivation
- Añadir una actualización en la entrada de blog para informar que Calixto fue recibido por su nueva familia en San Luis Potosí y reforzar la narrativa de cuidado de la marca.
- Incluir una imagen y estilo visual (separador y sombras) para diferenciar la actualización del contenido original.
- Resaltar el uso del `Paquete Bienestar Xoloitzcuintle` y la línea `xolosArmy Naturals` para reforzar la confianza en los productos de la marca.

### Description
- Se insertó un separador `hr` y un bloque `div.article-update` con `data-aos="fade-up"` antes del cierre de la sección `article-content` en `blog/2026-01-05-entrega-xoloitzcuintle-miniatura-cdmx.html`.
- El bloque incluye un `h2` con estilo tipográfico, párrafos en español, y un `figure` con imagen remota (`https://i.imgur.com/BkejOEQ.jpeg`) y `figcaption` para la foto de Calixto.
- Se añadieron estilos inline para bordes redondeados y sombra en la imagen, además de color terracota coherente con la marca.
- No se realizaron cambios en la lógica del sitio, solo contenido HTML estático dentro del archivo indicado.

### Testing
- Se levantó un servidor local con `python -m http.server` y se cargó la página para ver la inserción (verificación automática de renderizado).
- Se ejecutó una captura de pantalla automatizada con Playwright que produjo `artifacts/calixto-update.png` y completó con éxito.
- No se ejecutaron pruebas unitarias ya que es un cambio de contenido estático.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695e58b8c01c83329fb9a65f9291d2a7)