### PR TITLE
Remove "Leer historia completa" buttons from testimonios.html

### DIFF
--- a/testimonios.html
+++ b/testimonios.html
@@ -176,7 +176,6 @@ a{color:var(--accent);text-decoration:none;}
                 <p>"I got to say the not having hair is so nice for cleanup around the house."</p>
               </blockquote>
               <cite>— Jordan and Jake about Xoloitzcuintli Tzinzi Ramirez.</cite>
-              <a href="blog/tzinzi-ramirez.html" class="btn btn--sm" style="display: block; margin-top: 1rem;">Leer historia completa</a>
             </div>
           </article>
 
@@ -191,7 +190,6 @@ a{color:var(--accent);text-decoration:none;}
                 <p>"Ohtli is a mamas boy, he loves her"</p>
               </blockquote>
               <cite>— Alan about Xoloitzcuintli Ohtli Ramirez</cite>
-              <a href="blog/ohtli-ramirez.html" class="btn btn--sm" style="display: block; margin-top: 1rem;">Leer historia completa</a>
             </div>
           </article>
 
@@ -204,7 +202,6 @@ a{color:var(--accent);text-decoration:none;}
                 <p>"He's very intuitive. I feel like he knows a lot of things."</p>
               </blockquote>
               <cite>— JJ about xoloitzcuintli Django Ramirez</cite>
-              <a href="blog/django-ramirez.html" class="btn btn--sm" style="display: block; margin-top: 1rem;">Leer historia completa</a>
             </div>
           </article>
 
@@ -217,7 +214,6 @@ a{color:var(--accent);text-decoration:none;}
                 <p>"Chichen is a very homely dog. He is very attached to the family."</p>
               </blockquote>
               <cite>— Archibald about xoloitzcuintli Chichen Ramirez</cite>
-              <a href="blog/chichen-ramirez.html" class="btn btn--sm" style="display: block; margin-top: 1rem;">Leer historia completa</a>
             </div>
           </article>
 
@@ -230,7 +226,6 @@ a{color:var(--accent);text-decoration:none;}
                 <p>"They are good with the kids. They are good with other dogs."</p>
               </blockquote>
               <cite>— Yelena about xoloitzcuintlis Cosmo and Bonita Ramirez</cite>
-              <a href="blog/cosmo-bonita-ramirez.html" class="btn btn--sm" style="display: block; margin-top: 1rem;">Leer historia completa</a>
             </div>
           </article>
 
@@ -243,7 +238,6 @@ a{color:var(--accent);text-decoration:none;}
                 <p>"He felt at home right away and gives a lot of love"</p>
               </blockquote>
               <cite>— Juan about xoloitzcuintli Huitzi Ramirez</cite>
-              <a href="blog/huitzi-ramirez.html" class="btn btn--sm" style="display: block; margin-top: 1rem;">Leer historia completa</a>
             </div>
           </article>
 
@@ -256,7 +250,6 @@ a{color:var(--accent);text-decoration:none;}
                 <p>"Everyone was just so impressed with her. They had never seen a Xolo do agility before."</p>
               </blockquote>
               <cite>— Shelby about xoloitzcuintli Itza Ramirez</cite>
-              <a href="blog/itza-ramirez.html" class="btn btn--sm" style="display: block; margin-top: 1rem;">Leer historia completa</a>
             </div>
           </article>
 
@@ -272,7 +265,6 @@ a{color:var(--accent);text-decoration:none;}
                 <p>"A K'aay le encanta este su su masajito en las noches con su cremita."</p>
               </blockquote>
               <cite>— Michelle sobre la xoloitzcuintle Menta "K'aay" Ramirez</cite>
-              <a href="blog/menta-kaay-ramirez.html" class="btn btn--sm" style="display: block; margin-top: 1rem;">Leer historia completa</a>
             </div>
           </article>
 
@@ -287,7 +279,6 @@ a{color:var(--accent);text-decoration:none;}
                 <p>"Todo el mundo está enamorado de Pepe"</p>
               </blockquote>
               <cite>— Dayanne sobre el xoloitzcuintle Pepe Ramirez</cite>
-              <a href="blog/pepe-ramirez.html" class="btn btn--sm" style="display: block; margin-top: 1rem;">Leer historia completa</a>
             </div>
           </article>
 
@@ -302,7 +293,6 @@ a{color:var(--accent);text-decoration:none;}
                 <p>"Tecuani me ha recordado mis raíces mexicanas y me ha traído de vuelta a México, fortaleciendo mi orgullo de ser de dos países importantes para la civilización humana"</p>
               </blockquote>
               <cite>— Danay sobre el xoloitzcuintle Tecuani Ramirez</cite>
-              <a href="blog/tecuani-ramirez.html" class="btn btn--sm" style="display: block; margin-top: 1rem;">Leer historia completa</a>
             </div>
           </article>
 
@@ -317,7 +307,6 @@ a{color:var(--accent);text-decoration:none;}
                 <p>"Es como mi hijo, lo amo muchísimo."</p>
               </blockquote>
               <cite>— Eliana sobre el xoloitzcuintle Mezcal Ramirez</cite>
-              <a href="blog/mezcal-ramirez.html" class="btn btn--sm" style="display: block; margin-top: 1rem;">Leer historia completa</a>
             </div>
           </article>
 
@@ -331,7 +320,6 @@ a{color:var(--accent);text-decoration:none;}
                 <p>"Edzna es muy atlética y le encanta correr"</p>
               </blockquote>
               <cite>— Miguel sobre la xoloitzcuintle Edzna Ramirez</cite>
-              <a href="blog/edzna-ramirez.html" class="btn btn--sm" style="display: block; margin-top: 1rem;">Leer historia completa</a>
             </div>
           </article>
 
@@ -346,7 +334,6 @@ a{color:var(--accent);text-decoration:none;}
                 <p>"Shiny es una perrita muy buena, muy inteligente"</p>
               </blockquote>
               <cite>— Yeiron sobre la xoloitzcuintle Shiny Ramirez</cite>
-              <a href="blog/shiny-ramirez.html" class="btn btn--sm" style="display: block; margin-top: 1rem;">Leer historia completa</a>
             </div>
           </article>
 
@@ -360,7 +347,6 @@ a{color:var(--accent);text-decoration:none;}
                 <p>"Es una preciosura tener... Es que es una experiencia."</p>
               </blockquote>
               <cite>— Edgar sobre el xoloitzcuintle Maiz Ramirez</cite>
-              <a href="blog/maiz-ramirez.html" class="btn btn--sm" style="display: block; margin-top: 1rem;">Leer historia completa</a>
             </div>
           </article>
 
@@ -374,7 +360,6 @@ a{color:var(--accent);text-decoration:none;}
                 <p>"Pinole es educado y sabe convivir con otros perros"</p>
               </blockquote>
               <cite>— Edgar sobre el xoloitzcuintle Pinole Ramirez</cite>
-              <a href="blog/pinole-ramirez.html" class="btn btn--sm" style="display: block; margin-top: 1rem;">Leer historia completa</a>
             </div>
           </article>
 
@@ -389,7 +374,6 @@ a{color:var(--accent);text-decoration:none;}
                 <p>"Ameyalli es muy sociable y cómoda con el contacto físico y los abrazos"</p>
               </blockquote>
               <cite>— Carmen sobre las xoloitzcuintles Sesasi y Ameyalli Ramirez</cite>
-              <a href="blog/sesasi-ameyalli-ramirez.html" class="btn btn--sm" style="display: block; margin-top: 1rem;">Leer historia completa</a>
             </div>
           </article>
 
@@ -403,7 +387,6 @@ a{color:var(--accent);text-decoration:none;}
                 <p>"Chamoy es mi bebito"</p>
               </blockquote>
               <cite>— Emmanuel sobre el xoloitzcuintle Chamoy Ramirez</cite>
-              <a href="blog/chamoy-ramirez.html" class="btn btn--sm" style="display: block; margin-top: 1rem;">Leer historia completa</a>
             </div>
           </article>
 
@@ -417,7 +400,6 @@ a{color:var(--accent);text-decoration:none;}
                 <p>"Los Xolos no requieren cuidados especiales"</p>
               </blockquote>
               <cite>— Loida sobre la xoloitzcuintle Xaly Ramirez</cite>
-              <a href="blog/xaly-ramirez.html" class="btn btn--sm" style="display: block; margin-top: 1rem;">Leer historia completa</a>
             </div>
           </article>
 
@@ -432,7 +414,6 @@ a{color:var(--accent);text-decoration:none;}
                 <p>"Sesasi es el mejor regalo que he recibido"</p>
               </blockquote>
               <cite>— Lupita sobre la xoloitzcuintle Sesasi Ramirez</cite>
-              <a href="blog/sesasi-lupita-ramirez.html" class="btn btn--sm" style="display: block; margin-top: 1rem;">Leer historia completa</a>
             </div>
           </article>
 
@@ -447,7 +428,6 @@ a{color:var(--accent);text-decoration:none;}
                 <p>"Khaali me reconforta cuando llego cansado del trabajo"</p>
               </blockquote>
               <cite>— Marcos sobre la xoloitzcuintle Khaali Ramirez</cite>
-              <a href="blog/khaali-ramirez.html" class="btn btn--sm" style="display: block; margin-top: 1rem;">Leer historia completa</a>
             </div>
           </article>
 
@@ -460,7 +440,6 @@ a{color:var(--accent);text-decoration:none;}
                 <p>"Itzae es mi mejor amigo"</p>
               </blockquote>
               <cite>— Jack sobre el xoloitzcuintle Itzae Ramirez</cite>
-              <a href="blog/itzae-ramirez.html" class="btn btn--sm" style="display: block; margin-top: 1rem;">Leer historia completa</a>
             </div>
           </article>
 
@@ -474,7 +453,6 @@ a{color:var(--accent);text-decoration:none;}
                 <p>"Mezcal sabe cuando es la hora de su siesta"</p>
               </blockquote>
               <cite>— Dayanara sobre el xoloitzcuintle Mezcal Ramirez</cite>
-              <a href="blog/mezcal-dayanara-ramirez.html" class="btn btn--sm" style="display: block; margin-top: 1rem;">Leer historia completa</a>
             </div>
           </article>
 
@@ -492,7 +470,6 @@ a{color:var(--accent);text-decoration:none;}
                 <p>"¡Añade aquí la frase o testimonio que desees destacar de este video!"</p>
               </blockquote>
               <cite>— Xolos Ramírez Comunidad</cite>
-              <a href="blog/nueva-historia.html" class="btn btn--sm" style="display: block; margin-top: 1rem;">Leer historia completa</a>
             </div>
           </article>
 


### PR DESCRIPTION
### Motivation
- Simplify the testimonial cards by removing redundant "Leer historia completa" links from the page.
- Keep the visual focus on the embedded videos and short quotes without extra CTAs.
- Apply a static content cleanup to `testimonios.html` to reflect updated UI requirements.

### Description
- Deleted all anchor elements containing the text "Leer historia completa" from `testimonios.html` (23 deletions across testimonial cards). 
- Preserved the existing card markup, video iframes, quotes, and layout so visual structure remains unchanged.
- No CSS or JS changes were required; only the read-more anchors were removed.

### Testing
- Located occurrences with `rg -n "Leer historia completa" testimonios.html` to ensure all targets were removed and the search returned no remaining matches.
- Started a local server with `python -m http.server 8000` and ran a Playwright script to load `http://127.0.0.1:8000/testimonios.html` and capture `artifacts/testimonios-no-buttons.png`, which completed successfully as a visual smoke test.
- Confirmed the file change was staged and committed, and the repository state shows the updated `testimonios.html` with the deletions.
- No unit tests were required for this static content change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696132be16dc83329680872cd69e5b8f)