### PR TITLE
Mobile CTAs & trust micro-block for xolos-disponibles (mobile-only)

### DIFF
--- a/xolos-disponibles.html
+++ b/xolos-disponibles.html
@@ -110,9 +110,17 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
             Conoce a los xolositzcuintles que buscan un hogar. Cada ficha incluye
             edad, tamaño, personalidad y requisitos de adopción.
           </p>
+          <div class="cta-secondary-mobile">
+            <a href="testimonios.html" aria-label="Ver historias reales de familias"
+              >Ver historias reales de familias →</a
+            >
+          </div>
         </div>
       </section>
 
+      <section class="trust-mobile" data-aos="fade-up" data-aos-duration="900">
+        <p>✔️ Criadero documentado · ✔️ Acompañamiento real · ✔️ Entregas nacionales e internacionales</p>
+      </section>
 
       <section data-aos="fade-up" data-aos-duration="1000">
         <h2>Proceso de adopción responsable</h2>
@@ -652,6 +660,14 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
       </div>
       <p class="copyright">© 2025 Xolos Ramírez. Todos los derechos reservados.</p>
     </footer>
+    <a
+      href="https://wa.me/message/435RTKGJLTX2J1"
+      class="sticky-xolo-cta"
+      id="cta-whatsapp-mobile-disponibles"
+      aria-label="Hablar por WhatsApp"
+    >
+      Hablar por WhatsApp
+    </a>
     <a
       class="whatsapp-float"
       href="https://wa.me/message/435RTKGJLTX2J1"


### PR DESCRIPTION
### Motivation
- Improve mobile conversion by adding a subtle secondary CTA that points to testimonials, a compact trust micro-block, and a sticky WhatsApp CTA that can be tracked separately, without affecting desktop UX.

### Description
- Inserted a mobile-only secondary CTA inside the hero content in `xolos-disponibles.html` using the class `.cta-secondary-mobile` and linking to `testimonios.html` to match the site's nav.
- Added a mobile-only trust micro-block immediately after the hero section in `xolos-disponibles.html` using the class `.trust-mobile` with the three guarantee phrases requested.
- Appended a mobile-only sticky WhatsApp anchor before `</body>` in `xolos-disponibles.html` with `class="sticky-xolo-cta"` and `id="cta-whatsapp-mobile-disponibles"` and reused the existing site WhatsApp link (`https://wa.me/message/435RTKGJLTX2J1`).
- Merged mobile styles into the global stylesheet `css/styles.css` to implement the three unique classes, visibility rules (show only under 769px), and `body { padding-bottom: 90px; }` for `<768px` to avoid the sticky CTA covering content, reusing existing color tokens/variables.
- Files modified: `xolos-disponibles.html` and `css/styles.css`.

### Testing
- Started a local dev server with `python -m http.server` and captured a mobile viewport screenshot using Playwright at `390x844` to validate placement and visibility, and the visual smoke check succeeded and produced an artifact.
- Verified via automated text searches (`rg`) that the existing WhatsApp link is reused and that the new `id="cta-whatsapp-mobile-disponibles"` and classes are present in the updated files.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697b5b294a208332bd35730ba91a6ab3)