### PR TITLE
Remove critical inline styles from index and xolos-disponibles pages

### DIFF
--- a/index.html
+++ b/index.html
@@ -45,25 +45,6 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
     <link rel="preload" as="style" href="css/styles.css" onload="this.onload=null;this.rel='stylesheet'">
     <noscript><link rel="stylesheet" href="css/styles.css"></noscript>
     <link rel="icon" type="image/svg+xml" href="img/favicon.svg" />
-      <style data-critical="true">
-:root{color-scheme:dark;--bg:#111;--text:#f1e6d6;--muted:#b8ac98;--accent:#cba135;--accent-2:#fb923c;--card:rgba(0,0,0,0.6);--border:#3a2d10;--color-primario:#161616;--color-texto:#f5efe6;}
-*{box-sizing:border-box;}
-html,body{margin:0;padding:0;overflow-x:hidden;}
-body{font-family:'Poppins',system-ui,-apple-system,Segoe UI,Roboto,sans-serif;background:radial-gradient(circle at top, rgba(47, 33, 23, 0.35), transparent 60%), var(--color-primario);color:var(--color-texto);line-height:1.6;}
-img,picture,video{max-width:100%;height:auto;display:block;}
-a{color:var(--accent);text-decoration:none;}
-.container{width:min(96%,1200px);margin-inline:auto;}
-/*.hero{min-height:100svh;display:flex;align-items:center;justify-content:center;text-align:center;position:relative;isolation:isolate;padding:3rem 1rem;overflow:hidden;}*/
-.hero__media{position:absolute;inset:0;z-index:-2;display:block;}
-/*.hero__media img{width:100%;height:100%;object-fit:cover;display:block;}*/
-.hero::after{content:"";position:absolute;inset:0;z-index:-1;background:linear-gradient(180deg, rgba(0,0,0,.55), rgba(0,0,0,.65));}
-.hero h1{font-family:'Cinzel',serif;text-transform:uppercase;letter-spacing:1px;color:var(--accent);text-shadow:2px 2px 8px rgba(0,0,0,.6);font-size:clamp(2rem,6vw,3.5rem);}
-.hero p{font-size:clamp(1rem,2.6vw,1.25rem);color:var(--muted);max-width:60ch;margin-inline:auto;}
-.btn{display:inline-flex;align-items:center;justify-content:center;gap:.5rem;background:linear-gradient(135deg,var(--accent),var(--accent-2));color:#080808;padding:.85rem 1.75rem;border-radius:999px;border:1px solid var(--border);font-weight:600;letter-spacing:.05em;text-transform:uppercase;min-height:44px;}
-button,input,select,textarea{min-height:44px;}
-.skip-link{position:absolute;left:0;top:-200px;background:var(--accent);color:#fff;padding:.75rem 1.5rem;font-weight:600;border-radius:0 0 .75rem .75rem;transition:top .3s ease;z-index:100;}
-.skip-link:focus-visible{top:0;}
-</style>
       <link rel="preload" as="image" href="https://i.imgur.com/56uXiBf.jpeg">
   </head>
   <body>

--- a/xolos-disponibles.html
+++ b/xolos-disponibles.html
@@ -51,25 +51,6 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
     <link rel="preload" as="style" href="css/styles.css" onload="this.onload=null;this.rel='stylesheet'">
     <noscript><link rel="stylesheet" href="css/styles.css"></noscript>
     <link rel="icon" type="image/svg+xml" href="img/favicon.svg" />
-      <style data-critical="true">
-:root{color-scheme:dark;--bg:#111;--text:#f1e6d6;--muted:#b8ac98;--accent:#cba135;--accent-2:#fb923c;--card:rgba(0,0,0,0.6);--border:#3a2d10;--color-primario:#161616;--color-texto:#f5efe6;}
-*{box-sizing:border-box;}
-html,body{margin:0;padding:0;overflow-x:hidden;}
-body{font-family:'Poppins',system-ui,-apple-system,Segoe UI,Roboto,sans-serif;background:radial-gradient(circle at top, rgba(47, 33, 23, 0.35), transparent 60%), var(--color-primario);color:var(--color-texto);line-height:1.6;}
-img,picture,video{max-width:100%;height:auto;display:block;}
-a{color:var(--accent);text-decoration:none;}
-.container{width:min(96%,1200px);margin-inline:auto;}
-.hero{min-height:100svh;display:flex;align-items:center;justify-content:center;text-align:center;position:relative;isolation:isolate;padding:3rem 1rem;overflow:hidden;}
-.hero__media{position:absolute;inset:0;z-index:-2;display:block;}
-.hero__media img{width:100%;height:100%;object-fit:cover;display:block;}
-.hero::after{content:"";position:absolute;inset:0;z-index:-1;background:linear-gradient(180deg, rgba(0,0,0,.55), rgba(0,0,0,.65));}
-.hero h1{font-family:'Cinzel',serif;text-transform:uppercase;letter-spacing:1px;color:var(--accent);text-shadow:2px 2px 8px rgba(0,0,0,.6);font-size:clamp(2rem,6vw,3.5rem);}
-.hero p{font-size:clamp(1rem,2.6vw,1.25rem);color:var(--muted);max-width:60ch;margin-inline:auto;}
-.btn{display:inline-flex;align-items:center;justify-content:center;gap:.5rem;background:linear-gradient(135deg,var(--accent),var(--accent-2));color:#080808;padding:.85rem 1.75rem;border-radius:999px;border:1px solid var(--border);font-weight:600;letter-spacing:.05em;text-transform:uppercase;min-height:44px;}
-button,input,select,textarea{min-height:44px;}
-.skip-link{position:absolute;left:0;top:-200px;background:var(--accent);color:#fff;padding:.75rem 1.5rem;font-weight:600;border-radius:0 0 .75rem .75rem;transition:top .3s ease;z-index:100;}
-.skip-link:focus-visible{top:0;}
-</style>
   </head>
   <body>
     <!-- Google Tag Manager (noscript) -->


### PR DESCRIPTION
### Motivation
- The inline `<style data-critical="true">` block contained rules like `.hero{min-height:100svh;}` and `img{width:100%; height:100%;}` which broke image proportions on mobile devices. 
- Pages should rely on the shared external CSS (`css/styles.css`) for layout and responsive rules instead of overriding them inline. 

### Description
- Removed the entire `<style data-critical="true">` block from `index.html` so the head now uses only the preloaded external stylesheets. 
- Removed the entire `<style data-critical="true">` block from `xolos-disponibles.html` so the page uses shared CSS and inline video sizing no longer conflicts. 
- No other markup or external stylesheet references were changed. 

### Testing
- Started a local server with `python -m http.server 8000` and it served the site successfully. 
- Ran a Playwright script that opened `index.html` and `xolos-disponibles.html` and saved full-page screenshots, producing artifacts for manual visual verification. 
- Created a git commit for the two modified files and the commit succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69614025d7f88332856f437aa5e4b4a0)