### PR TITLE
Add testimonios CTA to Historias de adopción section

### DIFF
--- a/xolos-disponibles.html
+++ b/xolos-disponibles.html
@@ -378,6 +378,75 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
             <cite>— Lupita</cite>
           </article>
         </div>
+        <div class="cta-testimonios-wrapper">
+          <p class="cta-text">Cada Xoloitzcuintle tiene un propósito. Descubre el impacto en sus nuevas familias.</p>
+          <a href="testimonios.html" class="btn-aesthetic">
+            <span class="btn-text">Ver Historias de Éxito</span>
+            <span class="btn-icon">→</span>
+          </a>
+        </div>
+
+        <style>
+          /* Estilos para el botón estético y acorde al diseño */
+          .cta-testimonios-wrapper {
+            text-align: center;
+            padding: 50px 20px;
+            background: linear-gradient(to bottom, transparent, rgba(212, 175, 55, 0.05));
+            border-top: 1px solid #eee;
+            margin-top: 40px;
+          }
+
+          .cta-text {
+            font-family: 'Playfair Display', serif; /* O la fuente principal del sitio */
+            font-style: italic;
+            color: #555;
+            margin-bottom: 25px;
+            font-size: 1.1rem;
+          }
+
+          .btn-aesthetic {
+            display: inline-flex;
+            align-items: center;
+            padding: 15px 45px;
+            background-color: #2c2c2c; /* Negro/Gris oscuro elegante */
+            color: #d4af37; /* Dorado Xolo */
+            text-decoration: none;
+            border-radius: 2px; /* Estilo minimalista, no redondeado para verse más sobrio */
+            font-weight: 600;
+            text-transform: uppercase;
+            letter-spacing: 2px;
+            font-size: 0.85rem;
+            border: 1px solid #d4af37;
+            transition: all 0.4s cubic-bezier(0.25, 0.8, 0.25, 1);
+            position: relative;
+            overflow: hidden;
+          }
+
+          .btn-aesthetic:hover {
+            background-color: #d4af37;
+            color: #fff;
+            box-shadow: 0 10px 20px rgba(0, 0, 0, 0.15);
+            transform: translateY(-3px);
+          }
+
+          .btn-icon {
+            margin-left: 15px;
+            transition: transform 0.3s ease;
+          }
+
+          .btn-aesthetic:hover .btn-icon {
+            transform: translateX(8px);
+          }
+
+          /* Responsivo */
+          @media (max-width: 768px) {
+            .btn-aesthetic {
+              padding: 12px 30px;
+              width: 80%;
+              justify-content: center;
+            }
+          }
+        </style>
       </section>
 
       <section class="como-reservar parallax" data-aos="fade-up" data-aos-duration="1000">


### PR DESCRIPTION
### Motivation
- Add a visible call-to-action to the existing "Historias de adopción" section to drive users to the `testimonios.html` page and highlight success stories.

### Description
- Inserted a CTA block (`.cta-testimonios-wrapper`) with copy and a link to `testimonios.html` directly after the testimonials grid in `xolos-disponibles.html`.
- Included inline CSS for the CTA and button (`.btn-aesthetic`, `.btn-icon`, `.cta-text`) to match the site's aesthetic and provide hover micro-interactions and responsive behavior.
- The CTA uses an uppercase, letter-spaced button with a moving arrow on hover and a subtle background gradient to separate it visually from the testimonials.

### Testing
- Served the site locally with `python -m http.server 8000` and verified the page is reachable, which succeeded. 
- Captured a headless browser screenshot of `xolos-disponibles.html` using Playwright (output saved as `artifacts/xolos-disponibles-cta.png`) to confirm the CTA renders, which succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696e4b3cf2288332b4bb9241e3e62aba)