### PR TITLE
Improve mobile image responsiveness

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -953,6 +953,50 @@ h1,h2,h3,.site-header .brand span{font-family:'Cinzel',serif;text-transform:uppe
   html, body{ overflow-x:hidden; width:100%; }
 }
 
+@media (max-width: 768px) {
+  .hero,
+  #cta,
+  .hero.hero-disponibles,
+  .parallax {
+    width: 100vw;
+    max-width: 100%;
+  }
+
+  .hero__media,
+  .card__media,
+  .gallery-grid,
+  picture,
+  figure {
+    width: 100%;
+    max-width: 100%;
+    margin: 0;
+  }
+
+  .hero__media img,
+  .card__media img,
+  .gallery-grid img,
+  .article img,
+  picture img,
+  figure img {
+    width: 100%;
+    height: auto;
+    object-fit: cover;
+  }
+
+  .blog-card .card__media img {
+    height: auto;
+  }
+
+  .brand img {
+    width: clamp(32px, 10vw, 44px);
+    height: clamp(32px, 10vw, 44px);
+  }
+
+  .gallery-grid {
+    grid-template-columns: 1fr;
+  }
+}
+
 /* Corrección de visibilidad del texto en el formulario de contacto */
 form input,
 form select,


### PR DESCRIPTION
### Motivation
- Hacer que las imágenes de hero, banners y contenido sean totalmente responsivas en dispositivos móviles sin cambiar estilos de escritorio.
- Evitar anchos fijos en píxeles y asegurar que las imágenes mantengan proporción con `max-width: 100%` y `height: auto` en móvil.
- Aplicar `object-fit: cover` y ajustes de contenedores para fondos/medios grandes en la capa móvil dentro de un `@media (max-width: 768px)`.
- Ajustar el tamaño del logo y la cuadrícula de galería para evitar desbordes y mejorar la presentación en pantallas pequeñas.

### Description
- Añadido un bloque `@media (max-width: 768px)` en `css/styles.css` que aplica cambios móviles específicos sin tocar estilos de escritorio.
- Forzado `width: 100vw` / `max-width: 100%` para secciones de fondo como `.hero`, `#cta`, `.hero.hero-disponibles` y `.parallax` para evitar desbordes en móvil.
- Normalizados los wrappers de medios (`.hero__media`, `.card__media`, `.gallery-grid`, `picture`, `figure`) a `width:100%` y las imágenes a `width:100%; height:auto; object-fit:cover`, y `blog-card .card__media img` ahora tiene `height: auto` en móvil para eliminar alturas fijas.
- Ajustado el logo con `clamp()` (`.brand img`) y convertido la galería a una columna (`.gallery-grid { grid-template-columns: 1fr; }`) para mejor visualización en móviles.

### Testing
- Se creó un commit con el cambio (`git commit`) y la modificación de `css/styles.css` se aplicó correctamente. 
- Se levantó un servidor local de prueba con `python -m http.server` para previsualizar los cambios satisfactoriamente. 
- Se intentó una captura móvil automatizada con Playwright pero falló porque Chromium no pudo arrancar (`TargetClosedError` / proceso terminó con SIGSEGV), por lo que no se generó la captura visual automatizada exitosa.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6961338bb67883329b03d9f3dac2d830)