### PR TITLE
Corregir responsividad móvil y unificar estilos .hero/.grid/.card

### DIFF
--- a/blog/2025-10-21-malva-ramirez-xoloitzcuintle-viajera.html
+++ b/blog/2025-10-21-malva-ramirez-xoloitzcuintle-viajera.html
@@ -9,7 +9,7 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
 })(window,document,'script','dataLayer','GTM-MGTMWN7T');</script>
     <!-- End Google Tag Manager -->
   <meta charset="utf-8" />
-  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>Malva Ramírez: Una Xoloitzcuintle de Xolos Ramírez que viajará por el mundo</title>
   <meta name="description" content="Entrega de la xoloitzcuintle Malva Ramírez en la Federación Canófila Mexicana (FCM). Una embajadora de México que viajará entre México y Suiza con su nueva familia." />
   <link rel="canonical" href="https://www.xolosramirez.com/blog/malva-ramirez-xoloitzcuintle-viajera" />
@@ -29,6 +29,9 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
   <meta name="twitter:title" content="Malva Ramírez: Xoloitzcuintle que viajará por el mundo" />
   <meta name="twitter:description" content="Entrega oficial en la FCM y el inicio de la aventura internacional de Malva." />
   <meta name="twitter:image" content="https://www.xolosramirez.com/assets/blog/malva-ramirez/portada.jpg" />
+
+  <link rel="preload" as="style" href="../css/styles.css" onload="this.onload=null;this.rel='stylesheet'">
+  <noscript><link rel="stylesheet" href="../css/styles.css"></noscript>
 
   <style>
     :root{ --bg:#0c0c0c; --fg:#fff; --muted:#b5b5b5; --accent:#df3a3a; --card:#141414; --border:#242424; }

--- a/blog/2025-10-22-orejas-antenas-xoloitzcuintle-5g.html
+++ b/blog/2025-10-22-orejas-antenas-xoloitzcuintle-5g.html
@@ -9,7 +9,7 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
 })(window,document,'script','dataLayer','GTM-MGTMWN7T');</script>
     <!-- End Google Tag Manager -->
   <meta charset="utf-8" />
-  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>Orejas “antenas”: Xoloitzcuintle conectado desde nacimiento</title>
   <meta name="description" content="Las orejas erguidas del Xoloitzcuintle —sus ‘antenas’ naturales— como símbolo de conexión, historia y humor. Del mito prehispánico al meme ‘Conectado a 5G’." />
   <link rel="canonical" href="https://www.xolosramirez.com/blog/orejas-antenas-xoloitzcuintle-5g" />
@@ -29,6 +29,9 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
   <meta name="twitter:title" content="Orejas ‘antenas’: Xoloitzcuintle conectado desde nacimiento" />
   <meta name="twitter:description" content="Del mito prehispánico al meme ‘Conectado a 5G’: las orejas erguidas del Xolo como símbolo de conexión." />
   <meta name="twitter:image" content="https://www.xolosramirez.com/assets/blog/xolo-5g/portada.png" />
+
+  <link rel="preload" as="style" href="../css/styles.css" onload="this.onload=null;this.rel='stylesheet'">
+  <noscript><link rel="stylesheet" href="../css/styles.css"></noscript>
 
   <style>
     :root{ --bg:#0c0c0c; --fg:#fff; --muted:#b5b5b5; --accent:#df3a3a; --card:#141414; --border:#242424; }

--- a/blog/alergias-en-el-xoloitzcuintle.html
+++ b/blog/alergias-en-el-xoloitzcuintle.html
@@ -9,7 +9,7 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
 })(window,document,'script','dataLayer','GTM-MGTMWN7T');</script>
     <!-- End Google Tag Manager -->
   <meta charset="utf-8" />
-  <meta name="viewport" content="width=device-width,initial-scale=1" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>Alergias en el Xoloitzcuintle: causas comunes y cómo prevenirlas | Xolos Ramírez</title>
   <meta name="description" content="Guía práctica de Xolos Ramírez sobre los alérgenos más comunes en Xoloitzcuintles (piel, ambiente y alimentación), signos de alerta y cuidados naturales recomendados." />
   <link rel="canonical" href="https://xolosarmy.github.io/xolosramirez/blog/alergias-en-el-xoloitzcuintle.html" />
@@ -22,6 +22,9 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
   <meta name="twitter:title" content="Alergias en el Xoloitzcuintle: causas comunes y cómo prevenirlas" />
   <meta name="twitter:description" content="Causas comunes de alergias en Xoloitzcuintles y cómo prevenirlas con cuidado natural." />
   <meta name="twitter:image" content="https://xolosarmy.github.io/xolosramirez/img/blog/AlergiasXolo.png" />
+
+  <link rel="preload" as="style" href="../css/styles.css" onload="this.onload=null;this.rel='stylesheet'">
+  <noscript><link rel="stylesheet" href="../css/styles.css"></noscript>
 
   <style>
     :root {

--- a/blog/blog.css
+++ b/blog/blog.css
@@ -1,1 +1,51 @@
 body{font-family:Poppins,sans-serif;margin:0;padding:0;background-color:#fafafa;color:#333}.container{width:90%;max-width:800px;margin:0 auto;padding:20px}.header-content h1 a{text-decoration:none;color:inherit}.post-list{list-style:none;padding:0}.post-list li{margin-bottom:10px}.post-list a{color:#06c;text-decoration:none}.post-list a:hover{text-decoration:underline}.blog-entry{margin-bottom:20px}.blog-nav a{color:#06c;text-decoration:none}.blog-nav a:hover{text-decoration:underline}.blog-more{text-align:center;margin-top:20px}.blog-more .btn{background-color:#06c;color:#fff;padding:10px 20px;text-decoration:none;border-radius:4px}.blog-more .btn:hover{background-color:#004e99}img{max-width:100%;height:auto;display:block}
+
+/* FIX GLOBAL */
+img, picture, video {
+  max-width: 100% !important;
+  height: auto !important;
+  object-fit: cover !important;
+}
+.hero, .hero.hero-disponibles, #cta, .parallax {
+  width: 100% !important;
+  max-width: 100vw !important;
+  min-height: 70vh;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+.hero__media img, .hero img {
+  width: 100% !important;
+  height: 100% !important;
+  object-position: center !important;
+}
+
+.article img {
+  width: 100% !important;
+  height: auto !important;
+  display: block;
+  object-fit: cover !important;
+  object-position: center !important;
+}
+
+/* MEDIA QUERY MÓVIL */
+@media (max-width: 768px) {
+  .hero, .hero.hero-disponibles, #cta, .parallax {
+    min-height: 350px !important;
+    height: auto !important;
+    background-attachment: scroll !important;
+  }
+  .hero h1 { font-size: 1.8rem !important; }
+  .grid, .grid-2, .trust-grid, .gallery-grid, .footer-grid {
+    grid-template-columns: 1fr !important;
+    gap: 1.5rem !important;
+  }
+  .container {
+    width: 92% !important;
+    padding: 0 10px !important;
+  }
+  .card {
+    width: 100% !important;
+    margin-bottom: 1rem;
+  }
+}

--- a/blog/guia-tallas-xoloitzcuintle.html
+++ b/blog/guia-tallas-xoloitzcuintle.html
@@ -9,6 +9,8 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Guía de Tallas del Xoloitzcuintle</title>
+    <link rel="preload" as="style" href="../css/styles.css" onload="this.onload=null;this.rel='stylesheet'">
+    <noscript><link rel="stylesheet" href="../css/styles.css"></noscript>
     <!-- Tailwind CSS -->
     <script src="https://cdn.tailwindcss.com"></script>
     <!-- Chart.js -->

--- a/css/styles.css
+++ b/css/styles.css
@@ -50,15 +50,21 @@ main > section:not(.hero){
 }
 
 .hero{
+  position: relative;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: clamp(1rem, 3vw, 1.75rem);
+  margin-inline: calc(50% - 50vw);
+  width: 100vw;
   min-height: 100svh; /* mobile-safe viewport height */
-  display:flex;
-  align-items:center;
-  justify-content:center;
-  text-align:center;
-  position:relative;
-  isolation:isolate;
-  padding: 3rem 1rem;
-  overflow:hidden;
+  padding: clamp(4rem, 6vw, 6rem) 1.5rem;
+  text-align: center;
+  color: #fff;
+  text-shadow: 2px 2px 8px rgba(0, 0, 0, 0.7);
+  isolation: isolate;
+  overflow: hidden;
 }
 .hero__media{
   position:absolute;
@@ -80,14 +86,16 @@ main > section:not(.hero){
   z-index:-1;
   background: linear-gradient(180deg, rgba(0,0,0,.55), rgba(0,0,0,.65));
 }
-.hero h1{ font-size: clamp(2rem, 6vw, 3.5rem); }
-.hero p{ font-size: clamp(1rem, 2.6vw, 1.25rem); color:var(--muted); max-width:60ch; margin-inline:auto; }
+.hero h1{
+  font-size: clamp(2.5rem, 6vw, 3.5rem);
+  margin-bottom: 1rem;
+}
 
-@media (max-width: 768px){
-  .hero{
-    min-height: 300px;
-    background-attachment: scroll; /* desactiva parallax en móvil */
-  }
+.hero p{
+  font-size: clamp(1rem, 2.6vw, 1.25rem);
+  color: rgba(245, 239, 230, 0.9);
+  max-width: 45ch;
+  margin: 0 auto;
 }
 
 :root {
@@ -174,11 +182,6 @@ a:hover {
   outline-offset: 3px;
 }
 
-.grid{
-  display:grid; gap: clamp(.75rem, 2.5vw, 1.25rem);
-  grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
-}
-
 .trust-grid{
   display:grid;
   gap: clamp(1rem, 3vw, 1.5rem);
@@ -202,15 +205,6 @@ a:hover {
 @media (max-width: 640px){
   .trust-grid{ grid-template-columns: 1fr; }
 }
-
-.card{
-  background: var(--card);
-  border:1px solid var(--border);
-  border-radius: .85rem;
-  overflow:hidden;
-  transition: transform .25s ease, box-shadow .25s ease;
-}
-.card:hover{ transform: translateY(-4px); }
 
 .card__media{ display:block; line-height:0; }
 .card__media img{ width:100%; height:auto; display:block; }
@@ -256,39 +250,6 @@ a:hover {
 }
 
 
-.hero {
-  position: relative;
-  display: flex;
-  flex-direction: column;
-  justify-content: center;
-  align-items: center;
-  gap: clamp(1rem, 3vw, 1.75rem);
-  margin-inline: calc(50% - 50vw);
-  width: 100vw;
-  min-height: 100vh;
-  padding: clamp(4rem, 6vw, 6rem) 1.5rem;
-  text-align: center;
-  color: #fff;
-  text-shadow: 2px 2px 8px rgba(0, 0, 0, 0.7);
-  background:
-    linear-gradient(120deg, rgba(12, 10, 10, 0.75), rgba(65, 24, 19, 0.65)),
-    url('https://i.imgur.com/eMhsPcJ.jpeg') center/cover no-repeat;
-  background-attachment: fixed;
-  box-shadow: var(--sombra-suave);
-  isolation: isolate;
-}
-
-.hero h1 {
-  font-size: clamp(2.5rem, 6vw, 3.5rem);
-  margin-bottom: 1rem;
-}
-
-.hero p {
-  max-width: 45ch;
-  margin: 0 auto;
-  color: rgba(245, 239, 230, 0.9);
-}
-
 main {
   max-width: var(--max-width);
   margin: 0 auto;
@@ -313,6 +274,7 @@ section h2 {
 .grid {
   display: grid;
   gap: 1.5rem;
+  grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
 }
 
 .grid-2 {
@@ -433,7 +395,8 @@ footer {
   margin: 0 auto;
   padding: 2.5rem 1rem;
   display: grid;
-  gap: 1.75rem;
+  gap: 1rem;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
 }
 
 .footer-grid div {
@@ -494,12 +457,21 @@ footer {
 }
 
 @media (min-width: 768px) {
-  .footer-grid {
-    grid-template-columns: repeat(3, minmax(0, 1fr));
-  }
-
   .footer-grid div:nth-child(1) {
     grid-column: span 2;
+  }
+}
+
+@media (max-width: 900px) {
+  .footer-grid {
+    grid-template-columns: 1fr 1fr;
+  }
+}
+
+@media (max-width: 600px) {
+  .footer-grid {
+    grid-template-columns: 1fr;
+    text-align: center;
   }
 }
 
@@ -807,103 +779,6 @@ body :focus-visible {
 .politica-reserva.parallax {
   background-image: linear-gradient(180deg, rgba(15, 14, 14, 0.6), rgba(15, 14, 14, 0.9)), url('data:image/webp;base64,UklGRgwoAABXRUJQVlA4IAAoAACQSwGdASqwBCADPjEYiEQiIYh0dBABglpbuF3TkT1xiCLYuz/R9wPB/Nb/g/3E6n/uJhV5rvPP+9/un5ufL3/B/9L2Ifpv/Zf1z9//oK/W79dusl5iP6P/f/2I94//i/rd7yv7N/q/10+AD+qf7H0p/ZP/cv2B/5t/0/Td/eH4Yv6v/1v3f9r///+wB//+At8W/278mfhr3efd/7T+Nv/W6iL195q/Pvml/FPrv+b/t/7Y+v39b+x30j+R2oF+PfzX/G/lf+VXHB6J/q/QC9v/on+o+5T0oP5H0H+w/sAfzH+w/6zjYftXqAfx/+4f9/2Uf5T/pf5f/If9b/ke0T8t/x3/e/zXwGfy7+sf8f/Gdpv9y/ZL/Z//4AlekNgt8zSH6pDPfLD417ZkTc70zSH6pDPfLD42C3zNIfqkM98sPjYLfM0h+qQz3yw+NLpR3zNIfqkM98sPjYLfM0h+qQz3yw+Ngt8zSH6pDPfLD4nIXX5pD9Uhnvlh8bBb5mkP1SGe+WHxsFvmaQ/VIZ75YfGl0o75mkP1SGe+WHxsFvmaQ/VIZ75YfGwW+ZpD9Uhnvlh8TkLr80h+qQz3yw+Ngt8zSH6pDPgO1Wq1Wq1Wq1Wq1Wq1Wq1Wq1TntpoI/VIZ75YfGwW+ZpD9Uhnvlh8bBb5mkP1SGe+WHxsEejsmlptNptNptNptNptNptNptNptNptNprDLD42C3zNIfqkM98sPichdfmkP1SGe+WHxsFvmaQ/VIZ8Ctu3wpmGvHwMm7Tj0CRdlt2+FMw14+Bk2o/pII/VIZ75YfGwW+ZpD9Uhnvlh8bBb5mkP1SGe+WHxsFolR8zSH6pDPfLD42C3zNIfqkM98sPjYLfM0h+qQz3yw+Ne5UfM0h+qQz3yw+Ngt8zSH6pDPfLD42C3zNIfqkM98sPjXur0hnvlh8bBb5mkP1SGe+WHxsFvmaQ/VIZ75YfGwW+ZpDrcO2We+WHxsFvmaQ/VIZ75YfGwW+ZpD9Uhnvlh8bBb5mkDB/VIZ75YfGwW+ZpD9Uhnvlh8bB7Pj9f5VPcb4mrp6atp54Lfu2mgj9Uhnvlh8bBb5mkP1SGe+WHxsFvmaQ/VIZ75YfGwR6Ud8zSH6pDPfLD42C3zNIfqkM98sPjYLfM0h+qQz3yw+Jx4Smm02m02m02m02m02m02m02m02m02msZFFGb/lAVpxAUtkddp+mW7G3SjvmaQ/VIZ75YfGwW+ZpD9Uhnvlh8bBb5mkP1SGe+WHxOQuvzSH6pDPfLD42C3zNIfqkM+BW3b4UzDXj4GTdpx6BIuy27fCmYa8fAybUf0kEfqkM98sPjYLfM0h+qQz3yxKRrb9Mtk7SXblQbLtyoNl25UGy7TopMdIbBb5mkP1SGe+WHxsFvmaQ/VIZ75YfGwW+ZpD9UhlqriWHxsFvmaQ/VIZ75YfGwW+Zn7TcAiQFnRhoA39wXfLlp4DmD/n0Ww/q8a5vgZ+yvtJVrZPScG1abE3BaLR4mv1vyGgzx16Qz3yw+Ngt8zSH6pDPfLD42C3eQ1+iZ5zpFbYV8Y/ItwcrCvM0h+w/ODU+UV56ACV4dNz1WO6Q+AhDuLmAJgwdeSyt3asCfJNVoiB3Q2NrMcFK6ETohrFwC3kQyxWhRMItz3yw+Ngt8zSH6pDPfKDcq7D1bfWYkskuEGwW+ZpDqcnMiVCz4rIvrEeaV9/Z+etWsHMybft5CHoKej/2CiFowGC6vEbWlm+KxtSrFPiCM57xg3HXTD5sFu8w0D0XtlZlgSWMe2LecSfqfXBDT4tXfiJoLfc6GImPl0eSrsoU/68KjNLPWikMBHQFd4csZVd73MFFEmeFANnZz9NYfV9JIAzpwKt/NnbH8mzSs9CyGnZSQ2C3zNIfqkM98sPjYLfM0h+l6Be0ptesu6CD28v27TgcxF3XG8hCDAXEFr9/FFJ6H/AneDH+nxP3nhE1wT4DwrclLR5eEoO11L+irI1iGExW2qO4WURSn4qgPHVS6+Tqfpe/O4ZQqPBzjHchorR6UVu5W7i8cb57PEUs+JKsdRFsP6rjbGGZkhlupIC0qIdcpqrKZAEsr9Ci25rV46qRNv0YmWBfRje1lNmwW+ZpD9Uhnvlh8bBb5mkP1R0xdT33APIri1qF23cHTCaS/CsaQBkzMDnUEF/acz2G7v/EKG7mgMQ/2XlKRk9vR+aC7/EuXfnrvXdV7Be/8lMIvoy4FEMv3kDwzpofykJX8kg86wonhysGefUFjOcLexw5ES/y4yuQCxT4wEZQp+zmAa2pLL6CE0K/AlgaL+nlE32cTvchYEZYQ003Yp18t0wHP/4jrD42C3zNIfqkM+JZcqDZduVBsu3Kg2U5BSwQRWZRu/ZVW4Gx4ALhE5KdGtv0y2TtJduVBsu3Kf+We+WHxsFvmaQ/VIZ75YfGwW+ZpD9Uhnvlh8bBb5mkP1SGe+WHxsFvmaQ/VIZ75YfGwW+ZpD9Uhnvlh8bBb5mkP1W9bk5Gtv0y2TtJduVBsu3Kg2XblQbLtyoNl25UGy7cqDZduVBsu3Kg2XblQbLtyn/lnvlh8bBb5mkP1SGe+WHxsFvmaQ/VIZ75YfGwW+ZpD9ZIuJxOJxOJxOJxOJxOJxOJxOJxOJxOJxOJxOJxOJxOJxOJxOJxOJxOJwp75YfGwW+ZpD9Uhnvlh8bBb5mkP1SGe+WHxsFvmaQ/VIZ75YfGwW+ZpD9Uhnvlh8bBb5mkP1SGe+WHxsFvmaQ/VIZ75YfGwW+ZpD9Uhnvlh8bBb5mkP0tvrk9xacOtX2ucAzjXOAZxrnAM41zgGca5wDONc4BnGucAzjXOAZx0i3rcnI1t+mWydpLtyoNl25UGy7cqDZduVBsu3Kg1/g3gcP7nnDpb9OPQJF2W3b4UzDXj4GTdpx5NfGwW+ZpD9Uhnvlh8bBb5mkP1SGe6HnQsVM4gfqkM98sPjYLfM0h+qQz3yw+Ngt8zSH6pDPfLD42C3zMSKGDkljR/5QMHkDk2guJY1IZ75YfGwW+ZpD9Uhnvlh8bBb5mkP1O1G9RxReVSGe+WHxsFvmaQ/VIZ75YfGwW+ZpD9Uhnvlh8bBb5mnDwWEud/9Uhnvlh8bBb5myG43G43G43G43G43G43G43G43G43G43G43G43Bu4ezIGfJ+Q0Gg0Gg0Gg0Ggz/TQR+qQz3yw+Ngt8zSH6pDPfLD42C3pJSJHSe+WHxsFvmaQ/VIZ75YfGwW+ZpD9Uhnvlh8bBb5mkPu4Jl6yFmkP1SGe+WHxsNc5nM5nM5nM5nM5nM5nM5nM5nM5nM5nM5nM5nMxc8znknnX5pD9Uhnvlh8bBb5mkP1SGe+WHxsFvmaQ/VIZ75YfGldPXTQPjYLfM0h+qQz3yw+Ngt8zSH6pDPfLD42C3zNIfqkM8faztVqtVqtVqtVqtVp9jpDYLfM0h+qQz3yw+Ngt8zSH6pDPe/KlTg9TyCP1SGe+WHxsFvmaQ/VIZ75YfGwW+ZpD9Uhnvlh8bBaD34wzvmaQ/VIZ75YfGwW+ZpD9Uhnvlh8bBb5mkP1SGe+WHxNGVis0EfqkM98sPiYAA/v8cy/c6J7qs71z7nrZQADH/r+o3+XJ/pu+ftvIGhGxU1kjkAAAAABVn3nqKAAk/Ly8vLy8vLy8vLy8vLy8vLy8vLy8vLy8vLy8vLy8vLy3fAAAAAAAAApCgAAANLgAbzE6vGhIRT4TQkIp8JoSEU+E0JCKfCaEYcMAB87H0z0TeN43jeN43jeN43jeN43jeN43jeN43jeN43jeN43jeN43jeN4/YAAAAAAAAAYRQAVfrrFAqHI5HI5HI5HI5HI5HI5HI5IQYs94ABJY06Q6dIdOkOnSHTpDp0h06Q6dIdOkOnSHTpDp0h06Q6dIdOkOnSVdqOTCgAAAAAAAAdx24ABj7jAzp3Z9Id2fSHdn0h3Z9Id2fSHdn0h3Z9Id2fSHdn0h3Z9Id2fSHdn0h3Z9Id2fSHdn0h3Z9F+sx8XP5HZ/I7P5HZ/I7P5HZ/I7P5HZ/I7P5HZ/I7P5HZ/I7P5HZ/I7P5HZ/I7P5HZ/I7P5HZ/FAAAAAAFXLFAAAAAAAAk+/XpA3POnfr0gbnnTv16QNzzp369H2xgAIGXf88y+8diCdoKAk0BaaCgJNAWmgoCTQFpoKAk0BaaGxilc4TrAAAAAEgOADeyLy8vLy8vLy8vLy8vLy8vLy8vLy8vLy8vLy8vLy8vLzBTVAAB5ulvRH8zL9u0KOgjMk0ekv9Mvhm596WAdajAAAADewAG966yX6gGwQbYF0JhLJMaEwlkmNCYSyTGhMJZJjQmEskxoTCU9LnOurrs6SrJjVs6SrJjVs6SrJjVs6SrJjVs6SrJjVs6SrJjVs6SrJjVs6SrJjVs6SrJjVs6SrJjVsseJOk25D5RqfmTbjTVWl6Xpel6Xpel6Xpel6Xpel6Xpel6Xpel6Xpel6Xpel6Xpel6Xpel6XeAAAAAAAAAAB2mAAAAAAABA6CqZVe9k/XfrvTXXkUkpzJuUNc/qD0MgFyS/Awf2nSUc9iIEmYclbFZHKw3H1uB6MtqFcl1hQ2NQlXwDPzF4ZSMJOCzRurW5axAQ5Gh/opkVpr1x52sQVGwdk2QgAXp8osMhtBtFHF9gDrsV/eipj2H/vKUUlfxV5A/dHTAGdeqrRwBbC3V/wmX7tpbhbyktc9edKA8ETFdXmA2Qv0m791uOhzFZpzL6qGJifvJTpWyNihLLomRp6qpfaEqWWDtswIhbFPO8vlrvl019B+YfaATKcIEHjoZ/XQodMRk3ScqipNwqOHthB0fhu7kFpv47zg6Ljuk0f/4YIvfBd/YjxJ/48oqequvdTxDwtOPCqESejhf9+ThGTXT9d+u/Xfrv13679d+u/XfrlkTbRwACY3SG6C4hQdxwX8R6DHTFlIUspy6d9X1kNhLs9m/pVZqlUcZprL2biC40hsIZNhQYyjmwzdNCTD8zR5caUsQNcwibE2xqIj/S/78K2jghXZB+/ifp6rB272AWpSkic1siHzF+vqTE5fEKOV39WZaeaa/zsOzOmUZK/qKLki9OE91Hkm6bLaNYLf6g1uoFUuWgJ+e1zDQNl29KaYMmG+zWknVCayZ4iK5Th+j1ejdgjwmt6UFxBqVv9Ofjfy/bZdTl4f/86/9FQb/o+7Z3kDld+cGqarm98KZpRkQAAAAAA1YzbMP+OY1hbo1BzfB11LnrMV6blPw3iwOzcu7sb+Q+JnHz00O4ie/gh3jefJOFl5P8Udoo0HdQ64FBIcFYvrLzZ0lECNqpALj4oy/iDr8/nyf6exeA3E9W1eTxmUnyQvrOE+oc+EjfOdj9n1IwNcpBm7NBk1elhq+zhPOMbLWTJyvuPnOYrCtTG+Nz7gZW3fbhVybqPVmAvJUtNKpmvDvVwW/In6VutEWMj0xi4feD3ceM2s3G62z0AMJWNP/zCIPr6ui7lijFn0A5S5MrPo04913KsjAYHrRglufKbMxxZPO6mCjRc9bMwwjLZUF6gym/GNzt3+tSjpk2wAQ40ALSk+SBknt9wuIshvtQYAp0vQgShBh0B7fZz8oKUuL61lwyIhfbu8O9bNFcrzuJ0Sr+px5hvE50b8ZNu8VMV5jVvzD3uwvjy02CuEN554z7ATMCwt3sYp3GZv8hioWCc7hpet2tBUXrUpGD8L/cktfyU/GAR985NJ+ZbZh0piSRqrNE0mHsEWar36o1cx/wZ3fJWHSeZ+D7QbB20FXg0bV0QP9FQ4aLBLyh12aPzJSuE6vthD3yjcZbQYMuJW12dZnYAQV2s41zAmLjEYKvCDsDMrUeHAuVSP/jObBe7GI91/wjkaeEXxKMqBD8ony4DQAAb465IoO44L+I9Bjpiwkaf6/oW3alqx74iAq1fEry3pVVl6/MS4qacPZRaW/511ntCXtHBA0WCzCUphLYSJ0rbcbmeveYoZgKAPxIGKat+BvwoJzzKS3st39jsHm90EB9QAAHa7yz2IZuiC1YqISrwQeTwNYhRPN7OFbG28Vs1tpOdKVFWhPVRN61tOU3m/3KrE7tMqiWjNrwVz2x+c3lgfbOAcS6vZxXtjymW5/CxzHuwMIUttrBGE9ZYbZhS2U41ObFm2vDovLpSfuxGxOWCwpiLXR42JqdtGYOnuSR8xdTN9Q/ltBAVKLxmwus5/8ilz6FA/H9n8g3PQcIgfU4l7DsVxCqjWVGa7k34oKNFiH1U02mmKD7KBMxXbWsb4d4CdyeHAloOnMnDAeVgoAZjB3oMWkumMI/Hoz0Pu1n/bDhBH1KQJ2sHV58J3YuW7baTIYjNSv+QHFTRx81vexi/+9pSU/s/Zu1RKsNsYnhvSQ1/W4925pKAO7MYfH/mnAwrpt5Fc6HEckEqowigG2xpvD+5ZamUS1Wv4KDawaEtr/+68rmpfySH/ocWBfpknln/Hy+Ge/PfVqTKAZ2uymPvWnEMQiqC1ED7dz5Cpg18e/QMcvHYQI6Dqi27Kj4f2LwG4nq+TuCb1JDzYFlD1srxU0g0dTg2SfnpJc47vaFKTq5AkNO4VQBYTP5xuYzArc+oqZRzbHar8zpaoF7/5Sv4o7A4FxBwERHRs1SbvlOEjPJXpQS6Ta5mWokQf4DOXDmpMwBG79Pv+TiXT6T+R/s0fXpGGqBX70b/+94AUn2Aeu7lcV5wj5jtioniBSB/apjKxJ+qN5Ti+//gWHfHq7pAJ3wJ8wimFqaQGeThvbHH63wu4P6f1LDpJZ2hio3wOeYqlQzqYLX9ugPUGdAcVTd7WGvkMiiHcvLVJ6cG/qXDO6k6ym0nqrX4194FHwZvr0eP5zHuTt4LDTPhX+cLBsmX0Rmx/GkF9jb3is2ufFGzhB/pOyG7C3pT9oL5KC5JL5yHZ+9nt31WeX1vqsEFgPXkM3xbJYxQyYWZm9fyvgcn3pehtsfOphcCFD+LEsPG+sTPPuV4vvmN0PvqCgrDZEKjgOV8+hFlc8IYnnMfjFxQ4MF10m8/9hyPh6a8NlyYGAff4+Drwh4spnkw9xKlFFimvLu+DQxMM6wnTfnMcpeDGLBZBtgLozxEp7TnmJM2i9MsTKQeCt4HNsAGhReAdFJllLpr8Z7IKv4VwTP4Hlzx23q0Z+F1MWNNavH5/Brtu+39r/y1y05QvAccp6hMjgv5pANXm3/Oo33LpWnwUVieQgMSbTtWu7ASRl1HFb51jOKYj+ONVKclE6Oo4/W2RTZ5bPnapIo9/3Mu2LUZ/7e4X0UKh1lbdsQb0SjX36kW/b8asyCBxyYbQ/U5F+1xYVYNHkNl5tsnCFXPxDoYYI5TUq7Z/h1lHz5/Y7zqog5HG2/+YuimW87bke9id5I+IVOVK/YTM3WiydAbI/z8LiuAuQJv4dth/8g8h+HRYQ33VP2HyeGCYaItswALozLP6DzcGmdygqMx4XSb61pSUPzkjw81Hmet4WOHv/R4sbnXj2lhM0l5liph7U9hVFjnLlsCvXhbKjx2/ZZil6rP5Drhmf9EZUFdl8ODhFKIpZ1IfZSL5zB3H0JyJJqQWlAZYxZ18mjZVN5dc9wffbshEmb7WzIuIqURGYDHrH1ZMJMzBBe+5RK7Pz/7twanUQZ+Bp9Le30/whSJjQAK1ua9RCU1F5OUP7pjmXEWUj5V6FLGPuDpDArttv3hRgiL5CsrGh3V5BGvykt2jhEwrwkKWxrMi4WnKQv26QTul1oq7WnNZyptLz4F+U2I5Prlm6kZajiCtn8gUF7rQOICpOORjyBpcgAkUB6mdCPPZVreM1brC/qrfzrHx+/g1n5qxhJpZ+8yesq/065w+wloCp+/42TMz+msBQTT64ucv+I3qH/aA63k/Iw5U2KR+VaAwh7sliOZbnxR/mzVeV9MgzDFuWND6SuHHQJVz5RvaJ6zPl1nBYxqBIRSaPMsvg6UhSlgHNHKq9gTpjEVgVbac6378twElQVxUgbtm8gAV2obCyhpj7LM2klGZv+vhJUnhOQAZJXpheQqPQCSWmbvdxs6fnlAcvmfgQouSx1qpKZdKkwhWYZfaVfho0wT3aXf9KaoEeNSjNv2WSDMxngPxDGP28a5Y2O/j5pdAfgfUw9Y8j5UyNtPB/zzWeXz2xdHFT1SUddZB2JZ40/6axrWkiWgY6VSpbxZq1kfnBb4MRaEQCqKgcTRtWh1oLWewChtoTrhYwcM7l7H791cgDqD9zwApAZqU0WqG4MNnvK/zx5iBqx4ksXQ28HSn4c5AL7RGzDDFqgeaySyy8hi7FWtRPz9KXOQi8/LmqwID4ICgZg3tXNM/Fq77ai6z2J+F2GI/Qtc2WaSxaPt+OFP/IGCJ0K32ZVqe4yxU++awGt7o213hOC1NmZrRyUkRe2Vt2yVGs5vqe3f4TwyvRCdXoFbI6z+ADVGzXpPpf+6/mqR+nvE3Ezm/QQGqkLIOtO3SITHBJDr0sVCMaMbMWF46YBgCEOLTZEUnGrq1sG8Pfwcl3TxJkLatlaIK645YLEAgf2xPbv6SS3N9JdCw+tq/utmD4VgVZ0AZWQvIDfEk/838O4/00j4ObETid9rS/uZaIE/qTEF7NL7p0p6Vw1NK2bjhnH9TBFje0P2sBmnp66KT0XJXQgdKYGdAUfOXNl3egCFPzmMu6fLq6e5aZOFk8XMaTcwpy3RjYvybn//5koUjiG4+VQvIYeiihqcu46YfJ13YZE9LIvJ4iS9pJ4+A0NLKs8H6YSyzcaGiWwNrg8Ju6awQ3IyEYeDfQbs9Xc82EKVNM1n6rHBbDbVtZRnCgxKOo1HkVDJQjsJ2C7T55xifbPuwdV6S9I0dZf4p/+LpDnQHWCpoj3XNhzSSX66g5qootfqOL/OqsYt64fzkqmNHsTCgIf48I8IDEbxzscgeAb139x3qR36rQM+wo+dyxRNeEcSrrshVT9krYVC5q8p09MCc9k3V6tg4blgXDbf+MB/0vl2oOSCFiLOm6EcT779pEjD7owxnhwg4tvxQ02/Eg11mKzY7HCGSm5uV0hmJ03/dffoIywLQvYs6tnhskuTOfng2ZMLIsJp30aLhFPSL4Yvoq0ypWLohxjjBLwb6w5rJqGh7YE0IXeXTPp03DLOH7OiIBa8+kjS151oCRsuiPBal0OL/7NjckrO+nagWNymWBgSPHtPli1zvuzMbKaXapGXp0ivy2czSy4Hp914OID9TZ4BsJ7kCDXGlpfIxMAed4VkQcl0pq7jeBLisMkGOKBvMNfVHXxPnu0+CWCTIZZYqWlaP5t+VfhFuxX6R6H6OgRmQP5E8fDrZDKuT4o1wM2V82lT6mb/M9ioehXWlsdEMYM/7GnSXpaivXQHNPHVLMgq7K3Jt7xzF91AusqEcw/SF8y+4vYqJkofe29Kj6VCSXgjxsi3wpbfmdp6EHd60jgh8Yfjs9Jd7a8zMfhX/FjXDCHF0yfWXIIUQjZM2BRwQlKILoWOnLxMEeVkO5NVW+z937ojLOh3GAierGpchIz7NSiVxHkR33h8Is3I9WdioHX9A+aX2zYkwPm2cBwcKIbmZL7LBJw1JjnHeIdjOUFhZeF85urYq8Guj4zE7EVTawr4K5ChLJEyHcHXaQNRFVYlQFV8qGyl9hlTf3eManZoz1xjXGOYcQJU4LNxqjEln3dJZpWKXgYp7q7Ha3u2wRbwTWPu15MrAwmTK0ef8376cWLl903BzWfNfpAZeM+dq2HBDE9QnRzsz78TMqTVZWZlcMg7ejdAvHLh3jbUo2PI3gUn+1gz7m72rbYHIYzbyxoXAU1vVZRoqIYKYEq4V+vcsUTuqod2XlFsV6c3fSimmgCVErOyHk+36AUDmPw6LfL2TcfO3HIK0bltsMJObtwhjh2eB7eDIzBxfxCZK4DADAbh/NXGPZmfey80s1Gv6s9wJwHkR3mKjuNM4H1cmDoGw4V4THtiUWxMsK39kJewJfs549UI3yvNJIipf4bGj+eUDkme3ZBSTfZZPRHGD6B+3BRntc2VWbtmXIg8lJcueqBBhDXsI28857JGDrE9FR1ZAhrTtZfiJ3f+D/+lnVO7eKBcghz2Pmjr/oVCpTMg+frhH3IvQyW8TBhuc94w4+FXULm3sWVZPNoPzZ4rnuICZiFlLltWYy02Kia8v8995eyY9/VjRRAx3jyT/cdIUbv6SEC5G20B3JqBNp8cxfdQLrKhHMP0hfMvuL2KiZKH3tvSo+lQkl4I8bIt8KW35naehB3etI4EamyjGxYxLMVLvnVj2c3XDCHFc3CZhb+MnWBfU62koPXqbLQC4fGPAqS+1sJ7e2hCNbQvDEKsn/nW6zXEPn2alEriPIjvvD4RZuR6s7FQOw+lCsAAExLi2OOdj8LpL+MlwdxOq6hjKcI++Im2tkO2cC7yEZWDToWfYX0+qTSoGYjtCEwuh62ToM+w8d+1H1XIp4m2YRlxTX3b7sp7I1pk22flcpa9aCnEbWu2p/0X8MQ/4aGyH+A6vtX5y0C/gPVR4j6T2XnchkrvqsSMqH0u1ma9/cCOAcJj9v2hoAntTpGdkq9syXBypFUp0GBXkaW2A5Re9VxFWkxsOZ0tXntA8tmaralGLX5B24XsIOkWDBSWlfpiAS0q5KiD0VfSLpIHdEH1zKdw5E2aieKMOaMjJAYyO2h3CrzDoZak+XRwK/m6Z40K/qiwbVnPhfktoTDx3eoasr/1rp8O12+OuXiNEmlstsytRYZCfR17WgW8QzPB0GNCEQBiXmmT9RzM5NGbn/UXpq0T0kjrveMrNMdwxOX+Wq29U/qLtUB6P2lXbf4Uh7w/DbXnChWylqsGf1Vw0LpBsCST2HAf/b5IxmO4xPF0jx3JjUXltaYdsSyNmoQ6QRMYyn+S5v0A/SCoqvrc4BpP9L1H4A/ADZX17rxIUMpHcj/UwBklKdtuaSIfNodC9SIR6ks0L6zigf/n243qOGwvyfc6z/PPeC2RjhzgUP0/H6LZ0e1WpQDO1c/4uqvQQibbinbBtidET5I2Yvp8A/VqbGqfFRYs5IIL/+JGLWpqa6yJv3S8BHSQA6smfEHqlXwaH968F8KG7HsFHbdxVG7jJRDBDD+0m8FpnWeCFWYctp7eZyooo+B0dYigKOeBKry2G1zHUQMkRBgkh7PO7juDrWzLUBRhkcx/MV9QpClI97mdLyC6SVlh0RTv5VehWF27pMZE3VKY163wPMlkqOTIm3phYXE8iE9c4cseMCwbUFFdbX2z3naZ5h4ZdB2mdj5+bXdzt1nYQ653I7ALEarh5IpqEefKszef9Rjjw/+h1+2pZ2Fdc1ziiwKf7vhmIxk/b4dcy6qKBCLd2n1IDgLJBfCTtXw1HMpVO2yM5eBjRXom9hcOcIIG5TJf8O+SyRND7EZnx8xl5ufiIxrRwOxwQBpE2Qo0lhiNYKadS/zq/koRmxVCM6Z6IcwuSR9DgGGny/CjcSJE4yU9ZxxEVmDHpqEib7IQkqsVDiyQSOyUm7MSVGPCZ6Iy2J/vyI0xqEnFeBUZG9GowMyGZq//fXznaOgqdp8qH8BPYNe3NVjKWLZj/vnnlHDkY31DOremJJaR75atfAcrsTUGutdCpErNX9skQJ0/PzK0xKWA0QDXK6mYscYYrlin3g1tuAhNv3TWbThPHTW9FoHh00qFJ/vNbcAAqP+aNfxmpDu0JhY/wl3u2o9ytbvRTtuJtfHditKzAoUWLFRO9zOSCrk5Yn24E8vfEk8Xgp9RGi4hm/gO9Y+CX5lJPgOXG4vsEAECDLf6GAwHK5kPPan4cZfhPne4+uCWoKcTHvRdY3ybX+78UZB/vk3A8E0YSHHZg3nT3y4fEhK5UVCUlUwqA4g89XJpAdS/Zew0rIgNjbkEaKFnDFzFXBCMC+gJ4qHns9ddUAd/sP+CLIQv+IRXNM39MCA1ugDfJlDtG6ju7SNp0drdhfGJbGQ3bdEAONOLqcKfEfbOTa0wogc8V896Z3AmKhrQFglGf+Ha7Up2eVoxtTox+PmCvHkJKmWwTiSoxkPwu671+36L4pdqI7CWFGvMudmW9CZct00itHJXWElYXbukxkTdUpjXrfA8yWSo5MiY00KoeRNnhgHhSW07hOsEN7nc8z/CHd4dPD38rl4gYjXWfkcwrNVeTjchtggWdY+PW0Je3EdVDHNO9AV/2HX7alnYV1zXOKLAh4w/J4wvvhSeuZdVFAhFu7T6kBre4krlV90LgQfn5+bgCtFAKEACoAnRSEfWHxf0UBr39EucNaO/fX9boMo/8SZmrqytIiMYScs/OvdSaKJ1KOI0xlTt3CSJpHkOMf0PjF4pnuqVX2AS5tSAAAAAAAAAAAFGf2wsLCwsLCwsLCwsLCwsLCwsLCwsLCwsLCwsLCwsLCwsLCwsLCwsLCwsLCwsLCwsLCwsLCwsLCwsLCwsLCwsLCwsLCwsLCwsLCwowAAAAAAAAAAAAAAVXywhgAAAAAAAAAAAAAAAAFH9n7NiOgt88TUUZJNfDhPhrJOEY2hA37q4DNTyfoLnR0Cf+esBfJLqZ/U+PfaGLQD3md5tMcF4IL4hU6q8F9YH3IJ2toYW2tujCr/p7Ei0+1gOg6DdY1uQp673+V/09iRafawHQdBusa3IU9d8SdntziuYAAgFWXKFipIdwx2E2t8FVAKQvwUsHOe29x4dWgDg9MXp80poq8nKp30XnXtG83FudK7GGAEKN/QfD1RAAAAAAAAEMnt9y/BJhJ+sE/5KRcLY15BDvDhf5tIXOJrmHDf1EYbSm4KIZk0G65puZkkVRU7uCP9yQqgAAAC9AgQ4SmXt9tURlQbnzNV+4c59Of6rtBec/7ZfLsJE7OdDJ9ByBnwyQgbM9hBRFlA7qotirmhZDw6FJxYBbFXNCyHh0KTiwC1cAAJujlUfJAeaveCA/LWAryEOP0f6nl/4bbtDr2uEBzR0s0fgNE6aN9/7Xo6AAAAcEdAmAlkh/+upIb87TJCzbrCDbdJtuk23SbbpNt0m26TbdJtuk23SbbpNt0m26TbdJtuk23SbbpNt0m2xmEhUnX8ABTKr1BUH6913HGBlUqNUy+gVI2lFOm4qhZaZkhru3PK+lN02+ERiQqgkmEeijeMRuuvfZmI3XXvszEbrr32ZiN1177MxG6699mYjdde+zMRuuvjMyqlCgEhcrgHKbl/Gw/uC5gvLUdlrct1SIikofOG6j8nd64seAAMg5ucVzMhohw4AAAAAAAAAAAAAAAAAATRXy2b9ryvqwknrYNw08yMWkB4FaMySjkCdOdIFON5MrJ8jSkTutK+gPa6PKwDTiTN19rMxsBbJKuf2/dYzskq5/b91jOySrn9v3WM7JKuf3IZSk8jKY9WgCqBIuNZaWlH/BFkOuv6teGLh6U0GXd2odjZWvkBoG96Gat/a9fOHu+IF8ZHy7E2gXqnp92YiQouW39r184e74gXxkfLsTaBeqen3ZiJCi5bf2vXzh7viXXQ6+WtGr99qhTCrup4GLJlukbQy4pF+ShDeHghE0rSAQAAAAAAAAAAAAAAAAAABfGTULbRow0f/89Tyg1ezAxKN+phrwFigAAAANE6uSAAAAZLPFwQP4rThXwvxVCt8AxntSH3+P4kgAAAALsxBgC8TpC3dEKq4BPk2iwwj9G96v1g6H7UsaJWeCjmAAAADf4ja6TEgyoFpPkl2ehL/x9FUivvx1Cot6r/cfePid1nu9tQAAAA');
 }
-:root{color-scheme:dark;font-family:Poppins,sans-serif;line-height:1.6;--primary-color:#cba135;--secondary-color:#8c6a3b;--bg-color:#111111;--text-color:#f1e6d6;--accent-color:#bfa87a;--dark-accent:#cba135;--surface-color:#1c1c1c;--muted-text:#d1c6b5;--max-width:1100px}*{box-sizing:border-box}body{margin:0;background-color:#111111;color:#f1e6d6;font-family:'Poppins',sans-serif;line-height:1.6}h1,h2,h3,h4,h5,h6{color:#cba135;text-shadow:2px 2px 8px rgba(0,0,0,0.7);font-family:'Marcellus',serif;text-transform:uppercase;letter-spacing:1px}a{color:#cba135;text-decoration:none}a:focus,a:hover{text-decoration:underline}.btn{display:inline-flex;align-items:center;justify-content:center;gap:.5rem;background-color:var(--primary-color);color:#fff;padding:.8rem 1.6rem;border-radius:.5rem;border:none;cursor:pointer;font-weight:600;transition:background-color .3s ease,transform .2s ease}.btn:focus,.btn:hover{background-color:#872000}.btn:focus-visible{outline:3px solid rgba(50,50,50,.35);outline-offset:2px}header{background:var(--dark-accent);color:var(--bg-color);position:sticky;top:0;z-index:10}.site-header{display:flex;align-items:center;justify-content:space-between;max-width:var(--max-width);margin:0 auto;padding:1rem}.brand{display:inline-flex;align-items:center;gap:.75rem;font-weight:700;font-size:1.1rem;letter-spacing:.08em;text-transform:uppercase;color:var(--bg-color)}.brand img{width:44px;height:44px;border-radius:50%;object-fit:cover;box-shadow:0 4px 12px rgba(0,0,0,.15);background:#fff;padding:.25rem}nav ul{list-style:none;display:flex;gap:1rem;margin:0;padding:0}nav a{font-weight:600;color:var(--bg-color);transition:color .2s ease}nav a:focus,nav a:hover{color:var(--accent-color)}.hero{position:relative;display:flex;flex-direction:column;justify-content:center;align-items:center;gap:clamp(1rem,3vw,1.75rem);margin-inline:calc(50% - 50vw);width:100vw;min-height:100vh;padding:clamp(4rem,6vw,6rem) 1.5rem;text-align:center;color:#fff;text-shadow:2px 2px 8px rgba(0,0,0,.7);background:linear-gradient(120deg,rgba(12,10,10,.75),rgba(65,24,19,.65)),url('../img/hero/ceremonia.svg') center/cover no-repeat;background-attachment:fixed;box-shadow:var(--sombra-suave);isolation:isolate}.hero{background-image:linear-gradient(120deg,rgba(166,39,0,.9),rgba(50,50,50,.85)),url('../img/hero/hero-placeholder.svg')}.hero h1{font-size:clamp(2.5rem, 6vw, 3.5rem);margin-bottom:1rem}.hero p{max-width:45ch;margin:0 auto;color:rgba(245,239,230,.9)}main{max-width:var(--max-width);margin:0 auto;padding:2rem 1rem 4rem;display:grid;gap:2rem}section{background:var(--surface-color);padding:3rem 1rem;border-radius:.75rem;box-shadow:0 10px 30px rgba(50,50,50,.08)}section h2{margin-top:0;color:var(--dark-accent)}.grid{display:grid;gap:1.5rem}.grid-2{grid-template-columns:repeat(auto-fit,minmax(250px,1fr))}.card{background:rgba(0,0,0,.6);border:2px solid #d4af37;border-radius:.75rem;padding:1.25rem;display:flex;flex-direction:column;gap:.75rem;color:#fdf6d8;box-shadow:0 10px 30px rgba(0,0,0,.15);transition:transform .25s ease,box-shadow .25s ease}.card:hover{transform:translateY(-4px);box-shadow:0 16px 40px rgba(0,0,0,.25)}.card img{width:100%;height:auto;display:block;border-radius:.5rem}blockquote{margin:0;padding-left:1.25rem;border-left:4px solid var(--secondary-color);color:var(--muted-text)}.callout{background:rgba(107,112,92,.15);border-left:4px solid var(--secondary-color);padding:1rem 1.25rem;border-radius:.5rem}footer{background:var(--dark-accent);color:var(--bg-color)}.footer-grid{max-width:var(--max-width);margin:0 auto;padding:2rem 1rem;display:grid;gap:1.5rem}.footer-grid div{display:flex;flex-direction:column;gap:.75rem}.footer-grid h3,.footer-grid h4{margin:0;font-weight:600}.footer-grid p{margin:0;line-height:1.6}.footer-grid ul{list-style:none;margin:0;padding:0;display:flex;flex-direction:column;gap:.5rem}.footer-grid a{color:var(--bg-color);text-decoration:none}.footer-grid a:focus,.footer-grid a:hover{text-decoration:underline}.copyright{text-align:center;margin:0;padding:1.5rem 1rem;border-top:1px solid rgba(253,248,240,.15);font-size:.875rem;color:rgba(253,248,240,.8)}@media (min-width:768px){.footer-grid{grid-template-columns:repeat(3,minmax(0,1fr));align-items:flex-start}.footer-grid div:nth-child(1){max-width:22rem}}small{color:rgba(253,248,240,.8)}form{display:grid;gap:1rem}label{font-weight:600;color:var(--dark-accent)}input,select,textarea{width:100%;padding:.75rem;border-radius:.5rem;border:1px solid rgba(50,50,50,.15);font-size:1rem;font-family:inherit;background:#fff;color:var(--text-color)}input:focus,select:focus,textarea:focus{outline:3px solid rgba(166,39,0,.35);outline-offset:2px}button{background:var(--primary-color);color:#fff;border:none;padding:.75rem 1.5rem;border-radius:999px;font-size:1rem;font-weight:600;cursor:pointer;transition:background-color .3s ease}button:focus,button:hover{background:#872000}button:focus-visible{outline:3px solid rgba(50,50,50,.35);outline-offset:2px}.table{width:100%;border-collapse:collapse}.table td,.table th{padding:.75rem;border-bottom:1px solid rgba(50,50,50,.15);text-align:left}.table th{color:var(--primary-color);font-size:.95rem;text-transform:uppercase;letter-spacing:.05em}img{max-width:100%;height:auto;border-radius:8px;display:block}.visually-hidden{position:absolute;clip:rect(1px,1px,1px,1px);padding:0;border:0;height:1px;width:1px;overflow:hidden}.hero.blog-hero{background:linear-gradient(120deg,rgba(10,9,9,.78),rgba(68,34,24,.62)),url('../img/hero/hero-placeholder.svg') center/cover no-repeat;background-attachment:fixed}.article{display:grid;gap:1.5rem}.article header{position:static;background:0 0;color:inherit}.article figure{margin:0}.article img{width:100%;border-radius:.75rem}.article footer{background:0 0;color:inherit}
-.skip-link{position:absolute;left:0;top:-200px;background:var(--primary-color);color:#ffffff;padding:.75rem 1.5rem;font-weight:600;border-radius:0 0 .75rem .75rem;transition:top .3s ease;z-index:100}.skip-link:focus-visible{top:0}body :focus-visible{outline:3px solid var(--primary-color);outline-offset:2px;box-shadow:0 0 0 4px var(--bg-color)}
-
-#testimonios,#galeria{
-  background:var(--surface-color);
-  padding:3rem 2rem;
-  border-radius:20px;
-  box-shadow:0 18px 36px rgba(0,0,0,.08);
-  margin:3.5rem auto;
-  max-width:var(--max-width);
-}
-#testimonios h2,#galeria h2{
-  text-align:center;
-  margin-top:0;
-  margin-bottom:2rem;
-}
-#testimonios .grid{
-  display:grid;
-  grid-template-columns:repeat(auto-fit,minmax(260px,1fr));
-  gap:2rem;
-}
-#testimonios blockquote{
-  background:var(--bg-color);
-  padding:1.75rem;
-  border-radius:16px;
-  box-shadow:0 12px 28px rgba(0,0,0,.05);
-  margin:0;
-  font-style:italic;
-}
-#testimonios cite{
-  display:block;
-  margin-top:1.25rem;
-  font-style:normal;
-  font-weight:600;
-  color:var(--secondary-color);
-}
-#galeria .gallery-grid{
-  grid-template-columns:1fr 1fr;
-  gap:1rem;
-}
-#galeria img{
-  width:100%;
-  height:auto;
-  display:block;
-  border-radius:16px;
-  box-shadow:0 16px 32px rgba(0,0,0,.12);
-}
-#cta{
-  position:relative;
-  display:flex;
-  flex-direction:column;
-  justify-content:center;
-  align-items:center;
-  gap:clamp(1rem,2.5vw,2rem);
-  margin-inline:calc(50% - 50vw);
-  width:100vw;
-  min-height:100vh;
-  padding:clamp(4rem,6vw,6rem) 1.5rem;
-  text-align:center;
-  color:#fff;
-  text-shadow:2px 2px 8px rgba(0,0,0,.7);
-  background:linear-gradient(135deg,rgba(12,10,9,.75),rgba(68,34,24,.65)),url('../img/hero/ceremonia.svg') center/cover no-repeat;
-  background-attachment:fixed;
-  box-shadow:var(--sombra-profunda);
-  isolation:isolate;
-}
-#cta .btn{
-  padding:.875rem 2.5rem;
-  font-weight:600;
-  border-radius:999px;
-  box-shadow:0 12px 24px rgba(166,39,0,.35);
-}
-
-.hero.hero-disponibles{
-  position:relative;
-  display:flex;
-  flex-direction:column;
-  justify-content:center;
-  align-items:center;
-  min-height:100vh;
-  padding:0 1.5rem;
-  text-align:center;
-  background-image:linear-gradient(120deg,rgba(166,39,0,.75),rgba(50,50,50,.85)),url('../img/hero/ceremonia.svg');
-  background-size:cover;
-  background-position:center;
-  background-repeat:no-repeat;
-  background-attachment:fixed;
-}
-
-
-.parallax{background-attachment:fixed;background-position:center;background-size:cover;background-repeat:no-repeat;position:relative;isolation:isolate;color:var(--text-color);}
-.parallax::before{content:"";position:absolute;inset:0;background:rgba(0,0,0,0.55);z-index:0;pointer-events:none;}
-.parallax>*{position:relative;z-index:1;}
-.como-reservar.parallax{background-image:linear-gradient(180deg,rgba(19,19,19,0.6),rgba(19,19,19,0.9)),url('data:image/webp;base64,UklGRnYiAABXRUJQVlA4IGoiAADQRAGdASqwBCADPjEYiEQiIYhkXBABglpbuF3TnL1xiHkBLloH81HkekC9N/eP3R/rXvj3z+6c5JUnl3+V/tf/h/rP5b/Bb9g/c7+hv+b/Zv3////2Af1P+u+dv6jP229Qf7A/t57x/+B/d33P/3r1B/6L/wPSo9h70Bv5f58P70/DR/Xv/L+5/YAf//gV/IX+A7Pf7R+XvP/e1PNSicfIfrv+e/t37Ufll8U/5LwZ4AX5B/Hf8p+WH5b8d1k/7YeoF7i/Vv9B+cf+I9HbUL6sfcA/lf9Y/1H29c5FQA/mH9f/2H3ffS9/P/8v/M/lr7Vvzj/If9j/Df5b5Df5R/Wv+B/Zv3o/z/zlexj9gP//7l364f/gEb/zZs2bNmzZs2bNmzZsuW+AvOpw4cOHDhw4cOHDhw4cOHDhw4cOHDhw4cOHDhw4cOHCvRksECBAgQIECBAgQIECBAgQIECBAgQIECBAgQIECBAgPqCyAePHjx48ePHjx48ePHjx48ePHjx48ePHjx48ePHjx4IfcIECBAgQIECBAgQIECBAgQIECBAgQIECBAgQIECBAgPqCyAePHjx48ePHjx48ePHjx48ePHjx48ePHjx48ePHjx4HrYGDBgwYMGDBgwYMGDBgwYMGDE29xmLFixYsWLFixYsWBu1LQal4En3+wll4sdS8CT7/YSy8WOnDhw4cOHDhw4cOHDhw3VEH1+G7pwWLFixYsWLFixYsWLFkn7/f7/f7/f7/f7/f7/f7/f76GuENxOJxOJxOJxOJxOJxOJxOJxOJxOJwpppbArpybzyPvhNfX3wmvr74TX17pSdY8JpSPCaUjwmlI8JpSPCaUjwmlI8JX79+/fv379+/fv379+3gsgHjx48ePHjx48ePHjx48ePHkPP+dObArpybzyPvhNfX3wmvr74S9orBAgQIECBAgQIECBAgQIECBAhudObArpybzyPvhNfX3wmvr74TX0q6IX79+/fv379+/fv379+/fv379+/fv379+/fv379+/ft4LIB48ePHjx48ePHjx48ePHjx5YNpMHYZDIZDIZDIZDIZDIZDHEWnKlgbicTicTicTicTicTicTicTicTicKZMmTJkyZMmTJkyZMmTDaKwQIECBAgQIECBAgQIECBAgQIECBAgQIECBAgQIECBAVtzx48ePHjx48ePHjx48ePHjx4+7SYOwyGQyGQyGQyGQyGQyGQqm56PIPbciSWwK6cm88j74TX198Jr6++E19fe6eGMl4sdS8CT7/YSy8WOpduJIqSAYMGDBgwYMGDBgwYMGDBgwYMGDBgwYMGDBgwYMGDBgqaKwQIECBAgQIECBAgQIECBAgQJmVhpx4+EKv037/CFX6b9/hCr9N+/whV+br7hAgQIECBAgQIECBAgQIECBAgYe25EktgV05N55H3wmvr74TX198CWZB/AiLctu3whV+m/f4Qq/Tfv8IVfpv3+EKv037/CFXoXib/vBk1LW5cqQLmlfov82Wwf9Xbeuemv2kWohmtk7YdSXsKA4dVgL0Po+LFiu7z+LFixYsWLFixYsWLFixYsWLFx3PAsktKb1YU7gtNVsQ69Rp12nf/Jubk3NxbETYlIE/TfrAJ7SOMdUGnCd4cSsAiEai+IE438OEX1oQrqu+ZOXJfFtT060AJGQ6KD74TX198Jr6++E19ffCa+vvhNfX3f4d2yNU8rR7TRfv379+/fv37c4/C22YpA5EXShAQM6OLWj30Fk0eiRGzF8t9M+g603xBYV+COkyDpxMZYvjq3tCFQueIPPtMWZ+e6bUrI1R2dt8Ez/niVLGjzR2uZAufsWo7/ypfjaZh9AeKCQrvXYtvoNsStECvYW6J7fYD2HmIqgaqDunBYsWLFixYsWLzO379+/fv379+/bouLFrIBR/PSn95a398j3hepIre1DmePiprvVynpN6c4F+lQp4Ek7g6P0tcaJUQjCrAMyKGQ5x7rAwKJOVRvqHWXRXxxVck1zhThn7KLcdzV3hn4jsgBhVhIByHSFLk67qE5sVg5mTzWTv0okgghkIX79+/fv379+/f7427fCFX6b9/hCr9N+/whV+m08adwvsBfrekFcltNq+QYksVpmRP2wWrlt3IF4B2yO9dHDgmCeokO61HzL43kUPSnCi7OZfNmLke6jAMhGLKKrbWMF5v1bj4AUTVeENgHI7Wvu06ENW2XD9rf3uXEvPNd1l+1cDYNRz4xPRB9tObQCf2+EKv037/CFX6b9/hCr9N+43PXr169evXr169evX4bxPou+trie3ju4qT1LZNHWLqcOHDhw4cOHDhw4cOHDhw4cOHDhw4cOHDhw4cOHDhyAinDhw4cOHDhw4cOHDhw4cOHDhw4cOHDhw4cOHDhw4cOHDhw4cOHDhw4cOHDhw4cOHDhw4cOHDhw4cOHDhw4cOHDhw4cOHDhw4cOHDhw4cS79+/fv379+/fv379+/fv379+/fv379+/fv379+/fv38O0INx26+hk3ZbdvhCr9N+/whV+m/f4Qq/Tfv8IVfpv3+EKv037/CFX6b9/hCr9N+/whV+m/f4Qq8/379+/fv379+/fv379+/fv379+/fv379+/fv379+/fv379+/fv379+/fv379+/fv379+/fv379+/fv379+/fv37/erSWBuJxOJxOJxOJxOJxOJxOJxOJxOJxOJvh6uJtlDn8//oZ4/tLM9pZntLM9pZntLM9pZntLM9pZntLM9pZntLM+rPXr169evXr169evXr169evXr168ZS7hzFZb4yKbm5KSbmDpWMzNs3NyT4LFixYsWLFixYsWLFixYsWLFixYnIeV9HhVaGQ++E19ffCa+vvhNfX3umixYsWLFixYsWLFixYsWLFixYsWK+OzKJw0vi0mDsMhkMhkMhkMhj94sWLFixYsWLFixYsWLFixYsWLFixKPYk245MOevXr169evXr169evXr169evXr169evXr169evXr16xaZdY3p06dOnTp06dOnUMcOHDhw4cOHDhw4cOHDhw4cOHDhw4Vq2MVaVWCBAgQIECBAgS6qzN4tFotFotFotFotFotFotFotFotFotFotEy2WY8pNFotFotFotFotFos9WbNmzZs2bNmzZs2bNmzZs2bNmzZs2XIqYcmC6fJcJZeLHUvAk+/1OHDhw4cOHDhw4cOHDhw4cOHDhw4cK2gdOYv379+/fv379+/fv379+/fv379+/fv379+/fv379+/fYp88czBgwYMGDBgwYMGDBgwYMGDBgwYMGDBgwYMGDBgwYMF+orPEY+fgRFuW3b4Qq/Tfv8IVfos0WLFixYsWLFixYsWLFixYsWLFixYr49G0ak+LFixYsWLFixYsWLFixYsWLFixYsWLFixYsWLFixYrt2AoTO1JkyZMmTJkyZMmTJkyZMmTJkyZMmTJkyZMmTJkyZMmGa/YQeuYsWLFixYsWK7AA/v9fm/ooqa8jK++XU6Q8bIAek+s/b3HnAwFaLSn+10SZhSUGdQAAAkYUAAHLEAAAADk+ABU2HnOykZb8YkrTwKsApGW/GJK08CrAKRlvxiStPAqwCkZb8YkrTwKsApGW/GJK08CrAKRmBMUlAgAAAAIv4ACc4f3D+4f3D+4f3D+4f3D+4f3D+4f5TJWZKzJWZKzJWZKzJWZKzJWZKzJWZKzJW02Lo1VEHgaFFkinEoVOO3+KMpxKFTjt/ijKcShU47f4oynEoVOO3+KMpxKFTjt/ijKcShU47f4oynEoVOO3+KMpxKFTjt/ijKcShU47f4oynEoVOO5wkxMAAAAGyG4AAAAARQO90CqsicIdgICAgICAgICAgICAgICA3CN7LHr6+vr6+vr6+vr6+vr6+tNQI3t3/F0qA6xUB1ioDrFQHWKgOsVAeEw/wABND1AZImAAAAAABZCAAdXwBv6W4tAAEjTgCHcQwAAABHDwALc4BPDmXV/BdX8F1fwXV/BdX8F1fwXV/BdX8F1fwXV/BcmnWAAA7Sf7cqpfOX29sXNi5sXNi5sXNi5sXNi5sXNi5sXNi5sVqAAAAE8IABxNEwQRl63N4xSmCX4xSmCX4xSmCX4xSmCX4xSmCX4xSmCX4xSmCX4xSmCX4xSmCX4xSwQvZ81mSAB3GX+8DfrICYYAAAAZKKDRi7QAAAAAGGEgANxoyKQCLoIGAAMZSNYAG4vjJCsAAUTBIshkChEh1xFIOw93ibkMucCt7VgnlaI4SZDYgojiK/lkdCJ9wl2rnMOxvxpE6/2TDXADaHnWnDNh88agVu3S7PH7LJQ0YIk6kKQ6xwszd5Wk0jamT15Z6fZwn7qWPQHO4wxH9xieeird4RW57j7/AbWKDEXdmHVE//jb53xZczU9ppYyeeDDdLi/xYjtHj66ll48bKvkt9a2xlvwPekhGAa6weeTI/5rHXA8P8UVyvEVc/JOS2h01FsSAFUaSPO+pUZ0JeKctagKw8ibTmW75NT8mGdHhFxez96OVbrJfwkR8HpIRgGuqYCvM3+CiT8cwPGvF7LX0n0iMqsoHToYy0kOYohmslUDvR3y6hgAMR7RcYiXdZnLb3uNPGeWg6AK9bXQkAWFde85yLS9SgFlqfLOsEgOLt3MNIYIvuzxIVY0R09G7wPsRDga8bPuER7kMaX8DsPTv7yc4dd78WDOv9kwckI9dvlEZ9BaHJPd76bkhoxskBj2qx+xJ3dDPF7haWmqdGRt8HyXvVQTHHbrHrChf607WpgiHgszVUKCh9adkrfGL8CpJOmMfq3YoJYxTD05Gc6OodBs+YWHOwnttnKcJbS8uOMHUIuhDxnOekmnozObEYq7eoGZ0Uky+nrOQ7BkYW2eWIMY1INwU0V6CU6cacXy35yafRB+nMW3ERXxMM6lOUf8ZFfaf/WkTacy3euk5zPoQoJGTPum+9EAiiK9/Jv+KVlP2SWvRMwchKcByPApnHXv+QqW2wkCQd92SalP2Gwo8G+rL2C2NV6z1rD9tv0U4fonYEtWfP+QAEjfdjt6Qzo/88wtJcTVEd4kJDZ2SnRgzeSNsdnf9+mocGIZAxiGwNUJ2EqGnnulA71Sv5EYC/bpiStrsng8AJHJg4LKzg7+vMNQLsLeUcg832H6aHcH7/d4zd3nzmL+rfxy4Eu8hauAk/13pmhT64Z/wqkl/mQQC9oQsq8El4MjZT66P0MtfVhEBNOiUwQ8j3rnsqqdCD2ffRtpMl5aihZMLHgCddd4cuqr+ezU5QBmvyEy0ZQ9pbX29RAkWpbCf7Y//6/Hu838G5tcX5Mzgv5PhVUR3pz9i/pcqyVHe38jZkwGGTlnat1BiOfAYOeeTKoO30KDr1qbTjDtXAT9BENzAkyI+ACOODtP0/bqXFSbSGtnLx+Qr9X/Iev4dx2/YMCPv0qQztlZPawIYAHQB7XPdGRERAMIoE/RoeOUxPDTWS0Ye5ci0kDZaBZliLNZ2sJKm3KYA11FD60cKCdMY/VwvjMYfRn8b2YQASRMzSsXW5idMcWQtWNaImjUltcN7sqMvfkAC61oX/csc69EH/BFlqsSHGgDfbw+ctiqezDADEHb3PL/yZZFigMpt8dmBGRirTG6ChORB/sjNQUEN8wFsaSj+ETdX9pcP8ixrlLo1NYG54OrHxgddJQEBuCVoMBYFJn/lfCoN3kjUB0+6MLq/86HDj6b39nPeeMZ/vzzWuNERgQa0HNdlfIyj7rjfrRLcaXS1X5TXpsrsSg8h/HwmdIJOyKc1xM9wSz/0v969PS8yLMcLVTLkNvQf3Zlglfp4n15364yHvpIaovlAXQWTRJK8B0SeTKsFuvg0Wlg9a60nz40aXKME3QNZCp0h0ZSExZG78SuJo0OeRsKiGJC9m1bmrI7Gtby+h1u0+O8mfDWkDfq+DZqHJYZFm/a4tQ4JAm9xaZ0SCQBX7CD4Tf932rnlzUintsOwOIQtXJGigIl+shH5Wu8Eyb84GshjwOg6ZNFEhjiS+2/VES1a0N/UT6fVWo5PnT/YcLg+BUZigGYO91A9u+FElRcUTPb06u/sXGJduc2JSiZLArQfDX8dkUXyt6pkIsnrMTvg9VOHicTL8oY575bSMUzKxTIyYcw8RZQpIffuhw4dR65N4lrbGiLS2mQWz5Snn744IcpwO8AEk5neWBPmsgTkhCuj37cAqGwurIq2IZfz02rIOkbn5nnnaj281rwJLiCzJmAZ3Ev6OKGW5iWZwN9L5fBt1/Nw14+n8hspJ1kWzK98xaWuJPKyPQxcmSD55vHx89ZWKXfRZshoeKeFHKY4B3kjliwoUAoUWxN+68HxZBspectQMTvnJjCnvfeLiF0Q6UClLvE8SXej2e+RR4uEfuxBBgwJzwdjqgWnXHG2Oi0FjLNdJmxwZm3k8nxJeq9fltpI7KSh19RK2bov+ichazJ26aj9gsHs+XejvEGtN6aNMiokL9Wi/CIgIikfX+DV+v0OB8Tkm0xEfx5CprZ0mGXwajf/qzsxt/0mp257GK1/ImnH3RvVEXLrhd7acGqA5EIChuE41QTqoiPeoKUIULCFQpT+DZouilBsk4D3pqCzAAA5O9RQWx69A0MM5+Xk6nnHD2tzUEM/LMuxh/mOxysxhfiquTKky7JDrcVJwnUmYKTMjTYXQYznLnwFcsNFfqs4ztXxE5yUc+BbIv4c6lAMS/84h9L1CINyrR+tTb2gMb7AownNFegpHBEN/OT1QwzX2yvfOzPS742zIXpF3TwM1H0pI9vY3XT5H6xwZDzXVJNn+/w/HXOStz9vmQ0qj/Sgv0g/YCVmuv7FEsbndOr+VNm6f8lRYQuTDJCORpxbO+wTEEWs/rnvJGrxNfwC+Uex29jGuhlOFE2OACAI1/oOSvf/sCX/NCKvuZug+pfdyOsat33nA8sqNViONuaNM/uJd8z/51Weoa3WqkGX/bCCmGDffg6tZWyTxubny5tE9u64IYqy8gp+9bq4SySnCCBA/1hq8lcn7zGPCFX+BNz+BuJNDfb5yBDbdeD/1JT4Tw1+ABhTwHUa974k/SgpbpH644eBmDeX9u5JkN0+WzMpQrbKuK8LKIXBo+WaS99Fdtl/rDFxgXAXky9TYmqKRtORvxhMWHVU7u4ZWJ+X2MkGDpF5WnFdQ66cn2k5leENxZBzg+BVn4hAGk+wrb9upN/2a/f6VhPKJmubBC+sX58I+15KQija1qmBRbtNk3xdVKW0Cl2ayQ607OXL0mmPL2Rnva+00DuK41//qyl/aXoMi8oOGWOnIENn3OTi7P3iVsE1Comf73cpXTosGTnodtIPK7UTGXT11oXIq0NTjb+dFeq1Nf+yLVqkyYEcW9nKzfMeIYDClqJwLLiUZGNZqYDWPw0aDbZE/E2uLogMGuu84djiIMylaWHX2STY2ASMtg2Kb1YB77kl9Sq0ml9AMLg/WFO1o/Nxkn35ptcGuIfIlxNBnyKZQch7q0Bs6Anjup6wQp+l3WNSkVySjcrxSgZi1vY71t2/kTC2EV0EdRy/eoFX8M+hkHUC4wZvfSyUgef4JyHxMo/8uL5sZxzJA9wip7V+Vj8ywDaUXPJLqap6mftzgtdve6jkGA9glYGvmn9eIeOFozDCVs62FDPP51Kvxm9pMRVCuoG6Q1FvM2Al+5Vb72mvZxb8U1YG5emmwZj3eQcPzhXKsswjunpiOU9DYUteKto4gE+TYaIlwBA7wjYbbBqcKTUcwOJkqKHayxVL0kiSHeMufrMh0LpYoglOkZIyba6ik6R6QSsUQfy6PuHyhgKVeG2ITiPka4psknngN/nmUuCtLwMxpOWbcunofK39xfyBzb83th2Waw1kyV3zZiNAEDErTTfqMCdQIxzUOeW1HX9Fy81xRSAUfnRK6+8+6y9fqWwYYj1EWPWUjf0DBawa6WaIO5NKm6SFXa21JEdkTk6uSEIPi37a1qMIx8K1dMb5h97Y/CUPmScCQaQ1ptPr9lehhEOdQuNUJTfkdjzvIAjOhF0t0ocBS16/zdAFTTrPwQsgZDB15yAw80PrFNlPDd1yQw2XlssmQtkznjPmSB0XRU6I0rFW2hL1BQlkGYPEHATc76WU+w77aJAKiVyGhGgFlF3u9zewRYh5qihF9uS2B9b1U8uxaFdzNtHlF81TZAuzMG2NrHGXs9lm3sUN+mBxEYdg93MswtpCb89l4ik8/n2AZFIwNbeANc5rpZwbwxbjdd3wwQt3YBf6uNrAjVNKa60FbNqUf2iJ1N7myuFbArRj7KugwZy4QIZKh//gtpCExLkI7kyR6lGethEzWBycQz3b5YMhPV/8d13IXa9YpfCsiXLEbzqz58lykol9b7szyEECNZmaxQnFaumOD7aparoDXPrIfm/u33oXk34FbQxrYsNcloRP/lt6XX6RFYgs2N85fWuZtrUqUKEIzGVaj5U1Az+3gZceF/AWfJ5+lSeqM+/jBMJsHFFlsHzLJ7VIxho/FlR2JClvV7s2Hzd6y6XOJe+9WHabANxA70yTspoI2X0/bcvGqXu7+RP+tq4bwANxe3CykFf1JaKWuTE/kT88niOy2gidsoIDZbnf8UAVTadINOFZP/Ebxd1EEep14hWpeBUaxFeRcNiLhFJ8unbSexlfZZiWlEnCPdKYDUldnASn5tiKobpiY0Fkdf/MRTSMDsgvXNdc9xxJpczikPnKe8m/ZXnXtNn2Ejxxgxuo5KO934YD7wwaJtyz6kRPhgvQpz+exZ3rXzpGElIDQ32dwA5YVuvq6w8JyVva30MUG8lPnJwfSfoCJnYnZ2QXGdz7kdbs8BD1H9m9my2q9Y5hoNVKJErECDsbKmsGzLO33bpTp5wGD7IuTWs15XEFNSAFVtJPkZwDxKNS676FE9V0gdpZb2kAdT/5sVPem26HxwPQywehky5nLuzRbIGRiiLt+Eg4Uf2z1aPaP2MJbP9WtVwtetF737sXNjKXaPnKfvGbYnTOfS4V0LerO0TsBvVSeExE7uyXovHWaf0aKV3U91MxjPRuT5HMBssp5I00Q9Hk0aQnyFCbYi5tMK1AJDdZV3SEOwEBAQEBAQEBARHtdz7E35StrktEBOoyheDfcumuOOnH17nlpqmPNG9/jaS6kME+s1+hvTBDmUwy2ycf867ePpRhAcOHmu4J8Fpot8Q2p8dHjfN2+zxiYzIVzFM55pf9v9djqxPuDgceXuqdsGFqKtt+FSp3lA6Ah1SSCyXxE7pCxpvuh+r0Gqq4Kjksjkn5smpNtwbREg3pbxSsJiEZpa7ACDmBudEvQJ4Er5mT5BMnyG/t6f17LwW2V5M4LEkrbhY4q0wwF2+7Qs86JNvhQwU1vRrpDzb0L8yjsC2Yfr8VsP1EF9yxKz/En0BghbPdxLK8BD1lDcK2iOofFnFEPtsfJLA1liMxC/NZn3rMulzX3DCQhY0GEh0Lt3AyWuwavpq+x2zzJJcKL0ixK8Rg+O63SI9l/Kqh1Aewftp1uwcAJ/zjcPlnYcWRMcU7gvVGWFGorarUllqaeamzMSluqughyFPbF9K9Zfq5IY8u6DwDRP6+CLXyNQvSpsrqu2ixRrGj6hiDKJvtfVgh7+4M6tvNhAd+4KqtI4br5dEz81aNg/GNt40q6WDBGd3ltaekfGBH2Mu7lh2aE+Rm/bmvMt+IUADWn+mOzfw214o3Dm9zc44CNtwP8ZaCsTRKeoZB4o9T2qcDH1Vn9YrLYKbA7sUilGYTkcPpmmW/UCIko+v8dEmwguHqNlcXqm90wYH7rWymT6D1kotQEyDR0C4dsfKXmtr8Tf79C9ytl7xc1d0sJ3MsKaPpg4Lc1qbTfI9ggFdcPIMSZuCCfq1hF0Y/AhiKIhuLvc8VeT//ggmrWT3onBjYMXrKlMoc/36gfebeDfNvl/Z6KvYrYmB3sRQ+XpZre9yh3ECeVOtpEaiP9LyqS/O+UMBILWr3gfzlNAwOS+O5JJaBVslPpLvu3+wDDhGEgls6jyXv7UTG/ql79o2Se1PjmPOHVnXATNPNE6kdJ6OjzatzvIG5KD+jZB8V8tGZwrpQTARdmy3CqyjEROMACrTrWn1sPknHMIP6nvXu+pPSrqYOzPx/2CVlfIMNNxIA8NguH77Qz4ELSpGcYk34jhSYKi3xqYizRhQa+oogYMDoACViND/ZnUek8WXO7sncuOQpBoviczf7/Kc40881F9MWB/CICcyGkgnnUop0YnEAQfYRqjFWyr0Pi9bZJ6JNrQCIyqC3Y1Cab7hXP9fKi8OARhc+6l+OwzF1m+uO2BSqiZsg7OB2s8eYahgbVXnmugnIPB92IFF37hfSQzc+EBmraE1zv5/UQNfI0bTElVVtQAr260LyxdOnkx/icmDx1IYd1M5PKL3VcztiAkzNRQgICAgICAgICAf/gAAAAlRPgatVM2K7Hwz1t91L1uSaEXgNBN3mZDvJAHxRn6P6ONVpaaDayxKjpLrbthSHHO+RKYBXYqIXAZ/NbCT81Z8vT/DZfzM4oNMfpQ226F1Dax+EgvpBZibDnDwMQAAAAAAAAAAAAAAAAAAAFE4/gSCs2IFZsQKzYgVmxArNiBWbECs2IFZsQKzYgVmxArNiBWbECs2IFZsQKzYgVmxArNiBWbECs2IFZsQKzYgVmxArNiBWbqcAnI3oOdgAAAAAAAAAAAAAAADqdc4AAAjGI93b1N8uQ7rpvBf/RKGC01P2dQ2IS4K2+AmBXd8xEzstFcvBXLkVU/tW7OqfbKBAqSpltivgo26iY/fUiwZhPUWSEDlECo/Y4SRNkVBRAqP2OEkTZFQUQKj9jhJE2RUFECo/Y4SRNkSIAAGVgx2y61l9m/d4/7hsxFW74QUUcdjPYalBahrxLTUxUtJo//jpD2dThVO1Vmqjy46v273N+3e5v273N8AAAJk5kmSW9ns+nhigHoLw4lJBPX2UcflvXn9vKAQmUMNGgdoZCnr0MuEL/G6M3Q2eoKAAAABeCLoqrFzwdCLK1FssjXw+jqAgkzmRvK/rWDiiYUdbYVM1sLgBPNiMi30sSoAAAAABtDwLXuJZfC7Q9W2xvGndyLm0iVcMlA4dTqubQr6MQCL6fSwfBu8+usGHtKeimH+KqAlMP8VUBKYf4qoCUw/xVQEph/iqgJTD/FVASmH+KqAlMP8B+xkH7GQfsZB+xkH7GQfsZB+xkH7GQfsZB+xkH7GQfsZB+xkH7GQfsZB+xkHu9osYAQiBoCmgsyJcp2erL+BKjmnh2Dfrd6PW6+fCmsy5mx8jRBOo+Wr3d3d3d3d3d3d3d3d3d3d3d3d3d3eF7QAAAAAB7eMI8JBI88DZjUUoYSpRuoWkQYlevAdxoc0MAXc1khYbTpNAnUyG7N9OAIAAGaRvVwAAH5tR+PhlGRk/dd8VTO6voUFo9NHy4pPey8IePVhLqX7VVR6ylnJHt8Bjl7AvYF7AvYF7AvYFzwAAIJocjE/ViAkJiYeCJobglyi9QTEvMwirJCJfF+hj5zRdAAAAAA+oJk9cBLE81G1Hfvp6tO7TuQvRN7cDjtK/66qvQoHfAAAAAQ2gA+G/Z7ssLVojTmLXgpmvxuXO/OAAAAAJYgDDNrBvr6+vr6+vr6+41YAAAJUo1b+XLWUqNEEL5wDJFsL0ZfjgAAAAC1jkSYcIAgcvZISQzFSDFtPbAkpGyq7t/MEsC+DDiOpw9AAAABQoFqSvOvHbGXs1lMBFJYqmPfy/uSitks2y87ZWhE23qdIfh/8P/h/8P/h/8P/g+AAAA==');}
-.politica-reserva.parallax{background-image:linear-gradient(180deg,rgba(19,19,19,0.6),rgba(19,19,19,0.9)),url('data:image/webp;base64,UklGRgwoAABXRUJQVlA4IAAoAACQSwGdASqwBCADPjEYiEQiIYh0dBABglpbuF3TkT1xiCLYuz/R9wPB/Nb/g/3E6n/uJhV5rvPP+9/un5ufL3/B/9L2Ifpv/Zf1z9//oK/W79dusl5iP6P/f/2I94//i/rd7yv7N/q/10+AD+qf7H0p/ZP/cv2B/5t/0/Td/eH4Yv6v/1v3f9r///+wB//+At8W/278mfhr3efd/7T+Nv/W6iL195q/Pvml/FPrv+b/t/7Y+v39b+x30j+R2oF+PfzX/G/lf+VXHB6J/q/QC9v/on+o+5T0oP5H0H+w/sAfzH+w/6zjYftXqAfx/+4f9/2Uf5T/pf5f/If9b/ke0T8t/x3/e/zXwGfy7+sf8f/Gdpv9y/ZL/Z//4AlekNgt8zSH6pDPfLD417ZkTc70zSH6pDPfLD42C3zNIfqkM98sPjYLfM0h+qQz3yw+NLpR3zNIfqkM98sPjYLfM0h+qQz3yw+Ngt8zSH6pDPfLD4nIXX5pD9Uhnvlh8bBb5mkP1SGe+WHxsFvmaQ/VIZ75YfGl0o75mkP1SGe+WHxsFvmaQ/VIZ75YfGwW+ZpD9Uhnvlh8TkLr80h+qQz3yw+Ngt8zSH6pDPgO1Wq1Wq1Wq1Wq1Wq1Wq1Wq1TntpoI/VIZ75YfGwW+ZpD9Uhnvlh8bBb5mkP1SGe+WHxsEejsmlptNptNptNptNptNptNptNptNptNprDLD42C3zNIfqkM98sPichdfmkP1SGe+WHxsFvmaQ/VIZ8Ctu3wpmGvHwMm7Tj0CRdlt2+FMw14+Bk2o/pII/VIZ75YfGwW+ZpD9Uhnvlh8bBb5mkP1SGe+WHxsFolR8zSH6pDPfLD42C3zNIfqkM98sPjYLfM0h+qQz3yw+Ne5UfM0h+qQz3yw+Ngt8zSH6pDPfLD42C3zNIfqkM98sPjXur0hnvlh8bBb5mkP1SGe+WHxsFvmaQ/VIZ75YfGwW+ZpDrcO2We+WHxsFvmaQ/VIZ75YfGwW+ZpD9Uhnvlh8bBb5mkDB/VIZ75YfGwW+ZpD9Uhnvlh8bB7Pj9f5VPcb4mrp6atp54Lfu2mgj9Uhnvlh8bBb5mkP1SGe+WHxsFvmaQ/VIZ75YfGwR6Ud8zSH6pDPfLD42C3zNIfqkM98sPjYLfM0h+qQz3yw+Jx4Smm02m02m02m02m02m02m02m02m02msZFFGb/lAVpxAUtkddp+mW7G3SjvmaQ/VIZ75YfGwW+ZpD9Uhnvlh8bBb5mkP1SGe+WHxOQuvzSH6pDPfLD42C3zNIfqkM+BW3b4UzDXj4GTdpx6BIuy27fCmYa8fAybUf0kEfqkM98sPjYLfM0h+qQz3yxKRrb9Mtk7SXblQbLtyoNl25UGy7TopMdIbBb5mkP1SGe+WHxsFvmaQ/VIZ75YfGwW+ZpD9UhlqriWHxsFvmaQ/VIZ75YfGwW+Zn7TcAiQFnRhoA39wXfLlp4DmD/n0Ww/q8a5vgZ+yvtJVrZPScG1abE3BaLR4mv1vyGgzx16Qz3yw+Ngt8zSH6pDPfLD42C3eQ1+iZ5zpFbYV8Y/ItwcrCvM0h+w/ODU+UV56ACV4dNz1WO6Q+AhDuLmAJgwdeSyt3asCfJNVoiB3Q2NrMcFK6ETohrFwC3kQyxWhRMItz3yw+Ngt8zSH6pDPfKDcq7D1bfWYkskuEGwW+ZpDqcnMiVCz4rIvrEeaV9/Z+etWsHMybft5CHoKej/2CiFowGC6vEbWlm+KxtSrFPiCM57xg3HXTD5sFu8w0D0XtlZlgSWMe2LecSfqfXBDT4tXfiJoLfc6GImPl0eSrsoU/68KjNLPWikMBHQFd4csZVd73MFFEmeFANnZz9NYfV9JIAzpwKt/NnbH8mzSs9CyGnZSQ2C3zNIfqkM98sPjYLfM0h+l6Be0ptesu6CD28v27TgcxF3XG8hCDAXEFr9/FFJ6H/AneDH+nxP3nhE1wT4DwrclLR5eEoO11L+irI1iGExW2qO4WURSn4qgPHVS6+Tqfpe/O4ZQqPBzjHchorR6UVu5W7i8cb57PEUs+JKsdRFsP6rjbGGZkhlupIC0qIdcpqrKZAEsr9Ci25rV46qRNv0YmWBfRje1lNmwW+ZpD9Uhnvlh8bBb5mkP1R0xdT33APIri1qF23cHTCaS/CsaQBkzMDnUEF/acz2G7v/EKG7mgMQ/2XlKRk9vR+aC7/EuXfnrvXdV7Be/8lMIvoy4FEMv3kDwzpofykJX8kg86wonhysGefUFjOcLexw5ES/y4yuQCxT4wEZQp+zmAa2pLL6CE0K/AlgaL+nlE32cTvchYEZYQ003Yp18t0wHP/4jrD42C3zNIfqkM+JZcqDZduVBsu3Kg2U5BSwQRWZRu/ZVW4Gx4ALhE5KdGtv0y2TtJduVBsu3Kf+We+WHxsFvmaQ/VIZ75YfGwW+ZpD9Uhnvlh8bBb5mkP1SGe+WHxsFvmaQ/VIZ75YfGwW+ZpD9Uhnvlh8bBb5mkP1W9bk5Gtv0y2TtJduVBsu3Kg2XblQbLtyoNl25UGy7cqDZduVBsu3Kg2XblQbLtyn/lnvlh8bBb5mkP1SGe+WHxsFvmaQ/VIZ75YfGwW+ZpD9ZIuJxOJxOJxOJxOJxOJxOJxOJxOJxOJxOJxOJxOJxOJxOJxOJxOJxOJwp75YfGwW+ZpD9Uhnvlh8bBb5mkP1SGe+WHxsFvmaQ/VIZ75YfGwW+ZpD9Uhnvlh8bBb5mkP1SGe+WHxsFvmaQ/VIZ75YfGwW+ZpD9Uhnvlh8bBb5mkP0tvrk9xacOtX2ucAzjXOAZxrnAM41zgGca5wDONc4BnGucAzjXOAZx0i3rcnI1t+mWydpLtyoNl25UGy7cqDZduVBsu3Kg1/g3gcP7nnDpb9OPQJF2W3b4UzDXj4GTdpx5NfGwW+ZpD9Uhnvlh8bBb5mkP1SGe6HnQsVM4gfqkM98sPjYLfM0h+qQz3yw+Ngt8zSH6pDPfLD42C3zMSKGDkljR/5QMHkDk2guJY1IZ75YfGwW+ZpD9Uhnvlh8bBb5mkP1O1G9RxReVSGe+WHxsFvmaQ/VIZ75YfGwW+ZpD9Uhnvlh8bBb5mnDwWEud/9Uhnvlh8bBb5myG43G43G43G43G43G43G43G43G43G43G43G43Bu4ezIGfJ+Q0Gg0Gg0Gg0Ggz/TQR+qQz3yw+Ngt8zSH6pDPfLD42C3pJSJHSe+WHxsFvmaQ/VIZ75YfGwW+ZpD9Uhnvlh8bBb5mkPu4Jl6yFmkP1SGe+WHxsNc5nM5nM5nM5nM5nM5nM5nM5nM5nM5nM5nM5nMxc8znknnX5pD9Uhnvlh8bBb5mkP1SGe+WHxsFvmaQ/VIZ75YfGldPXTQPjYLfM0h+qQz3yw+Ngt8zSH6pDPfLD42C3zNIfqkM8faztVqtVqtVqtVqtVp9jpDYLfM0h+qQz3yw+Ngt8zSH6pDPe/KlTg9TyCP1SGe+WHxsFvmaQ/VIZ75YfGwW+ZpD9Uhnvlh8bBaD34wzvmaQ/VIZ75YfGwW+ZpD9Uhnvlh8bBb5mkP1SGe+WHxNGVis0EfqkM98sPiYAA/v8cy/c6J7qs71z7nrZQADH/r+o3+XJ/pu+ftvIGhGxU1kjkAAAAABVn3nqKAAk/Ly8vLy8vLy8vLy8vLy8vLy8vLy8vLy8vLy8vLy8vLy3fAAAAAAAAApCgAAANLgAbzE6vGhIRT4TQkIp8JoSEU+E0JCKfCaEYcMAB87H0z0TeN43jeN43jeN43jeN43jeN43jeN43jeN43jeN43jeN43jeN4/YAAAAAAAAAYRQAVfrrFAqHI5HI5HI5HI5HI5HI5HI5IQYs94ABJY06Q6dIdOkOnSHTpDp0h06Q6dIdOkOnSHTpDp0h06Q6dIdOkOnSVdqOTCgAAAAAAAAdx24ABj7jAzp3Z9Id2fSHdn0h3Z9Id2fSHdn0h3Z9Id2fSHdn0h3Z9Id2fSHdn0h3Z9Id2fSHdn0h3Z9F+sx8XP5HZ/I7P5HZ/I7P5HZ/I7P5HZ/I7P5HZ/I7P5HZ/I7P5HZ/I7P5HZ/I7P5HZ/I7P5HZ/FAAAAAAFXLFAAAAAAAAk+/XpA3POnfr0gbnnTv16QNzzp369H2xgAIGXf88y+8diCdoKAk0BaaCgJNAWmgoCTQFpoKAk0BaaGxilc4TrAAAAAEgOADeyLy8vLy8vLy8vLy8vLy8vLy8vLy8vLy8vLy8vLy8vLzBTVAAB5ulvRH8zL9u0KOgjMk0ekv9Mvhm596WAdajAAAADewAG966yX6gGwQbYF0JhLJMaEwlkmNCYSyTGhMJZJjQmEskxoTCU9LnOurrs6SrJjVs6SrJjVs6SrJjVs6SrJjVs6SrJjVs6SrJjVs6SrJjVs6SrJjVs6SrJjVs6SrJjVsseJOk25D5RqfmTbjTVWl6Xpel6Xpel6Xpel6Xpel6Xpel6Xpel6Xpel6Xpel6Xpel6Xpel6XeAAAAAAAAAAB2mAAAAAAABA6CqZVe9k/XfrvTXXkUkpzJuUNc/qD0MgFyS/Awf2nSUc9iIEmYclbFZHKw3H1uB6MtqFcl1hQ2NQlXwDPzF4ZSMJOCzRurW5axAQ5Gh/opkVpr1x52sQVGwdk2QgAXp8osMhtBtFHF9gDrsV/eipj2H/vKUUlfxV5A/dHTAGdeqrRwBbC3V/wmX7tpbhbyktc9edKA8ETFdXmA2Qv0m791uOhzFZpzL6qGJifvJTpWyNihLLomRp6qpfaEqWWDtswIhbFPO8vlrvl019B+YfaATKcIEHjoZ/XQodMRk3ScqipNwqOHthB0fhu7kFpv47zg6Ljuk0f/4YIvfBd/YjxJ/48oqequvdTxDwtOPCqESejhf9+ThGTXT9d+u/Xfrv13679d+u/XfrlkTbRwACY3SG6C4hQdxwX8R6DHTFlIUspy6d9X1kNhLs9m/pVZqlUcZprL2biC40hsIZNhQYyjmwzdNCTD8zR5caUsQNcwibE2xqIj/S/78K2jghXZB+/ifp6rB272AWpSkic1siHzF+vqTE5fEKOV39WZaeaa/zsOzOmUZK/qKLki9OE91Hkm6bLaNYLf6g1uoFUuWgJ+e1zDQNl29KaYMmG+zWknVCayZ4iK5Th+j1ejdgjwmt6UFxBqVv9Ofjfy/bZdTl4f/86/9FQb/o+7Z3kDld+cGqarm98KZpRkQAAAAAA1YzbMP+OY1hbo1BzfB11LnrMV6blPw3iwOzcu7sb+Q+JnHz00O4ie/gh3jefJOFl5P8Udoo0HdQ64FBIcFYvrLzZ0lECNqpALj4oy/iDr8/nyf6exeA3E9W1eTxmUnyQvrOE+oc+EjfOdj9n1IwNcpBm7NBk1elhq+zhPOMbLWTJyvuPnOYrCtTG+Nz7gZW3fbhVybqPVmAvJUtNKpmvDvVwW/In6VutEWMj0xi4feD3ceM2s3G62z0AMJWNP/zCIPr6ui7lijFn0A5S5MrPo04913KsjAYHrRglufKbMxxZPO6mCjRc9bMwwjLZUF6gym/GNzt3+tSjpk2wAQ40ALSk+SBknt9wuIshvtQYAp0vQgShBh0B7fZz8oKUuL61lwyIhfbu8O9bNFcrzuJ0Sr+px5hvE50b8ZNu8VMV5jVvzD3uwvjy02CuEN554z7ATMCwt3sYp3GZv8hioWCc7hpet2tBUXrUpGD8L/cktfyU/GAR985NJ+ZbZh0piSRqrNE0mHsEWar36o1cx/wZ3fJWHSeZ+D7QbB20FXg0bV0QP9FQ4aLBLyh12aPzJSuE6vthD3yjcZbQYMuJW12dZnYAQV2s41zAmLjEYKvCDsDMrUeHAuVSP/jObBe7GI91/wjkaeEXxKMqBD8ony4DQAAb465IoO44L+I9Bjpiwkaf6/oW3alqx74iAq1fEry3pVVl6/MS4qacPZRaW/511ntCXtHBA0WCzCUphLYSJ0rbcbmeveYoZgKAPxIGKat+BvwoJzzKS3st39jsHm90EB9QAAHa7yz2IZuiC1YqISrwQeTwNYhRPN7OFbG28Vs1tpOdKVFWhPVRN61tOU3m/3KrE7tMqiWjNrwVz2x+c3lgfbOAcS6vZxXtjymW5/CxzHuwMIUttrBGE9ZYbZhS2U41ObFm2vDovLpSfuxGxOWCwpiLXR42JqdtGYOnuSR8xdTN9Q/ltBAVKLxmwus5/8ilz6FA/H9n8g3PQcIgfU4l7DsVxCqjWVGa7k34oKNFiH1U02mmKD7KBMxXbWsb4d4CdyeHAloOnMnDAeVgoAZjB3oMWkumMI/Hoz0Pu1n/bDhBH1KQJ2sHV58J3YuW7baTIYjNSv+QHFTRx81vexi/+9pSU/s/Zu1RKsNsYnhvSQ1/W4925pKAO7MYfH/mnAwrpt5Fc6HEckEqowigG2xpvD+5ZamUS1Wv4KDawaEtr/+68rmpfySH/ocWBfpknln/Hy+Ge/PfVqTKAZ2uymPvWnEMQiqC1ED7dz5Cpg18e/QMcvHYQI6Dqi27Kj4f2LwG4nq+TuCb1JDzYFlD1srxU0g0dTg2SfnpJc47vaFKTq5AkNO4VQBYTP5xuYzArc+oqZRzbHar8zpaoF7/5Sv4o7A4FxBwERHRs1SbvlOEjPJXpQS6Ta5mWokQf4DOXDmpMwBG79Pv+TiXT6T+R/s0fXpGGqBX70b/+94AUn2Aeu7lcV5wj5jtioniBSB/apjKxJ+qN5Ti+//gWHfHq7pAJ3wJ8wimFqaQGeThvbHH63wu4P6f1LDpJZ2hio3wOeYqlQzqYLX9ugPUGdAcVTd7WGvkMiiHcvLVJ6cG/qXDO6k6ym0nqrX4194FHwZvr0eP5zHuTt4LDTPhX+cLBsmX0Rmx/GkF9jb3is2ufFGzhB/pOyG7C3pT9oL5KC5JL5yHZ+9nt31WeX1vqsEFgPXkM3xbJYxQyYWZm9fyvgcn3pehtsfOphcCFD+LEsPG+sTPPuV4vvmN0PvqCgrDZEKjgOV8+hFlc8IYnnMfjFxQ4MF10m8/9hyPh6a8NlyYGAff4+Drwh4spnkw9xKlFFimvLu+DQxMM6wnTfnMcpeDGLBZBtgLozxEp7TnmJM2i9MsTKQeCt4HNsAGhReAdFJllLpr8Z7IKv4VwTP4Hlzx23q0Z+F1MWNNavH5/Brtu+39r/y1y05QvAccp6hMjgv5pANXm3/Oo33LpWnwUVieQgMSbTtWu7ASRl1HFb51jOKYj+ONVKclE6Oo4/W2RTZ5bPnapIo9/3Mu2LUZ/7e4X0UKh1lbdsQb0SjX36kW/b8asyCBxyYbQ/U5F+1xYVYNHkNl5tsnCFXPxDoYYI5TUq7Z/h1lHz5/Y7zqog5HG2/+YuimW87bke9id5I+IVOVK/YTM3WiydAbI/z8LiuAuQJv4dth/8g8h+HRYQ33VP2HyeGCYaItswALozLP6DzcGmdygqMx4XSb61pSUPzkjw81Hmet4WOHv/R4sbnXj2lhM0l5liph7U9hVFjnLlsCvXhbKjx2/ZZil6rP5Drhmf9EZUFdl8ODhFKIpZ1IfZSL5zB3H0JyJJqQWlAZYxZ18mjZVN5dc9wffbshEmb7WzIuIqURGYDHrH1ZMJMzBBe+5RK7Pz/7twanUQZ+Bp9Le30/whSJjQAK1ua9RCU1F5OUP7pjmXEWUj5V6FLGPuDpDArttv3hRgiL5CsrGh3V5BGvykt2jhEwrwkKWxrMi4WnKQv26QTul1oq7WnNZyptLz4F+U2I5Prlm6kZajiCtn8gUF7rQOICpOORjyBpcgAkUB6mdCPPZVreM1brC/qrfzrHx+/g1n5qxhJpZ+8yesq/065w+wloCp+/42TMz+msBQTT64ucv+I3qH/aA63k/Iw5U2KR+VaAwh7sliOZbnxR/mzVeV9MgzDFuWND6SuHHQJVz5RvaJ6zPl1nBYxqBIRSaPMsvg6UhSlgHNHKq9gTpjEVgVbac6378twElQVxUgbtm8gAV2obCyhpj7LM2klGZv+vhJUnhOQAZJXpheQqPQCSWmbvdxs6fnlAcvmfgQouSx1qpKZdKkwhWYZfaVfho0wT3aXf9KaoEeNSjNv2WSDMxngPxDGP28a5Y2O/j5pdAfgfUw9Y8j5UyNtPB/zzWeXz2xdHFT1SUddZB2JZ40/6axrWkiWgY6VSpbxZq1kfnBb4MRaEQCqKgcTRtWh1oLWewChtoTrhYwcM7l7H791cgDqD9zwApAZqU0WqG4MNnvK/zx5iBqx4ksXQ28HSn4c5AL7RGzDDFqgeaySyy8hi7FWtRPz9KXOQi8/LmqwID4ICgZg3tXNM/Fq77ai6z2J+F2GI/Qtc2WaSxaPt+OFP/IGCJ0K32ZVqe4yxU++awGt7o213hOC1NmZrRyUkRe2Vt2yVGs5vqe3f4TwyvRCdXoFbI6z+ADVGzXpPpf+6/mqR+nvE3Ezm/QQGqkLIOtO3SITHBJDr0sVCMaMbMWF46YBgCEOLTZEUnGrq1sG8Pfwcl3TxJkLatlaIK645YLEAgf2xPbv6SS3N9JdCw+tq/utmD4VgVZ0AZWQvIDfEk/838O4/00j4ObETid9rS/uZaIE/qTEF7NL7p0p6Vw1NK2bjhnH9TBFje0P2sBmnp66KT0XJXQgdKYGdAUfOXNl3egCFPzmMu6fLq6e5aZOFk8XMaTcwpy3RjYvybn//5koUjiG4+VQvIYeiihqcu46YfJ13YZE9LIvJ4iS9pJ4+A0NLKs8H6YSyzcaGiWwNrg8Ju6awQ3IyEYeDfQbs9Xc82EKVNM1n6rHBbDbVtZRnCgxKOo1HkVDJQjsJ2C7T55xifbPuwdV6S9I0dZf4p/+LpDnQHWCpoj3XNhzSSX66g5qootfqOL/OqsYt64fzkqmNHsTCgIf48I8IDEbxzscgeAb139x3qR36rQM+wo+dyxRNeEcSrrshVT9krYVC5q8p09MCc9k3V6tg4blgXDbf+MB/0vl2oOSCFiLOm6EcT779pEjD7owxnhwg4tvxQ02/Eg11mKzY7HCGSm5uV0hmJ03/dffoIywLQvYs6tnhskuTOfng2ZMLIsJp30aLhFPSL4Yvoq0ypWLohxjjBLwb6w5rJqGh7YE0IXeXTPp03DLOH7OiIBa8+kjS151oCRsuiPBal0OL/7NjckrO+nagWNymWBgSPHtPli1zvuzMbKaXapGXp0ivy2czSy4Hp914OID9TZ4BsJ7kCDXGlpfIxMAed4VkQcl0pq7jeBLisMkGOKBvMNfVHXxPnu0+CWCTIZZYqWlaP5t+VfhFuxX6R6H6OgRmQP5E8fDrZDKuT4o1wM2V82lT6mb/M9ioehXWlsdEMYM/7GnSXpaivXQHNPHVLMgq7K3Jt7xzF91AusqEcw/SF8y+4vYqJkofe29Kj6VCSXgjxsi3wpbfmdp6EHd60jgh8Yfjs9Jd7a8zMfhX/FjXDCHF0yfWXIIUQjZM2BRwQlKILoWOnLxMEeVkO5NVW+z937ojLOh3GAierGpchIz7NSiVxHkR33h8Is3I9WdioHX9A+aX2zYkwPm2cBwcKIbmZL7LBJw1JjnHeIdjOUFhZeF85urYq8Guj4zE7EVTawr4K5ChLJEyHcHXaQNRFVYlQFV8qGyl9hlTf3eManZoz1xjXGOYcQJU4LNxqjEln3dJZpWKXgYp7q7Ha3u2wRbwTWPu15MrAwmTK0ef8376cWLl903BzWfNfpAZeM+dq2HBDE9QnRzsz78TMqTVZWZlcMg7ejdAvHLh3jbUo2PI3gUn+1gz7m72rbYHIYzbyxoXAU1vVZRoqIYKYEq4V+vcsUTuqod2XlFsV6c3fSimmgCVErOyHk+36AUDmPw6LfL2TcfO3HIK0bltsMJObtwhjh2eB7eDIzBxfxCZK4DADAbh/NXGPZmfey80s1Gv6s9wJwHkR3mKjuNM4H1cmDoGw4V4THtiUWxMsK39kJewJfs549UI3yvNJIipf4bGj+eUDkme3ZBSTfZZPRHGD6B+3BRntc2VWbtmXIg8lJcueqBBhDXsI28857JGDrE9FR1ZAhrTtZfiJ3f+D/+lnVO7eKBcghz2Pmjr/oVCpTMg+frhH3IvQyW8TBhuc94w4+FXULm3sWVZPNoPzZ4rnuICZiFlLltWYy02Kia8v8995eyY9/VjRRAx3jyT/cdIUbv6SEC5G20B3JqBNp8cxfdQLrKhHMP0hfMvuL2KiZKH3tvSo+lQkl4I8bIt8KW35naehB3etI4EamyjGxYxLMVLvnVj2c3XDCHFc3CZhb+MnWBfU62koPXqbLQC4fGPAqS+1sJ7e2hCNbQvDEKsn/nW6zXEPn2alEriPIjvvD4RZuR6s7FQOw+lCsAAExLi2OOdj8LpL+MlwdxOq6hjKcI++Im2tkO2cC7yEZWDToWfYX0+qTSoGYjtCEwuh62ToM+w8d+1H1XIp4m2YRlxTX3b7sp7I1pk22flcpa9aCnEbWu2p/0X8MQ/4aGyH+A6vtX5y0C/gPVR4j6T2XnchkrvqsSMqH0u1ma9/cCOAcJj9v2hoAntTpGdkq9syXBypFUp0GBXkaW2A5Re9VxFWkxsOZ0tXntA8tmaralGLX5B24XsIOkWDBSWlfpiAS0q5KiD0VfSLpIHdEH1zKdw5E2aieKMOaMjJAYyO2h3CrzDoZak+XRwK/m6Z40K/qiwbVnPhfktoTDx3eoasr/1rp8O12+OuXiNEmlstsytRYZCfR17WgW8QzPB0GNCEQBiXmmT9RzM5NGbn/UXpq0T0kjrveMrNMdwxOX+Wq29U/qLtUB6P2lXbf4Uh7w/DbXnChWylqsGf1Vw0LpBsCST2HAf/b5IxmO4xPF0jx3JjUXltaYdsSyNmoQ6QRMYyn+S5v0A/SCoqvrc4BpP9L1H4A/ADZX17rxIUMpHcj/UwBklKdtuaSIfNodC9SIR6ks0L6zigf/n243qOGwvyfc6z/PPeC2RjhzgUP0/H6LZ0e1WpQDO1c/4uqvQQibbinbBtidET5I2Yvp8A/VqbGqfFRYs5IIL/+JGLWpqa6yJv3S8BHSQA6smfEHqlXwaH968F8KG7HsFHbdxVG7jJRDBDD+0m8FpnWeCFWYctp7eZyooo+B0dYigKOeBKry2G1zHUQMkRBgkh7PO7juDrWzLUBRhkcx/MV9QpClI97mdLyC6SVlh0RTv5VehWF27pMZE3VKY163wPMlkqOTIm3phYXE8iE9c4cseMCwbUFFdbX2z3naZ5h4ZdB2mdj5+bXdzt1nYQ653I7ALEarh5IpqEefKszef9Rjjw/+h1+2pZ2Fdc1ziiwKf7vhmIxk/b4dcy6qKBCLd2n1IDgLJBfCTtXw1HMpVO2yM5eBjRXom9hcOcIIG5TJf8O+SyRND7EZnx8xl5ufiIxrRwOxwQBpE2Qo0lhiNYKadS/zq/koRmxVCM6Z6IcwuSR9DgGGny/CjcSJE4yU9ZxxEVmDHpqEib7IQkqsVDiyQSOyUm7MSVGPCZ6Iy2J/vyI0xqEnFeBUZG9GowMyGZq//fXznaOgqdp8qH8BPYNe3NVjKWLZj/vnnlHDkY31DOremJJaR75atfAcrsTUGutdCpErNX9skQJ0/PzK0xKWA0QDXK6mYscYYrlin3g1tuAhNv3TWbThPHTW9FoHh00qFJ/vNbcAAqP+aNfxmpDu0JhY/wl3u2o9ytbvRTtuJtfHditKzAoUWLFRO9zOSCrk5Yn24E8vfEk8Xgp9RGi4hm/gO9Y+CX5lJPgOXG4vsEAECDLf6GAwHK5kPPan4cZfhPne4+uCWoKcTHvRdY3ybX+78UZB/vk3A8E0YSHHZg3nT3y4fEhK5UVCUlUwqA4g89XJpAdS/Zew0rIgNjbkEaKFnDFzFXBCMC+gJ4qHns9ddUAd/sP+CLIQv+IRXNM39MCA1ugDfJlDtG6ju7SNp0drdhfGJbGQ3bdEAONOLqcKfEfbOTa0wogc8V896Z3AmKhrQFglGf+Ha7Up2eVoxtTox+PmCvHkJKmWwTiSoxkPwu671+36L4pdqI7CWFGvMudmW9CZct00itHJXWElYXbukxkTdUpjXrfA8yWSo5MiY00KoeRNnhgHhSW07hOsEN7nc8z/CHd4dPD38rl4gYjXWfkcwrNVeTjchtggWdY+PW0Je3EdVDHNO9AV/2HX7alnYV1zXOKLAh4w/J4wvvhSeuZdVFAhFu7T6kBre4krlV90LgQfn5+bgCtFAKEACoAnRSEfWHxf0UBr39EucNaO/fX9boMo/8SZmrqytIiMYScs/OvdSaKJ1KOI0xlTt3CSJpHkOMf0PjF4pnuqVX2AS5tSAAAAAAAAAAAFGf2wsLCwsLCwsLCwsLCwsLCwsLCwsLCwsLCwsLCwsLCwsLCwsLCwsLCwsLCwsLCwsLCwsLCwsLCwsLCwsLCwsLCwsLCwsLCwsLCwowAAAAAAAAAAAAAAVXywhgAAAAAAAAAAAAAAAAFH9n7NiOgt88TUUZJNfDhPhrJOEY2hA37q4DNTyfoLnR0Cf+esBfJLqZ/U+PfaGLQD3md5tMcF4IL4hU6q8F9YH3IJ2toYW2tujCr/p7Ei0+1gOg6DdY1uQp673+V/09iRafawHQdBusa3IU9d8SdntziuYAAgFWXKFipIdwx2E2t8FVAKQvwUsHOe29x4dWgDg9MXp80poq8nKp30XnXtG83FudK7GGAEKN/QfD1RAAAAAAAAEMnt9y/BJhJ+sE/5KRcLY15BDvDhf5tIXOJrmHDf1EYbSm4KIZk0G65puZkkVRU7uCP9yQqgAAAC9AgQ4SmXt9tURlQbnzNV+4c59Of6rtBec/7ZfLsJE7OdDJ9ByBnwyQgbM9hBRFlA7qotirmhZDw6FJxYBbFXNCyHh0KTiwC1cAAJujlUfJAeaveCA/LWAryEOP0f6nl/4bbtDr2uEBzR0s0fgNE6aN9/7Xo6AAAAcEdAmAlkh/+upIb87TJCzbrCDbdJtuk23SbbpNt0m26TbdJtuk23SbbpNt0m26TbdJtuk23SbbpNt0m2xmEhUnX8ABTKr1BUH6913HGBlUqNUy+gVI2lFOm4qhZaZkhru3PK+lN02+ERiQqgkmEeijeMRuuvfZmI3XXvszEbrr32ZiN1177MxG6699mYjdde+zMRuuvjMyqlCgEhcrgHKbl/Gw/uC5gvLUdlrct1SIikofOG6j8nd64seAAMg5ucVzMhohw4AAAAAAAAAAAAAAAAAATRXy2b9ryvqwknrYNw08yMWkB4FaMySjkCdOdIFON5MrJ8jSkTutK+gPa6PKwDTiTN19rMxsBbJKuf2/dYzskq5/b91jOySrn9v3WM7JKuf3IZSk8jKY9WgCqBIuNZaWlH/BFkOuv6teGLh6U0GXd2odjZWvkBoG96Gat/a9fOHu+IF8ZHy7E2gXqnp92YiQouW39r184e74gXxkfLsTaBeqen3ZiJCi5bf2vXzh7viXXQ6+WtGr99qhTCrup4GLJlukbQy4pF+ShDeHghE0rSAQAAAAAAAAAAAAAAAAAABfGTULbRow0f/89Tyg1ezAxKN+phrwFigAAAANE6uSAAAAZLPFwQP4rThXwvxVCt8AxntSH3+P4kgAAAALsxBgC8TpC3dEKq4BPk2iwwj9G96v1g6H7UsaJWeCjmAAAADf4ja6TEgyoFpPkl2ehL/x9FUivvx1Cot6r/cfePid1nu9tQAAAA');}
-
-
 h1,h2,h3,.site-header .brand span{font-family:'Cinzel',serif;text-transform:uppercase;letter-spacing:2px;}
 /* Filtros de Xolos disponibles */
 .filtros{
@@ -944,65 +819,6 @@ h1,h2,h3,.site-header .brand span{font-family:'Cinzel',serif;text-transform:uppe
   }
 }
 
-.footer-grid{
-  display:grid; gap:1rem;
-  grid-template-columns: repeat(3, 1fr);
-}
-@media (max-width: 900px){
-  .footer-grid{ grid-template-columns: 1fr 1fr; }
-}
-@media (max-width: 600px){
-  .footer-grid{ grid-template-columns: 1fr; text-align:center; }
-}
-
-@media (max-width: 768px){
-  html, body{ overflow-x:hidden; width:100%; }
-}
-
-@media (max-width: 768px) {
-  .hero,
-  #cta,
-  .hero.hero-disponibles,
-  .parallax {
-    width: 100vw;
-    max-width: 100%;
-    min-height: 300px;
-  }
-
-  .hero__media,
-  .card__media,
-  .gallery-grid,
-  picture,
-  figure {
-    width: 100%;
-    max-width: 100%;
-    margin: 0;
-  }
-
-  .hero__media img,
-  .card__media img,
-  .gallery-grid img,
-  .article img,
-  picture img,
-  figure img {
-    width: 100%;
-    height: auto;
-    object-fit: cover;
-  }
-
-  .blog-card .card__media img {
-    height: auto;
-  }
-
-  .brand img {
-    width: clamp(32px, 10vw, 44px);
-    height: clamp(32px, 10vw, 44px);
-  }
-
-  .gallery-grid {
-    grid-template-columns: 1fr;
-  }
-}
 
 /* Corrección de visibilidad del texto en el formulario de contacto */
 form input,
@@ -1018,29 +834,6 @@ form select:focus,
 form textarea:focus {
     color: #000000;
     outline: 2px solid var(--accent-color, #d4af37); /* Opcional: resalta el campo activo */
-}
-
-html,
-body {
-  overflow-x: hidden;
-}
-
-*,
-*::before,
-*::after {
-  box-sizing: border-box;
-}
-
-img,
-picture,
-video {
-  max-width: 100%;
-  height: auto;
-  display: block;
-}
-
-img {
-  object-fit: cover;
 }
 
 h2 {
@@ -1064,8 +857,7 @@ textarea {
 }
 
 .cards-container,
-.testimonials-grid,
-.gallery-grid {
+.testimonials-grid {
   display: grid;
   gap: 1rem;
 }
@@ -1076,10 +868,6 @@ textarea {
 
 .testimonials-grid {
   grid-template-columns: 1fr;
-}
-
-.gallery-grid {
-  grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
 }
 
 @media (min-width: 768px) {
@@ -1149,76 +937,44 @@ textarea {
   .nav-menu ul { display: flex; flex-direction: row; gap: 1.5rem; list-style: none; }
 }
 
-/* ============================================================
-   FIX DEFINITIVO: RESPONSIVIDAD GLOBAL (HERO, IMÁGENES, GRIDS)
-   ============================================================ */
-
-/* 1. Ajuste Universal de Imágenes */
+/* FIX GLOBAL */
 img, picture, video {
-    max-width: 100% !important;
-    height: auto !important;
-    display: block;
-    object-fit: cover; /* Cambia a 'contain' si NO quieres que se corte nada de la imagen */
+  max-width: 100% !important;
+  height: auto !important;
+  object-fit: cover !important;
+}
+.hero, .hero.hero-disponibles, #cta, .parallax {
+  width: 100% !important;
+  max-width: 100vw !important;
+  min-height: 70vh;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+.hero__media img, .hero img {
+  width: 100% !important;
+  height: 100% !important;
+  object-position: center !important;
 }
 
-/* 2. Fix para secciones Hero (Principal y Subpáginas) */
-.hero, 
-.hero.hero-disponibles, 
-#cta, 
-.parallax {
-    width: 100% !important;
-    max-width: 100vw !important;
-    margin-inline: 0 !important; /* Elimina márgenes negativos que causan scroll lateral */
-    min-height: 70vh; /* Altura generosa en desktop */
-    display: flex;
-    align-items: center;
-    justify-content: center;
-}
-
-/* 3. Ajuste de Imágenes dentro de Hero (Evita que se corten demasiado) */
-.hero__media img, 
-.hero img {
-    width: 100% !important;
-    height: 100% !important;
-    object-fit: cover !important;
-    object-position: center !important;
-}
-
-/* 4. MEDIA QUERIES PARA MÓVIL (Celulares) */
+/* MEDIA QUERY MÓVIL */
 @media (max-width: 768px) {
-    /* Reducimos la altura del hero para que la imagen no se pierda */
-    .hero, 
-    .hero.hero-disponibles, 
-    #cta, 
-    .parallax {
-        min-height: 350px !important; /* Altura fija razonable para móvil */
-        height: auto !important;
-        background-attachment: scroll !important; /* El parallax suele romperse en móvil */
-    }
-
-    .hero h1 {
-        font-size: 1.8rem !important;
-    }
-
-    /* Grids responsivas: 1 sola columna en móvil */
-    .grid, 
-    .grid-2, 
-    .trust-grid, 
-    .gallery-grid, 
-    .footer-grid {
-        grid-template-columns: 1fr !important;
-        gap: 1.5rem !important;
-    }
-
-    /* Contenedores */
-    .container {
-        width: 92% !important;
-        padding: 0 10px !important;
-    }
-
-    /* Forzar que las tarjetas no se desborden */
-    .card {
-        width: 100% !important;
-        margin-bottom: 1rem;
-    }
+  .hero, .hero.hero-disponibles, #cta, .parallax {
+    min-height: 350px !important;
+    height: auto !important;
+    background-attachment: scroll !important;
+  }
+  .hero h1 { font-size: 1.8rem !important; }
+  .grid, .grid-2, .trust-grid, .gallery-grid, .footer-grid {
+    grid-template-columns: 1fr !important;
+    gap: 1.5rem !important;
+  }
+  .container {
+    width: 92% !important;
+    padding: 0 10px !important;
+  }
+  .card {
+    width: 100% !important;
+    margin-bottom: 1rem;
+  }
 }

--- a/index.html
+++ b/index.html
@@ -53,12 +53,6 @@ body{font-family:'Poppins',system-ui,-apple-system,Segoe UI,Roboto,sans-serif;ba
 img,picture,video{max-width:100%;height:auto;display:block;}
 a{color:var(--accent);text-decoration:none;}
 .container{width:min(96%,1200px);margin-inline:auto;}
-/*.hero{min-height:100svh;display:flex;align-items:center;justify-content:center;text-align:center;position:relative;isolation:isolate;padding:3rem 1rem;overflow:hidden;}*/
-.hero__media{position:absolute;inset:0;z-index:-2;display:block;}
-/*.hero__media img{width:100%;height:100%;object-fit:cover;display:block;}*/
-.hero::after{content:"";position:absolute;inset:0;z-index:-1;background:linear-gradient(180deg, rgba(0,0,0,.55), rgba(0,0,0,.65));}
-.hero h1{font-family:'Cinzel',serif;text-transform:uppercase;letter-spacing:1px;color:var(--accent);text-shadow:2px 2px 8px rgba(0,0,0,.6);font-size:clamp(2rem,6vw,3.5rem);}
-.hero p{font-size:clamp(1rem,2.6vw,1.25rem);color:var(--muted);max-width:60ch;margin-inline:auto;}
 .btn{display:inline-flex;align-items:center;justify-content:center;gap:.5rem;background:linear-gradient(135deg,var(--accent),var(--accent-2));color:#080808;padding:.85rem 1.75rem;border-radius:999px;border:1px solid var(--border);font-weight:600;letter-spacing:.05em;text-transform:uppercase;min-height:44px;}
 button,input,select,textarea{min-height:44px;}
 .skip-link{position:absolute;left:0;top:-200px;background:var(--accent);color:#fff;padding:.75rem 1.5rem;font-weight:600;border-radius:0 0 .75rem .75rem;transition:top .3s ease;z-index:100;}


### PR DESCRIPTION
### Motivation

- Resolver problemas de responsividad que provocaban recortes y overflow en móviles sin alterar el diseño de escritorio.  
- Eliminar reglas duplicadas y contradictorias relacionadas con `.hero`, `.hero__media img`, `.container`, `.gallery-grid`, `.grid`, `.card` y `.footer-grid`.  
- Forzar una política móvil compatible (`!important`) para imágenes y secciones hero/parallax para evitar que estilos inline/carentes de prioridad rompan la experiencia en dispositivos pequeños.  
- Asegurar que las entradas del blog carguen la hoja `styles.css` y tengan la meta `viewport` correcta para comportamiento móvil consistente.  

### Description

- Consolidé y reorganicé reglas CSS en `css/styles.css`: un bloque principal único para `.hero`, `.hero__media img`, `.container`, `.grid`, `.card`, `.gallery-grid` y `.footer-grid`, eliminando duplicados dispersos y contradicciones.  
- Añadí al final de `css/styles.css` y `blog/blog.css` un bloque de correcciones globales con prioridad (`!important`) que normaliza `img, picture, video`, ajusta `.hero`, `#cta`, `.parallax` y define media query móvil para grids, contenedores y tarjetas.  
- Eliminé/Comenté las reglas críticas de `.hero` embebidas en `index.html` que sobreescribían el CSS externo y causaban problemas en móvil.  
- Actualicé varias páginas del blog para asegurar `../css/styles.css` se cargue y normalicé la etiqueta `<meta name="viewport" content="width=device-width, initial-scale=1.0">` donde faltaba o estaba incompleta; además añadí una regla en `blog/blog.css` para `.article img`.  

### Testing

- Se generó una captura móvil usando `playwright` navegando a la instancia local para validar visualmente la corrección en `index.html`, y la operación finalizó correctamente.  
- Se ejecutaron búsquedas con `rg` para verificar que las páginas del blog cargan `../css/styles.css` y contienen la meta `viewport` con `initial-scale=1.0`, confirmando los cambios (satisfactorio).  
- Se arrancó un servidor HTTP local (`python -m http.server`) para revisar las páginas servidas y validar que los estilos aplican en entorno estático (funcionó).  
- No se detectaron fallos automatizados en las comprobaciones realizadas durante la modificación (no se ejecutaron suites de tests adicionales).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69613e0948448332aeeddecb8d00c4c1)