### PR TITLE
Add Tonalli floating CTA button

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -1006,3 +1006,41 @@ form textarea:focus {
     color: #000000;
     outline: 2px solid var(--accent-color, #d4af37); /* Opcional: resalta el campo activo */
 }
+
+/* Estilo para el botón flotante Tonalli */
+.tonalli-float-btn {
+    position: fixed;
+    top: 25px;
+    right: 25px;
+    background-color: #000000; /* Fondo negro */
+    color: #d4af37;           /* Texto dorado/ocre */
+    padding: 12px 24px;
+    border: 1px solid #d4af37; /* Borde dorado */
+    border-radius: 50px;       /* Forma redondeada moderna */
+    text-decoration: none;
+    font-weight: bold;
+    font-family: 'Segoe UI', Tahoma, Geneva, Verdana, sans-serif;
+    font-size: 14px;
+    text-transform: uppercase;
+    letter-spacing: 1px;
+    z-index: 9999;             /* Asegura que esté por encima de todo */
+    transition: all 0.3s ease;
+    box-shadow: 0 4px 15px rgba(0,0,0,0.3);
+}
+
+.tonalli-float-btn:hover {
+    background-color: #d4af37;
+    color: #000000;
+    box-shadow: 0 6px 20px rgba(212, 175, 55, 0.4);
+    transform: translateY(-2px);
+}
+
+/* Ajuste para móviles */
+@media (max-width: 768px) {
+    .tonalli-float-btn {
+        top: 15px;
+        right: 15px;
+        padding: 8px 16px;
+        font-size: 12px;
+    }
+}

--- a/index.html
+++ b/index.html
@@ -310,5 +310,8 @@ Selección de Ejemplares de Calidad: Seleccionamos cuidadosamente a los perros q
     <script>
       AOS.init({ once: true, duration: 700, offset: 60, easing: 'ease-out' });
     </script>
+    <a href="https://app.tonalli.cash" target="_blank" class="tonalli-float-btn">
+        open Tonalli
+    </a>
   </body>
 </html>


### PR DESCRIPTION
### Motivation
- Provide a persistent, high-visibility CTA that links to the Tonalli app from the site header area and match the Xolos Ramírez black/gold palette.

### Description
- Inserted a floating anchor link in `index.html` just before `</body>` with class `tonalli-float-btn` that opens `https://app.tonalli.cash` in a new tab.
- Added styles for `.tonalli-float-btn` to `css/styles.css` including color, border, rounded shape, shadow, hover state, `z-index`, and responsive adjustments for mobile.
- Changes are limited to `index.html` and `css/styles.css` and do not modify existing scripts or markup flow.

### Testing
- Launched a local server with `python -m http.server 8000` and it started successfully.
- Ran a Playwright script that loaded `http://127.0.0.1:8000/index.html` and captured a screenshot (`artifacts/tonalli-button.png`), which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6967e75de22c83329faf5e835b78b513)