### PR TITLE
Restore featured blog image display and newsletter CTA on homepage

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -387,6 +387,25 @@ section h2 {
   box-shadow: 0 15px 35px rgba(0, 0, 0, 0.35);
 }
 
+.blog-card--featured .card__media {
+  aspect-ratio: 16 / 9;
+  overflow: hidden;
+  border-radius: 0.65rem;
+  background: rgba(0, 0, 0, 0.35);
+}
+
+.blog-card--featured .card__media img {
+  width: 100%;
+  height: 100%;
+  object-fit: contain;
+  object-position: center;
+  background: rgba(0, 0, 0, 0.35);
+}
+
+.newsletter-callout {
+  display: block;
+}
+
 blockquote {
   margin: 0;
   padding-left: 1.25rem;

--- a/index.html
+++ b/index.html
@@ -226,7 +226,7 @@ Selección de Ejemplares de Calidad: Seleccionamos cuidadosamente a los perros q
             Organizamos recorridos culturales, charlas con especialistas y
             encuentros familiares donde los xolos son protagonistas.
           </p>
-          <p class="callout">
+          <p class="callout newsletter-callout">
             <a href="mailto:contacto@xolosarmy.xyz?subject=Suscripción al Boletín&body=Hola, me gustaría suscribirme a su lista de correos electrónicos para recibir noticias sobre los xolos." 
                style="color: var(--accent-color); text-underline-offset: 4px;">
                Suscríbete al boletín por email
@@ -245,8 +245,8 @@ Selección de Ejemplares de Calidad: Seleccionamos cuidadosamente a los perros q
         </article>
       </section>
 
-      <article class="card blog-card" data-aos="zoom-in" data-aos-delay="250">
-  <picture class="card__media">
+      <article class="card blog-card blog-card--featured" data-aos="zoom-in" data-aos-delay="250">
+  <picture class="card__media card__media--contain">
     <img src="img/blog/AlergiasXolo.png" width="600" height="400" loading="lazy" decoding="async" alt="Xoloitzcuintle con piel sensible recibiendo cuidado">
   </picture>
   <h2>Alergias en el Xoloitzcuintle: causas comunes y cómo prevenirlas</h2>


### PR DESCRIPTION
### Motivation
- Restore the previous, better-looking homepage UI so the featured blog image is shown in full and the Spanish newsletter CTA is visible.
- Fix an unintended image crop caused by `object-fit: cover` and a fixed media height for the featured card.
- Reintroduce the missing `Suscríbete al boletín…` message without changing copy, layout, colors, or images.
- Make a small, targeted change that preserves desktop and mobile aesthetics and avoids redesign.

### Description
- Add a featured modifier to the blog article by setting `class="card blog-card blog-card--featured"` and add `card__media--contain` to the media element in `index.html`.
- Add CSS rules in `css/styles.css` for `.blog-card--featured .card__media` to use `aspect-ratio: 16 / 9`, stable overflow handling, and for `.blog-card--featured .card__media img` to use `object-fit: contain` with centered letterboxing to show the full image.
- Restore the newsletter block visibility by adding `class="callout newsletter-callout"` to the existing paragraph and enabling it with `.newsletter-callout { display: block; }` in `css/styles.css` so the original Spanish CTA appears unchanged.
- Modified files: `index.html`, `css/styles.css`.

### Testing
- Launched a local HTTP server and ran a Playwright script to load `http://127.0.0.1:8000/index.html` and capture a screenshot, which completed successfully.
- The automated visual check (screenshot) confirms the featured blog image is rendered with `object-fit: contain` and the newsletter CTA text is visible.
- No unit tests exist for these UI changes in the repository, and no automated test failures were produced during the verification run.
- Changes were committed to the working branch after verification.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696117e1d1288332bedd8a4454266102)