### PR TITLE
Add mobile-only secondary CTA, trust micro-block, and sticky WhatsApp CTA on homepage

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -165,6 +165,68 @@ a:hover {
   outline-offset: 3px;
 }
 
+.cta-secondary-mobile {
+  margin-top: 14px;
+  text-align: center;
+}
+
+.cta-secondary-mobile a {
+  font-size: 0.9rem;
+  color: var(--color-dorado);
+  text-decoration: none;
+  letter-spacing: 1px;
+  font-weight: 500;
+}
+
+.cta-secondary-mobile a:hover {
+  text-decoration: underline;
+}
+
+.trust-mobile {
+  text-align: center;
+  padding: 18px 14px;
+  background: rgba(212, 175, 55, 0.08);
+}
+
+.trust-mobile p {
+  font-size: 0.85rem;
+  color: var(--color-texto-suave);
+  line-height: 1.6;
+  margin: 0;
+}
+
+.sticky-xolo-cta {
+  position: fixed;
+  bottom: 14px;
+  left: 50%;
+  transform: translateX(-50%);
+  background: var(--color-secundario);
+  color: var(--color-dorado);
+  padding: 14px 26px;
+  border: 1px solid var(--color-dorado);
+  font-size: 0.9rem;
+  letter-spacing: 2px;
+  text-transform: uppercase;
+  z-index: 999;
+  text-decoration: none;
+  border-radius: 2px;
+  box-shadow: 0 10px 20px rgba(0, 0, 0, 0.15);
+}
+
+@media (min-width: 769px) {
+  .cta-secondary-mobile,
+  .trust-mobile,
+  .sticky-xolo-cta {
+    display: none;
+  }
+}
+
+@media (max-width: 768px) {
+  body {
+    padding-bottom: 90px;
+  }
+}
+
 .grid{
   display:grid; gap: clamp(.75rem, 2.5vw, 1.25rem);
   grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));

--- a/index.html
+++ b/index.html
@@ -107,8 +107,17 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
             <h1>Criadero Xolos Ramírez</h1>
             <p>Guardianes ancestrales de la cultura mexicana.</p>
             <a href="xolos-disponibles.html" class="btn btn--primary">Adopta un Xolo</a>
+            <div class="cta-secondary-mobile">
+              <a href="/testimonios.html" aria-label="Ver historias reales de familias">
+                Ver historias reales de familias →
+              </a>
+            </div>
           </div>
         </div>
+      </section>
+
+      <section class="trust-mobile" data-aos="fade-up" data-aos-duration="900">
+        <p>✔️ Criadero documentado · ✔️ Acompañamiento real · ✔️ Entregas nacionales e internacionales</p>
       </section>
 
       <section data-aos="fade-up" data-aos-duration="1000">
@@ -312,6 +321,14 @@ Selección de Ejemplares de Calidad: Seleccionamos cuidadosamente a los perros q
     <script>
       AOS.init({ once: true, duration: 700, offset: 60, easing: 'ease-out' });
     </script>
+    <a
+      href="https://wa.me/message/435RTKGJLTX2J1"
+      class="sticky-xolo-cta"
+      id="cta-whatsapp-mobile"
+      aria-label="Hablar por WhatsApp"
+    >
+      Hablar por WhatsApp
+    </a>
     <a href="https://app.tonalli.cash" target="_blank" class="tonalli-float-btn">
         open Tonalli
     </a>


### PR DESCRIPTION
### Motivation
- Improve mobile conversions on the home (hero) area by adding a subtle secondary CTA, a compact trust micro-block and a sticky WhatsApp contact, while preserving the site’s dark + gold aesthetic and existing layout.
- Ensure these additions are mobile-first and do not affect desktop UX by restricting visibility to <769px and adding page bottom spacing so the sticky CTA does not cover content.

### Description
- Added a mobile-only secondary CTA under the main hero button in `index.html` inside the hero content as the element with class `cta-secondary-mobile` linking to `/testimonios.html`.
- Inserted a compact trust micro-block immediately after the hero in `index.html` as a `section` with class `trust-mobile` and the requested copy and AOS attributes.
- Appended a sticky WhatsApp CTA near the end of `index.html` (before `</body>`) as an `<a>` with class `sticky-xolo-cta` and `id="cta-whatsapp-mobile"`, using the existing WhatsApp URL found elsewhere on the site (`https://wa.me/message/435RTKGJLTX2J1`).
- Added global CSS rules in `css/styles.css` to style `.cta-secondary-mobile`, `.trust-mobile`, and `.sticky-xolo-cta`, to hide them at `min-width:769px`, and to add `padding-bottom:90px` on mobile so the sticky CTA doesn't overlap content; the styles reuse existing color tokens (e.g. `--color-dorado`) to keep the premium look.

### Testing
- Confirmed the testimonials page exists with `ls` and that the WhatsApp URL is already used elsewhere via `rg` so the same link/phone was reused (search succeeded).
- Launched a local static server with `python -m http.server` and rendered the home page at a mobile viewport using Playwright, producing a screenshot (`artifacts/home-mobile-cta.png`) to validate layout and visibility on mobile (render succeeded).
- Verified the new elements are present in `index.html` and styles are applied by inspecting the updated `css/styles.css` entries (file checks succeeded).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697b586aa1dc8332b340c21e05ea95ed)