### PR TITLE
Add six featured puppy cards to xolos-disponibles.html

### DIFF
--- a/xolos-disponibles.html
+++ b/xolos-disponibles.html
@@ -358,6 +358,120 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
               📲 Consultar vía WhatsApp
             </a>
           </article>
+
+          <article class="card" data-aos="zoom-in" data-aos-duration="900" data-aos-delay="450">
+            <picture class="card__media"></picture>
+            <div class="video-container" style="position: relative; padding-bottom: 56.25%; height: 0; overflow: hidden; margin-top: 1rem;">
+              <iframe 
+                src="https://www.youtube.com/embed/sGuF_4-dmxY?autoplay=1&mute=1&loop=1&playlist=sGuF_4-dmxY" 
+                style="position: absolute; top: 0; left: 0; width: 100%; height: 100%; border: 0;" 
+                allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" 
+                allowfullscreen>
+              </iframe>
+            </div>
+            <h3>Mitla Ramirez</h3>
+            <p>(xoloitzcuintle hembra talla estándar variedad sin pelo color negro)</p>
+            <p>Nacida este 18 de enero del 2026.</p>
+            <a href="contacto.html">Más información</a>
+            <a class="btn-whatsapp" href="https://wa.me/message/435RTKGJLTX2J1" target="_blank" rel="noopener" onclick="dataLayer.push({ event: 'click_whatsapp', cachorro: 'Mitla Ramirez', source: 'xolos_disponibles' })">
+              📲 Consultar vía WhatsApp
+            </a>
+          </article>
+
+          <article class="card" data-aos="zoom-in" data-aos-duration="900" data-aos-delay="500">
+            <picture class="card__media"></picture>
+            <div class="video-container" style="position: relative; padding-bottom: 56.25%; height: 0; overflow: hidden; margin-top: 1rem;">
+              <iframe 
+                src="https://www.youtube.com/embed/b8T4yvdQ84U?autoplay=1&mute=1&loop=1&playlist=b8T4yvdQ84U" 
+                style="position: absolute; top: 0; left: 0; width: 100%; height: 100%; border: 0;" 
+                allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" 
+                allowfullscreen>
+              </iframe>
+            </div>
+            <h3>Ozomatli Ramirez</h3>
+            <p>(xoloitzcuintle macho talla estándar variedad sin pelo color negro)</p>
+            <p>Nacido este 18 de enero del 2026.</p>
+            <a href="contacto.html">Más información</a>
+            <a class="btn-whatsapp" href="https://wa.me/message/435RTKGJLTX2J1" target="_blank" rel="noopener" onclick="dataLayer.push({ event: 'click_whatsapp', cachorro: 'Ozomatli Ramirez', source: 'xolos_disponibles' })">
+              📲 Consultar vía WhatsApp
+            </a>
+          </article>
+
+          <article class="card" data-aos="zoom-in" data-aos-duration="900" data-aos-delay="550">
+            <picture class="card__media"></picture>
+            <div class="video-container" style="position: relative; padding-bottom: 56.25%; height: 0; overflow: hidden; margin-top: 1rem;">
+              <iframe 
+                src="https://www.youtube.com/embed/b8T4yvdQ84U?autoplay=1&mute=1&loop=1&playlist=b8T4yvdQ84U" 
+                style="position: absolute; top: 0; left: 0; width: 100%; height: 100%; border: 0;" 
+                allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" 
+                allowfullscreen>
+              </iframe>
+            </div>
+            <h3>Amoxtli Ramirez</h3>
+            <p>(xoloitzcuintle hembra talla estándar variedad sin pelo color negro)</p>
+            <p>Nacida este 18 de enero del 2026.</p>
+            <a href="contacto.html">Más información</a>
+            <a class="btn-whatsapp" href="https://wa.me/message/435RTKGJLTX2J1" target="_blank" rel="noopener" onclick="dataLayer.push({ event: 'click_whatsapp', cachorro: 'Amoxtli Ramirez', source: 'xolos_disponibles' })">
+              📲 Consultar vía WhatsApp
+            </a>
+          </article>
+
+          <article class="card" data-aos="zoom-in" data-aos-duration="900" data-aos-delay="600">
+            <picture class="card__media"></picture>
+            <div class="video-container" style="position: relative; padding-bottom: 56.25%; height: 0; overflow: hidden; margin-top: 1rem;">
+              <iframe 
+                src="https://www.youtube.com/embed/1VOf592ZK-4?autoplay=1&mute=1&loop=1&playlist=1VOf592ZK-4" 
+                style="position: absolute; top: 0; left: 0; width: 100%; height: 100%; border: 0;" 
+                allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" 
+                allowfullscreen>
+              </iframe>
+            </div>
+            <h3>Tejocote Ramirez</h3>
+            <p>(xoloitzcuintle macho talla estándar variedad sin pelo color negro)</p>
+            <p>Nacido este 18 de enero del 2026.</p>
+            <a href="contacto.html">Más información</a>
+            <a class="btn-whatsapp" href="https://wa.me/message/435RTKGJLTX2J1" target="_blank" rel="noopener" onclick="dataLayer.push({ event: 'click_whatsapp', cachorro: 'Tejocote Ramirez', source: 'xolos_disponibles' })">
+              📲 Consultar vía WhatsApp
+            </a>
+          </article>
+
+          <article class="card" data-aos="zoom-in" data-aos-duration="900" data-aos-delay="650">
+            <picture class="card__media"></picture>
+            <div class="video-container" style="position: relative; padding-bottom: 56.25%; height: 0; overflow: hidden; margin-top: 1rem;">
+              <iframe 
+                src="https://www.youtube.com/embed/iQoxvzJQVUQ?autoplay=1&mute=1&loop=1&playlist=iQoxvzJQVUQ" 
+                style="position: absolute; top: 0; left: 0; width: 100%; height: 100%; border: 0;" 
+                allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" 
+                allowfullscreen>
+              </iframe>
+            </div>
+            <h3>Nox Ramirez</h3>
+            <p>(xoloitzcuintle macho talla estándar variedad sin pelo color negro)</p>
+            <p>Nacido este 18 de enero del 2026.</p>
+            <a href="contacto.html">Más información</a>
+            <a class="btn-whatsapp" href="https://wa.me/message/435RTKGJLTX2J1" target="_blank" rel="noopener" onclick="dataLayer.push({ event: 'click_whatsapp', cachorro: 'Nox Ramirez', source: 'xolos_disponibles' })">
+              📲 Consultar vía WhatsApp
+            </a>
+          </article>
+
+          <article class="card" data-aos="zoom-in" data-aos-duration="900" data-aos-delay="700">
+            <picture class="card__media"></picture>
+            <div class="video-container" style="position: relative; padding-bottom: 56.25%; height: 0; overflow: hidden; margin-top: 1rem;">
+              <iframe 
+                src="https://www.youtube.com/embed/45xiyITmsSk?autoplay=1&mute=1&loop=1&playlist=45xiyITmsSk" 
+                style="position: absolute; top: 0; left: 0; width: 100%; height: 100%; border: 0;" 
+                allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" 
+                allowfullscreen>
+              </iframe>
+            </div>
+            <h3>Taxco Ramirez</h3>
+            <p>(xoloitzcuintle hembra talla estándar variedad sin pelo color negro)</p>
+            <p>Nacida este 18 de enero del 2026.</p>
+            <a href="contacto.html">Más información</a>
+            <a class="btn-whatsapp" href="https://wa.me/message/435RTKGJLTX2J1" target="_blank" rel="noopener" onclick="dataLayer.push({ event: 'click_whatsapp', cachorro: 'Taxco Ramirez', source: 'xolos_disponibles' })">
+              📲 Consultar vía WhatsApp
+            </a>
+          </article>
           
         </div>
       </section>


### PR DESCRIPTION
### Motivation
- Add six new puppy profiles to the “Perfiles destacados” section right after Chichiltik Ramirez while preserving the existing card structure, animations, and contact flows.

### Description
- Inserted six `<article class="card">` blocks into `xolos-disponibles.html` immediately after the Chichiltik Ramirez card.
- Each card keeps an empty `picture.card__media`, a `.video-container` with a YouTube Shorts `iframe` embed, and the same `Más información`/WhatsApp button format.
- All cards use `data-aos="zoom-in"` and `data-aos-duration="900"` with progressive `data-aos-delay` values of `450`, `500`, `550`, `600`, `650`, and `700` (50ms increments).
- WhatsApp buttons include `onclick` handlers that call `dataLayer.push` with the puppy name and `source: 'xolos_disponibles'` for tracking.

### Testing
- Served the site locally with `python -m http.server` and rendered `http://127.0.0.1:8000/xolos-disponibles.html` using Playwright to capture a full-page screenshot; screenshot generation succeeded and produced `artifacts/xolos-disponibles.png`.
- Verified the new HTML fragment is present in the rendered output and that the structure, embeds, and buttons appear as expected in the screenshot; no unit tests were required for this static HTML change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697aa969c5fc8332953ef673a11efb33)