### PR TITLE
Add audio playback to Xoloitzcuintle pronunciation card

### DIFF
--- a/blog/2026-01-13-how-to-pronounce-xoloitzcuintle.html
+++ b/blog/2026-01-13-how-to-pronounce-xoloitzcuintle.html
@@ -271,6 +271,9 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
       const pronunciationCard = document.querySelector('.pronunciation-card');
       const syllables = document.querySelectorAll('[data-syllable]');
 
+      // Cargar el audio desde la carpeta assets
+      const audioPronunciacion = new Audio('../assets/Xoloitzcuintle.mp3');
+
       const flash = (element) => {
         element.classList.add('is-active');
         setTimeout(() => {
@@ -279,6 +282,14 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
       };
 
       const playFull = () => {
+        // Reiniciar audio para permitir clics repetitivos
+        audioPronunciacion.currentTime = 0;
+
+        // Reproducir audio con manejo de promesa para evitar errores de navegador
+        audioPronunciacion.play().catch((error) => {
+          console.error('Error al reproducir el audio:', error);
+        });
+
         console.log('Pronouncing: Xoloitzcuintle');
       };
 


### PR DESCRIPTION
### Motivation
- Provide an audible pronunciation for the interactive mini-app so users can hear the correct pronunciation.
- Load the audio file from the project `assets/` directory using the correct relative path from the blog page (`../assets/Xoloitzcuintle.mp3`).
- Allow repeated playback from the pronunciation card and support keyboard activation for accessibility.
- Avoid unhandled promise rejections from `Audio.play()` by adding basic error handling.

### Description
- Added `const audioPronunciacion = new Audio('../assets/Xoloitzcuintle.mp3');` to the inline script in `blog/2026-01-13-how-to-pronounce-xoloitzcuintle.html`.
- Updated `playFull()` to reset playback with `audioPronunciacion.currentTime = 0` and to call `audioPronunciacion.play().catch(...)` to handle playback errors.
- Preserved the existing syllable `flash()` behavior and the keyboard handlers that trigger playback on `Enter` and `Space`.
- Only the blog HTML file was modified; no other assets or build files were changed.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69664e52c9988332a5f4142530405400)