### PR TITLE
Remove "Leer historia completa" links from testimonios.html

### DIFF
--- a/testimonios.html
+++ b/testimonios.html
@@ -160,7 +160,6 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
                 <p>"I got to say the not having hair is so nice for cleanup around the house."</p>
               </blockquote>
               <cite>— Jordan and Jake about Xoloitzcuintli Tzinzi Ramirez.</cite>
-              <a href="blog/tzinzi-ramirez.html" class="btn btn--sm" style="display: block; margin-top: 1rem;">Leer historia completa</a>
             </div>
           </article>
 
@@ -175,7 +174,6 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
                 <p>"Ohtli is a mamas boy, he loves her"</p>
               </blockquote>
               <cite>— Alan about Xoloitzcuintli Ohtli Ramirez</cite>
-              <a href="blog/ohtli-ramirez.html" class="btn btn--sm" style="display: block; margin-top: 1rem;">Leer historia completa</a>
             </div>
           </article>
 
@@ -188,7 +186,6 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
                 <p>"He's very intuitive. I feel like he knows a lot of things."</p>
               </blockquote>
               <cite>— JJ about xoloitzcuintli Django Ramirez</cite>
-              <a href="blog/django-ramirez.html" class="btn btn--sm" style="display: block; margin-top: 1rem;">Leer historia completa</a>
             </div>
           </article>
 
@@ -201,7 +198,6 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
                 <p>"Chichen is a very homely dog. He is very attached to the family."</p>
               </blockquote>
               <cite>— Archibald about xoloitzcuintli Chichen Ramirez</cite>
-              <a href="blog/chichen-ramirez.html" class="btn btn--sm" style="display: block; margin-top: 1rem;">Leer historia completa</a>
             </div>
           </article>
 
@@ -214,7 +210,6 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
                 <p>"They are good with the kids. They are good with other dogs."</p>
               </blockquote>
               <cite>— Yelena about xoloitzcuintlis Cosmo and Bonita Ramirez</cite>
-              <a href="blog/cosmo-bonita-ramirez.html" class="btn btn--sm" style="display: block; margin-top: 1rem;">Leer historia completa</a>
             </div>
           </article>
 
@@ -227,7 +222,6 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
                 <p>"He felt at home right away and gives a lot of love"</p>
               </blockquote>
               <cite>— Juan about xoloitzcuintli Huitzi Ramirez</cite>
-              <a href="blog/huitzi-ramirez.html" class="btn btn--sm" style="display: block; margin-top: 1rem;">Leer historia completa</a>
             </div>
           </article>
 
@@ -240,7 +234,6 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
                 <p>"Everyone was just so impressed with her. They had never seen a Xolo do agility before."</p>
               </blockquote>
               <cite>— Shelby about xoloitzcuintli Itza Ramirez</cite>
-              <a href="blog/itza-ramirez.html" class="btn btn--sm" style="display: block; margin-top: 1rem;">Leer historia completa</a>
             </div>
           </article>
 
@@ -256,7 +249,6 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
                 <p>"A K'aay le encanta este su su masajito en las noches con su cremita."</p>
               </blockquote>
               <cite>— Michelle sobre la xoloitzcuintle Menta "K'aay" Ramirez</cite>
-              <a href="blog/menta-kaay-ramirez.html" class="btn btn--sm" style="display: block; margin-top: 1rem;">Leer historia completa</a>
             </div>
           </article>
 
@@ -271,7 +263,6 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
                 <p>"Todo el mundo está enamorado de Pepe"</p>
               </blockquote>
               <cite>— Dayanne sobre el xoloitzcuintle Pepe Ramirez</cite>
-              <a href="blog/pepe-ramirez.html" class="btn btn--sm" style="display: block; margin-top: 1rem;">Leer historia completa</a>
             </div>
           </article>
 
@@ -286,7 +277,6 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
                 <p>"Tecuani me ha recordado mis raíces mexicanas y me ha traído de vuelta a México, fortaleciendo mi orgullo de ser de dos países importantes para la civilización humana"</p>
               </blockquote>
               <cite>— Danay sobre el xoloitzcuintle Tecuani Ramirez</cite>
-              <a href="blog/tecuani-ramirez.html" class="btn btn--sm" style="display: block; margin-top: 1rem;">Leer historia completa</a>
             </div>
           </article>
 
@@ -301,7 +291,6 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
                 <p>"Es como mi hijo, lo amo muchísimo."</p>
               </blockquote>
               <cite>— Eliana sobre el xoloitzcuintle Mezcal Ramirez</cite>
-              <a href="blog/mezcal-ramirez.html" class="btn btn--sm" style="display: block; margin-top: 1rem;">Leer historia completa</a>
             </div>
           </article>
 
@@ -315,7 +304,6 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
                 <p>"Edzna es muy atlética y le encanta correr"</p>
               </blockquote>
               <cite>— Miguel sobre la xoloitzcuintle Edzna Ramirez</cite>
-              <a href="blog/edzna-ramirez.html" class="btn btn--sm" style="display: block; margin-top: 1rem;">Leer historia completa</a>
             </div>
           </article>
 
@@ -330,7 +318,6 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
                 <p>"Shiny es una perrita muy buena, muy inteligente"</p>
               </blockquote>
               <cite>— Yeiron sobre la xoloitzcuintle Shiny Ramirez</cite>
-              <a href="blog/shiny-ramirez.html" class="btn btn--sm" style="display: block; margin-top: 1rem;">Leer historia completa</a>
             </div>
           </article>
 
@@ -344,7 +331,6 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
                 <p>"Es una preciosura tener... Es que es una experiencia."</p>
               </blockquote>
               <cite>— Edgar sobre el xoloitzcuintle Maiz Ramirez</cite>
-              <a href="blog/maiz-ramirez.html" class="btn btn--sm" style="display: block; margin-top: 1rem;">Leer historia completa</a>
             </div>
           </article>
 
@@ -358,7 +344,6 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
                 <p>"Pinole es educado y sabe convivir con otros perros"</p>
               </blockquote>
               <cite>— Edgar sobre el xoloitzcuintle Pinole Ramirez</cite>
-              <a href="blog/pinole-ramirez.html" class="btn btn--sm" style="display: block; margin-top: 1rem;">Leer historia completa</a>
             </div>
           </article>
 
@@ -373,7 +358,6 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
                 <p>"Ameyalli es muy sociable y cómoda con el contacto físico y los abrazos"</p>
               </blockquote>
               <cite>— Carmen sobre las xoloitzcuintles Sesasi y Ameyalli Ramirez</cite>
-              <a href="blog/sesasi-ameyalli-ramirez.html" class="btn btn--sm" style="display: block; margin-top: 1rem;">Leer historia completa</a>
             </div>
           </article>
 
@@ -387,7 +371,6 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
                 <p>"Chamoy es mi bebito"</p>
               </blockquote>
               <cite>— Emmanuel sobre el xoloitzcuintle Chamoy Ramirez</cite>
-              <a href="blog/chamoy-ramirez.html" class="btn btn--sm" style="display: block; margin-top: 1rem;">Leer historia completa</a>
             </div>
           </article>
 
@@ -401,7 +384,6 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
                 <p>"Los Xolos no requieren cuidados especiales"</p>
               </blockquote>
               <cite>— Loida sobre la xoloitzcuintle Xaly Ramirez</cite>
-              <a href="blog/xaly-ramirez.html" class="btn btn--sm" style="display: block; margin-top: 1rem;">Leer historia completa</a>
             </div>
           </article>
 
@@ -416,7 +398,6 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
                 <p>"Sesasi es el mejor regalo que he recibido"</p>
               </blockquote>
               <cite>— Lupita sobre la xoloitzcuintle Sesasi Ramirez</cite>
-              <a href="blog/sesasi-lupita-ramirez.html" class="btn btn--sm" style="display: block; margin-top: 1rem;">Leer historia completa</a>
             </div>
           </article>
 
@@ -431,7 +412,6 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
                 <p>"Khaali me reconforta cuando llego cansado del trabajo"</p>
               </blockquote>
               <cite>— Marcos sobre la xoloitzcuintle Khaali Ramirez</cite>
-              <a href="blog/khaali-ramirez.html" class="btn btn--sm" style="display: block; margin-top: 1rem;">Leer historia completa</a>
             </div>
           </article>
 
@@ -444,7 +424,6 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
                 <p>"Itzae es mi mejor amigo"</p>
               </blockquote>
               <cite>— Jack sobre el xoloitzcuintle Itzae Ramirez</cite>
-              <a href="blog/itzae-ramirez.html" class="btn btn--sm" style="display: block; margin-top: 1rem;">Leer historia completa</a>
             </div>
           </article>
 
@@ -458,7 +437,6 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
                 <p>"Mezcal sabe cuando es la hora de su siesta"</p>
               </blockquote>
               <cite>— Dayanara sobre el xoloitzcuintle Mezcal Ramirez</cite>
-              <a href="blog/mezcal-dayanara-ramirez.html" class="btn btn--sm" style="display: block; margin-top: 1rem;">Leer historia completa</a>
             </div>
           </article>
 
@@ -476,7 +454,6 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
                 <p>"¡Añade aquí la frase o testimonio que desees destacar de este video!"</p>
               </blockquote>
               <cite>— Xolos Ramírez Comunidad</cite>
-              <a href="blog/nueva-historia.html" class="btn btn--sm" style="display: block; margin-top: 1rem;">Leer historia completa</a>
             </div>
           </article>
 


### PR DESCRIPTION
### Motivation
- Remove the repeated "Leer historia completa" CTA links from each testimonial card to simplify the testimonials UI.
- Ensure the testimonial blocks end with the description/citation only, without navigation links to individual blog pages.

### Description
- Deleted all anchor elements containing the text "Leer historia completa" from `testimonios.html` so cards no longer show those buttons.
- No other layout or content changes were made to the testimonial cards.
- Updated the single static HTML file `testimonios.html` to reflect the removal across all testimonial entries.

### Testing
- Located all occurrences with `rg -n "Leer historia completa" testimonios.html` to verify targets before changes, which succeeded.
- Ran the Python cleanup script to remove matching lines from `testimonios.html`, which executed successfully.
- Served the site with `python -m http.server 8000` and captured a visual verification screenshot using a Playwright script that produced `artifacts/testimonios-sin-botones.png`, which confirmed the buttons are gone.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696170c1565883329fb46ab2f51331dd)