### PR TITLE
Add Mictlán mini-app blog post and index card

### DIFF
--- a/blog/2026-01-14-xoloitzcuintle-guia-del-mictlan.html
+++ b/blog/2026-01-14-xoloitzcuintle-guia-del-mictlan.html
@@ -1,0 +1,100 @@
+<!DOCTYPE html>
+<html lang="es">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Xoloitzcuintle: El Guardián del Inframundo | Xolos Ramírez</title>
+    <meta name="description" content="Una experiencia interactiva sobre la leyenda del Xoloitzcuintle y su papel sagrado en el Día de Muertos.">
+    <link rel="stylesheet" href="../css/styles.css">
+    <link href="https://fonts.googleapis.com/css2?family=Cinzel:wght@400;700&family=Poppins:wght@400;600&display=swap" rel="stylesheet">
+    <link href="https://unpkg.com/aos@2.3.1/dist/aos.css" rel="stylesheet">
+    <style>
+        :root { --cempasuchil: #FF9800; --mictlan-dark: #1a1a1a; }
+        .mini-app-container { background: var(--mictlan-dark); color: #fff; padding: 2rem; border-radius: 15px; border: 1px solid var(--cempasuchil); margin: 2rem 0; font-family: 'Poppins', sans-serif; }
+        .story-step { display: none; min-height: 300px; }
+        .story-step.active { display: block; animation: fadeIn 0.8s ease; }
+        .progress-bar { height: 4px; background: #333; margin-bottom: 2rem; border-radius: 2px; }
+        .progress-fill { height: 100%; background: var(--cempasuchil); width: 0%; transition: width 0.4s; }
+        .story-nav { display: flex; justify-content: space-between; margin-top: 2rem; }
+        .btn-story { background: var(--cempasuchil); color: #000; border: none; padding: 0.8rem 1.5rem; cursor: pointer; font-weight: bold; font-family: 'Cinzel'; transition: transform 0.2s; }
+        .btn-story:hover { transform: scale(1.05); }
+        .btn-story:disabled { background: #555; cursor: not-allowed; }
+        .fact-box { background: rgba(255, 152, 0, 0.1); border-left: 4px solid var(--cempasuchil); padding: 1rem; margin-top: 1rem; font-style: italic; font-size: 0.9rem; }
+        @keyframes fadeIn { from { opacity: 0; transform: translateY(10px); } to { opacity: 1; transform: translateY(0); } }
+    </style>
+</head>
+<body>
+    <header class="site-header">
+        <div class="container header-row">
+            <a class="brand" href="../index.html"><span>Xolos Ramírez</span></a>
+            <nav class="nav-menu">
+                <ul>
+                    <li><a href="index.html">Volver al Blog</a></li>
+                </ul>
+            </nav>
+        </div>
+    </header>
+
+    <main class="container article">
+        <section data-aos="fade-up">
+            <h1 style="color: var(--cempasuchil); text-align: center;">El Guía de las Almas</h1>
+            <p style="text-align: center;">Interactúa con esta mini-experiencia para conocer la conexión milenaria entre el Xolo y el Mictlán.</p>
+
+            <div class="mini-app-container">
+                <div class="progress-bar"><div class="progress-fill" id="progressBar"></div></div>
+
+                <div class="story-step active" id="step1">
+                    <h2 class="post-card__title">I. El Regalo de Xólotl</h2>
+                    <p>Cuenta la leyenda que el dios Xólotl creó al perro de una astilla del Hueso de la Vida. No lo hizo como una simple mascota, sino como un guardián sagrado para la transición más importante del ser humano.</p>
+                    <div class="fact-box">
+                        <strong>Dato Documental:</strong> Los hallazgos arqueológicos en entierros prehispánicos muestran que los Xoloitzcuintles eran sacrificados para acompañar a sus dueños en el viaje post-mortem.
+                    </div>
+                </div>
+
+                <div class="story-step" id="step2">
+                    <h2 class="post-card__title">II. El Cruce del Gran Río</h2>
+                    <p>Para llegar al Mictlán, el alma debe cruzar el Apanohuacalhuia (el primer nivel del inframundo). Aquí, el perro reconoce a su dueño. Solo si fuiste bueno con los animales en vida, el Xolo te permitirá subir a su lomo para cruzar las aguas profundas.</p>
+                    <div class="fact-box">
+                        <strong>Storytelling:</strong> Imagina la oscuridad total, solo interrumpida por el calor térmico que emana de la piel de tu guía.
+                    </div>
+                </div>
+
+                <div class="story-step" id="step3">
+                    <h2 class="post-card__title">III. Luz en la Ofrenda</h2>
+                    <p>Hoy, en cada altar de Día de Muertos, la figura del Xolo (ya sea en barro o presente en la casa) asegura que el camino de regreso de nuestros ancestros esté protegido y libre de distracciones.</p>
+                    <div class="fact-box">
+                        <strong>Preservación:</strong> En Xolos Ramírez, criamos a estos guardianes manteniendo la pureza y la mística que los convirtió en símbolos nacionales.
+                    </div>
+                    <div style="text-align: center; margin-top: 2rem;">
+                        <a href="https://xolosramirez.com/xolos-disponibles" class="btn">Conoce a tu futuro guardián aquí</a>
+                    </div>
+                </div>
+
+                <div class="story-nav">
+                    <button class="btn-story" id="prevBtn" onclick="changeStep(-1)" disabled>Anterior</button>
+                    <button class="btn-story" id="nextBtn" onclick="changeStep(1)">Siguiente</button>
+                </div>
+            </div>
+        </section>
+    </main>
+
+    <script>
+        let currentStep = 1;
+        const totalSteps = 3;
+
+        function changeStep(n) {
+            document.getElementById(`step${currentStep}`).classList.remove('active');
+            currentStep += n;
+            document.getElementById(`step${currentStep}`).classList.add('active');
+
+            document.getElementById('prevBtn').disabled = currentStep === 1;
+            document.getElementById('nextBtn').style.display = currentStep === totalSteps ? 'none' : 'block';
+
+            const progress = ((currentStep - 1) / (totalSteps - 1)) * 100;
+            document.getElementById('progressBar').style.width = `${progress}%`;
+        }
+    </script>
+    <script src="https://unpkg.com/aos@2.3.1/dist/aos.js"></script>
+    <script>AOS.init();</script>
+</body>
+</html>

--- a/blog/index.html
+++ b/blog/index.html
@@ -114,6 +114,27 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
 
    <section aria-label="Listado de artículos del blog" class="grid" data-aos="fade-up" data-aos-duration="1000">
     <article class="post-card" data-aos="fade-up">
+     <a aria-label="Leer: Xoloitzcuintle: El Guardián del Inframundo (App Interactiva)" class="post-card__media" href="2026-01-14-xoloitzcuintle-guia-del-mictlan.html">
+      <img alt="Xoloitzcuintle y cempasúchil" height="360" loading="lazy" src="../img/blog/historia.svg" width="640"/>
+     </a>
+     <div class="post-card__body">
+      <time class="post-card__date" datetime="2026-01-14">
+       14 Ene 2026
+      </time>
+      <h2 class="post-card__title">
+       <a href="2026-01-14-xoloitzcuintle-guia-del-mictlan.html">
+        Xoloitzcuintle: El Guardián del Inframundo (Mini-App Interactiva)
+       </a>
+      </h2>
+      <p class="post-card__excerpt">
+       Explora a través de esta experiencia interactiva la leyenda del guía de las almas y su importancia vital en la tradición del Día de Muertos.
+      </p>
+      <a class="btn btn--sm" href="2026-01-14-xoloitzcuintle-guia-del-mictlan.html">
+       Iniciar experiencia →
+      </a>
+     </div>
+    </article>
+    <article class="post-card" data-aos="fade-up">
      <a aria-label="Leer: Patricia y Sami Ramírez: Una Conexión de Ley y Tradición" class="post-card__media" href="2026-01-13-entrega-sami-ramirez-unam.html">
       <img alt="Entrega de Sami Ramírez a Patricia" height="360" loading="lazy" src="https://img.youtube.com/vi/RGwZ_AMNhWc/maxresdefault.jpg" width="640"/>
      </a>


### PR DESCRIPTION
### Motivation

- Add an interactive mini-app that explains the Xoloitzcuintle’s role in Mictlán as a new piece of content for the blog and surface it prominently in the blog listing.

### Description

- Create `blog/2026-01-14-xoloitzcuintle-guia-del-mictlan.html` containing the mini-app HTML, inline styles, step navigation logic, progress bar, and AOS integration.
- Insert a new article card at the start of the blog grid in `blog/index.html` that links to the new mini-app and includes a CTA.
- Include a CTA link to the site adoption page and reference Google Fonts and the AOS stylesheet for animations.

### Testing

- Launched a local server with `python -m http.server 8000` and rendered the new page using Playwright to capture `artifacts/xolo-mictlan-miniapp.png`, which completed successfully.
- Verified the changes were staged and committed with `git` and the commit succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6967ffa5c4f8833295a587da0adb06c2)