### PR TITLE
Add archaeology article card to blog index

### DIFF
--- a/blog/index.html
+++ b/blog/index.html
@@ -212,6 +212,28 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
      </a>
     </div>
    </article>
+   <article class="blog-card" data-aos="fade-up">
+    <div class="card-image">
+     <img alt="Hallazgo arqueológico en La Lagunilla INAH" src="https://inah.gob.mx/images/boletines/2025/648/foto6.jpg"/>
+     <span class="category">
+      Arqueología / INAH
+     </span>
+    </div>
+    <div class="card-content">
+     <span class="post-date">
+      29 de Enero, 2026
+     </span>
+     <h3>
+      Restos de Xoloitzcuintle y entierros en Tlatelolco
+     </h3>
+     <p>
+      Análisis de los hallazgos del INAH en La Lagunilla: entierros infantiles y restos animales que definen los límites del islote de Tlatelolco...
+     </p>
+     <a class="read-more" href="restos-arqueologico-xoloitzcuintle-tlatelolco.html">
+      Leer reporte académico →
+     </a>
+    </div>
+   </article>
    <article class="blog-card">
     <div class="card-image">
      <img alt="Tonalli Wallet Tutorial" src="../img/blog/AlergiasXolo.png"/>


### PR DESCRIPTION
### Motivation
- Surface a recent INAH La Lagunilla archaeological report as a featured item in the blog listing so it appears among recent posts.
- Keep the blog index up to date with a dedicated card including image, category, date, excerpt and link for the new article.

### Description
- Inserted an `<article class="blog-card" data-aos="fade-up">` block immediately after the Ceniza Ramírez entry in `blog/index.html` containing the image, category `Arqueología / INAH`, date `29 de Enero, 2026`, title `Restos de Xoloitzcuintle y entierros en Tlatelolco`, excerpt text, and link `restos-arqueologico-xoloitzcuintle-tlatelolco.html`.
- The change is a static HTML insertion in `blog/index.html` (about 22 lines added around the blog list section).

### Testing
- Started a local server with `python -m http.server 8000` and loaded `/blog/index.html` successfully.
- Captured a full-page screenshot using Playwright which saved to `artifacts/blog-index-new-article.png` and confirmed the new card rendered without errors.
- Verified the modified file is present at `blog/index.html` and the inserted article appears in the blog listing when served locally.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697b6bacfd0c8332a9e311ff42a0fbbd)