### PR TITLE
Fix mobile layout regressions and mobile nav behavior

### DIFF
--- a/FIXES_NOTES.md
+++ b/FIXES_NOTES.md
@@ -1,0 +1,25 @@
+# Mobile layout/UI fixes
+
+## What was broken
+- Mobile hero sections were causing horizontal overflow and a shifted layout due to full-bleed `100vw` sizing combined with translated layouts.
+- Mobile navigation had conflicting legacy styles and did not consistently open/close or prevent background scrolling.
+- The testimonials page lost its intended styling because the expected `#testimonios` wrapper was missing.
+- Some card media classes were misspelled, preventing media styling from applying.
+- Video hero backgrounds could introduce instability on mobile without a safe fallback.
+
+## What changed
+- Added mobile-specific overrides to keep hero/CTA sections within the viewport and hide background video iframes on small screens.
+- Hardened the hamburger menu behavior (ARIA state, body scroll lock, outside/Escape close) and neutralized legacy mobile `nav ul` rules.
+- Restored the testimonials wrapper and grid structure so existing `#testimonios` styles apply again.
+- Corrected `card_media` to `card__media` in card markup.
+- Added consistent language switches to Spanish pages to match the English navigation.
+
+## How to test quickly (mobile)
+1. Open DevTools and emulate a mobile viewport (e.g., 360×800).
+2. Verify there is no horizontal scroll and the hero is centered.
+3. Tap the hamburger menu: the panel should slide in, links are tappable, and the page behind should not scroll.
+4. Confirm testimonials display as styled cards inside the restored wrapper.
+5. Run Lighthouse (mobile) and confirm CLS and layout stability remain healthy.
+
+## Legacy nav CSS removed/neutralized
+- Conflicting legacy `nav ul { transform: scale(0) }` mobile rules were overridden to ensure the `.nav-menu` system remains the single source of truth.

--- a/contacto.html
+++ b/contacto.html
@@ -110,6 +110,9 @@ a{color:var(--accent);text-decoration:none;}
             <li><a href="contacto.html">Contacto</a></li>
           </ul>
         </nav>
+        <div class="lang-switch">
+          <a href="en/contact.html" lang="en" aria-label="View site in English">EN</a>
+        </div>
       </div>
     </header>
 

--- a/css/styles.css
+++ b/css/styles.css
@@ -13,6 +13,7 @@ body{ font-family:'Poppins', system-ui, -apple-system, Segoe UI, Roboto, sans-se
 html{ box-sizing:border-box; font-size:16px; }
 *,*::before,*::after{ box-sizing:inherit; }
 html,body{ margin:0; padding:0; background:var(--bg); color:var(--text); }
+body.nav-open{ overflow:hidden; }
 img, picture, video, canvas{ max-width:100%; height:auto; display:block; }
 a{ color:var(--accent); text-decoration:none; }
 a:hover{ text-decoration:underline; }
@@ -243,6 +244,8 @@ a:hover {
     background: rgba(20, 20, 20, 0.95);
     backdrop-filter: blur(1rem);
     z-index: 1000;
+    max-width: 100%;
+    overflow-y: auto;
     transform: translateX(100%);
     transition: transform 350ms ease-out;
   }
@@ -994,6 +997,26 @@ h1,h2,h3,.site-header .brand span{font-family:'Cinzel',serif;text-transform:uppe
 
 @media (max-width: 768px){
   html, body{ overflow-x:hidden; width:100%; }
+}
+
+@media (max-width: 768px){
+  .hero,
+  #cta{
+    margin-inline: 0;
+    width: 100%;
+    max-width: 100%;
+  }
+
+  .hero__media iframe{
+    display: none;
+  }
+
+  .nav-menu ul{
+    transform: none;
+    position: static;
+    background: transparent;
+    box-shadow: none;
+  }
 }
 
 /* Corrección de visibilidad del texto en el formulario de contacto */

--- a/en/index.html
+++ b/en/index.html
@@ -246,7 +246,7 @@ a{color:var(--accent);text-decoration:none;}
       </section>
 
       <article class="card blog-card" data-aos="zoom-in" data-aos-delay="250">
-  <picture class="card_media">
+  <picture class="card__media">
     <img src="img/blog/AlergiasXolo.png" width="600" height="400" loading="lazy" decoding="async" alt="Xoloitzcuintle con piel sensible recibiendo cuidado">
   </picture>
   <h2>Allergies in the Xoloitzcuintle: common causes and how to prevent them</h2>

--- a/galeria.html
+++ b/galeria.html
@@ -110,6 +110,9 @@ a{color:var(--accent);text-decoration:none;}
             <li><a href="contacto.html">Contacto</a></li>
           </ul>
         </nav>
+        <div class="lang-switch">
+          <a href="en/gallery.html" lang="en" aria-label="View site in English">EN</a>
+        </div>
       </div>
     </header>
 

--- a/index.html
+++ b/index.html
@@ -246,7 +246,7 @@ Selección de Ejemplares de Calidad: Seleccionamos cuidadosamente a los perros q
       </section>
 
       <article class="card blog-card" data-aos="zoom-in" data-aos-delay="250">
-  <picture class="card_media">
+  <picture class="card__media">
     <img src="img/blog/AlergiasXolo.png" width="600" height="400" loading="lazy" decoding="async" alt="Xoloitzcuintle con piel sensible recibiendo cuidado">
   </picture>
   <h2>Alergias en el Xoloitzcuintle: causas comunes y cómo prevenirlas</h2>

--- a/js/main.js
+++ b/js/main.js
@@ -2,23 +2,41 @@ const navMenu = document.getElementById('menu');
 const navToggle = document.querySelector('.hamburger');
 
 if (navToggle && navMenu) {
+  const openMenu = () => {
+    navMenu.setAttribute('data-visible', 'true');
+    navToggle.setAttribute('aria-expanded', 'true');
+    document.body.classList.add('nav-open');
+  };
+
+  const closeMenu = () => {
+    navMenu.setAttribute('data-visible', 'false');
+    navToggle.setAttribute('aria-expanded', 'false');
+    document.body.classList.remove('nav-open');
+  };
+
   navToggle.addEventListener('click', () => {
     const visibility = navMenu.getAttribute('data-visible');
-
-    if (visibility === 'false') {
-      navMenu.setAttribute('data-visible', 'true');
-      navToggle.setAttribute('aria-expanded', 'true');
-    } else {
-      navMenu.setAttribute('data-visible', 'false');
-      navToggle.setAttribute('aria-expanded', 'false');
+    if (visibility === 'true') {
+      closeMenu();
+      return;
     }
+    openMenu();
   });
 
   navMenu.querySelectorAll('a').forEach((link) => {
-    link.addEventListener('click', () => {
-      navMenu.setAttribute('data-visible', 'false');
-      navToggle.setAttribute('aria-expanded', 'false');
-    });
+    link.addEventListener('click', closeMenu);
+  });
+
+  document.addEventListener('click', (event) => {
+    if (navMenu.getAttribute('data-visible') !== 'true') return;
+    if (navMenu.contains(event.target) || navToggle.contains(event.target)) return;
+    closeMenu();
+  });
+
+  document.addEventListener('keydown', (event) => {
+    if (event.key !== 'Escape') return;
+    if (navMenu.getAttribute('data-visible') !== 'true') return;
+    closeMenu();
   });
 }
 

--- a/testimonios.html
+++ b/testimonios.html
@@ -109,6 +109,9 @@ a{color:var(--accent);text-decoration:none;}
             <li><a href="contacto.html">Contacto</a></li>
           </ul>
         </nav>
+        <div class="lang-switch">
+          <a href="en/testimonials.html" lang="en" aria-label="View site in English">EN</a>
+        </div>
       </div>
     </header>
 
@@ -135,43 +138,45 @@ a{color:var(--accent);text-decoration:none;}
         </div>
       </section>
 
-      <section class="grid" data-aos="fade-up" data-aos-duration="1000">
-        <article class="card" data-aos="zoom-in" data-aos-delay="100">
-          <blockquote style="font-family: var(--font-secondary); padding: 1.5rem;">
-            <p>"Se llama K'aay. Significa amor en maya."</p>
-            <p>"Es una perrita muy muy muy inteligente. Ella es una Xolo muy inteligente, muy obediente, muy entendida, muy lista, súper súper adaptable."</p>
-            <p>"Lo aprende todo en tres días"</p>
-            <p>"A K'aay le encanta este su su masajito en las noches con su cremita."</p>
-            <cite style="display: block; margin-top: 1rem; font-weight: bold;">— Michelle sobre la xoloitzcuintle Menta "K'aay" Ramirez</cite>
-          </blockquote>
-        </article>
+      <section id="testimonios" data-aos="fade-up" data-aos-duration="1000">
+        <div class="grid">
+          <article class="card" data-aos="zoom-in" data-aos-delay="100">
+            <blockquote style="font-family: var(--font-secondary); padding: 1.5rem;">
+              <p>"Se llama K'aay. Significa amor en maya."</p>
+              <p>"Es una perrita muy muy muy inteligente. Ella es una Xolo muy inteligente, muy obediente, muy entendida, muy lista, súper súper adaptable."</p>
+              <p>"Lo aprende todo en tres días"</p>
+              <p>"A K'aay le encanta este su su masajito en las noches con su cremita."</p>
+              <cite style="display: block; margin-top: 1rem; font-weight: bold;">— Michelle sobre la xoloitzcuintle Menta "K'aay" Ramirez</cite>
+            </blockquote>
+          </article>
 
-        <article class="card" data-aos="zoom-in" data-aos-delay="200">
-          <blockquote style="font-family: var(--font-secondary); padding: 1.5rem;">
-            <p>"Pepe es el único xoloitzcuintle que nosotros sabemos que está aquí en Venezuela"</p>
-            <p>"Pepe es una, una sensación, es una celebrity"</p>
-            <p>"Todo el mundo está enamorado de Pepe"</p>
-            <cite style="display: block; margin-top: 1rem; font-weight: bold;">— Dayanne sobre el xoloitzcuintle Pepe Ramirez</cite>
-          </blockquote>
-        </article>
+          <article class="card" data-aos="zoom-in" data-aos-delay="200">
+            <blockquote style="font-family: var(--font-secondary); padding: 1.5rem;">
+              <p>"Pepe es el único xoloitzcuintle que nosotros sabemos que está aquí en Venezuela"</p>
+              <p>"Pepe es una, una sensación, es una celebrity"</p>
+              <p>"Todo el mundo está enamorado de Pepe"</p>
+              <cite style="display: block; margin-top: 1rem; font-weight: bold;">— Dayanne sobre el xoloitzcuintle Pepe Ramirez</cite>
+            </blockquote>
+          </article>
 
-        <article class="card" data-aos="zoom-in" data-aos-delay="300">
-          <blockquote style="font-family: var(--font-secondary); padding: 1.5rem;">
-            <p>"Tecuani llama mucho la atención porque es el primer xoloitzcuintle oficial que llega a Grecia"</p>
-            <p>"Tecuani tiene una manera de expresarse totalmente diferente"</p>
-            <p>"Tecuani me ha recordado mis raíces mexicanas y me ha traído de vuelta a México, fortaleciendo mi orgullo de ser de dos países importantes para la civilización humana"</p>
-            <cite style="display: block; margin-top: 1rem; font-weight: bold;">— Danay sobre el xoloitzcuintle Tecuani Ramirez</cite>
-          </blockquote>
-        </article>
+          <article class="card" data-aos="zoom-in" data-aos-delay="300">
+            <blockquote style="font-family: var(--font-secondary); padding: 1.5rem;">
+              <p>"Tecuani llama mucho la atención porque es el primer xoloitzcuintle oficial que llega a Grecia"</p>
+              <p>"Tecuani tiene una manera de expresarse totalmente diferente"</p>
+              <p>"Tecuani me ha recordado mis raíces mexicanas y me ha traído de vuelta a México, fortaleciendo mi orgullo de ser de dos países importantes para la civilización humana"</p>
+              <cite style="display: block; margin-top: 1rem; font-weight: bold;">— Danay sobre el xoloitzcuintle Tecuani Ramirez</cite>
+            </blockquote>
+          </article>
 
-        <article class="card" data-aos="zoom-in" data-aos-delay="400">
-          <blockquote style="font-family: var(--font-secondary); padding: 1.5rem;">
-            <p>"Me encanta abrazarlo, me da besitos."</p>
-            <p>"Es muy observador, se adapta muy fácil a cualquier ambiente, le encanta viajar."</p>
-            <p>"Es como mi hijo, lo amo muchísimo."</p>
-            <cite style="display: block; margin-top: 1rem; font-weight: bold;">— Eliana sobre el xoloitzcuintle Mezcal Ramirez</cite>
-          </blockquote>
-        </article>
+          <article class="card" data-aos="zoom-in" data-aos-delay="400">
+            <blockquote style="font-family: var(--font-secondary); padding: 1.5rem;">
+              <p>"Me encanta abrazarlo, me da besitos."</p>
+              <p>"Es muy observador, se adapta muy fácil a cualquier ambiente, le encanta viajar."</p>
+              <p>"Es como mi hijo, lo amo muchísimo."</p>
+              <cite style="display: block; margin-top: 1rem; font-weight: bold;">— Eliana sobre el xoloitzcuintle Mezcal Ramirez</cite>
+            </blockquote>
+          </article>
+        </div>
       </section>
 
       <section id="historias-reales" data-aos="fade-up" data-aos-duration="1000">

--- a/xolos-disponibles.html
+++ b/xolos-disponibles.html
@@ -115,6 +115,9 @@ a{color:var(--accent);text-decoration:none;}
             <li><a href="contacto.html">Contacto</a></li>
           </ul>
         </nav>
+        <div class="lang-switch">
+          <a href="en/available-xolos.html" lang="en" aria-label="View site in English">EN</a>
+        </div>
       </div>
     </header>
 


### PR DESCRIPTION
### Motivation
- Repair a critical mobile layout regression where the homepage/hero shifted right and produced horizontal overflow on small viewports.  
- Restore mobile navigation functionality that was broken by conflicting legacy and newer CSS patterns.  
- Re-apply intended testimonial card styling and correct class/name typos so cards render consistently across languages.  
- Ensure hero video/iframe backgrounds do not cause overflow or layout shift on mobile while preserving desktop behavior and AOS animations.

### Description
- Consolidated the nav system and hardened the toggle: `js/main.js` now toggles `data-visible`, sets `aria-expanded`, adds/removes `body.nav-open` to lock scroll, closes on outside click and `Escape`, and closes when links are tapped.  
- Neutralized legacy mobile nav rules and constrained the mobile panel in `css/styles.css` with `max-width:100%`, `overflow-y:auto`, and removed `nav ul` transform hiding so the `.nav-menu` is the single source of truth; also added `body.nav-open{ overflow:hidden }`.  
- Fixed hero overflow by removing dangerous full-bleed behaviors on mobile: added mobile CSS overrides to set `margin-inline:0`, `width:100%`, `max-width:100%`, and hide background iframes on small screens (iframe hidden via `.hero__media iframe { display: none; }`).  
- Restored testimonial wrapper and grid in `testimonios.html`, corrected `card_media` → `card__media` in `index.html` and `en/index.html`, and added consistent language switch links to the Spanish pages; added `FIXES_NOTES.md` documenting what was changed and how to test.

### Testing
- Launched a local static server with `python -m http.server 8000` and captured a mobile-emulated screenshot using Playwright (360×800); the script completed and produced `artifacts/mobile-hero.png`.  
- Verified the hamburger opens/closes, `body.nav-open` is applied/removed, and tapping links closes the menu in manual checks on the served site (mobile emulation).  
- Committed the changes (`git commit`) successfully; no automated CI was run beyond the local Playwright screenshot.  
- `FIXES_NOTES.md` includes quick mobile testing steps (DevTools + Lighthouse) for repeatable verification.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696112c978c883329f18dd6b1bbde8af)