### PR TITLE
Add featured autoplay testimonial video and interactive poem to Historias Reales

### DIFF
--- a/testimonios.html
+++ b/testimonios.html
@@ -146,6 +146,51 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
 
       <section id="historias-reales" data-aos="fade-up" data-aos-duration="1000">
         <h2>Historias Reales</h2>
+        <div class="testimonio-destacado" style="margin: 40px 0; text-align: center;">
+          <div class="video-responsive" style="position: relative; padding-bottom: 56.25%; height: 0; overflow: hidden; border-radius: 15px; border: 2px solid #c5a059; box-shadow: 0 10px 20px rgba(0,0,0,0.3); max-width: 900px; margin: 0 auto;">
+            <iframe
+              src="https://www.youtube.com/embed/CaFq2rbF4Io?autoplay=1&mute=1&loop=1&playlist=CaFq2rbF4Io"
+              style="position: absolute; top: 0; left: 0; width: 100%; height: 100%;"
+              frameborder="0"
+              allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
+              allowfullscreen>
+            </iframe>
+          </div>
+
+          <div class="poema-interactivo" style="margin-top: 30px; font-family: 'Lora', serif; color: #f4f4f4; line-height: 1.8; font-style: italic;">
+            <style>
+              .poema-verso {
+                transition: color 0.3s ease, transform 0.3s ease;
+                display: block;
+                margin-bottom: 15px;
+                font-size: 1.2rem;
+              }
+              .poema-verso:hover {
+                color: #c5a059;
+                transform: scale(1.02);
+              }
+            </style>
+
+            <div class="poema-container" style="max-width: 600px; margin: 0 auto; padding: 20px;">
+              <span class="poema-verso">
+                Piel de noche antigua, calor que emana del sol,<br>
+                Tizoc camina el presente con pasos de antepasado.
+              </span>
+              <span class="poema-verso">
+                En los brazos de Fonzi, el tiempo pierde su rol,<br>
+                un lazo de tinta y latido, en silencio forjado.
+              </span>
+              <span class="poema-verso">
+                No hacen falta palabras donde sobra la mirada,<br>
+                el Xolo es el guía, el hombre es el guardián.
+              </span>
+              <span class="poema-verso">
+                Entre mimos y juegos, la esencia queda grabada,<br>
+                en el alma "Tonalli", donde las almas se dan.
+              </span>
+            </div>
+          </div>
+        </div>
         <div class="grid" style="display: grid; grid-template-columns: repeat(auto-fit, minmax(300px, 1fr)); gap: 2rem; padding: 2rem 0;">
           
           <article class="post-card">


### PR DESCRIPTION
### Motivation
- Resaltar una historia testimonial dentro de la sección `Historias Reales` añadiendo un video destacado en reproducción automática y un poema que conserve la estética de la web.

### Description
- Se actualizó `testimonios.html` para insertar un bloque `div.testimonio-destacado` justo debajo del título de la sección `Historias Reales` con un `iframe` de YouTube configurado con `autoplay=1&mute=1&loop=1&playlist=<id>` para reproducción automática silenciosa y bucle.
- Se añadió estilo inline para que el video sea responsive y tenga `border-radius`, borde dorado `#c5a059` y sombra para destacar la pieza.
- Se incorporó un bloque `poema-interactivo` con fuente `'Lora'`, estrofas como `.poema-verso` y una regla CSS de hover que cambia el color a dorado y aplica una ligera escala para interactividad.
- El bloque fue insertado antes del grid de tarjetas existente para mantener el flujo visual de la página.

### Testing
- Levanté un servidor estático local con `python -m http.server 8000` para previsualizar los cambios y el servidor respondió correctamente antes de interrumpir la sesión. 
- Intenté generar una captura con Playwright mediante scripts de navegador, pero las ejecuciones agotaron el tiempo de espera y fallaron (timeout). 
- No se ejecutaron otras pruebas automatizadas de unidad o integración.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696ed0a4dba88332b88ac43e86d90d06)