### PR TITLE
Add testimonials and blog CTA sections to contacto.html

### DIFF
--- a/contacto.html
+++ b/contacto.html
@@ -157,6 +157,26 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
           </article>
         </div>
       </section>
+
+      <section class="cta-testimonios-wrapper" data-aos="fade-up" data-aos-duration="1000">
+        <div class="container text-center">
+          <h2>Historias reales de adopción</h2>
+          <p>Conoce las experiencias de familias que ya adoptaron un Xoloitzcuintle con nosotros.</p>
+          <a href="testimonios.html" class="btn-aesthetic">
+            Ver testimonios <span class="btn-icon">→</span>
+          </a>
+        </div>
+      </section>
+
+      <section class="cta-blog-wrapper" data-aos="fade-up" data-aos-duration="1000" data-aos-delay="100">
+        <div class="container text-center">
+          <h2>Aprende antes de adoptar</h2>
+          <p>¿Tienes dudas sobre el Xoloitzcuintle? Encuentra respuestas y consejos en nuestro blog especializado.</p>
+          <a href="blog/index.html" class="btn-aesthetic">
+            Visitar Blog <span class="btn-icon">→</span>
+          </a>
+        </div>
+      </section>
     </main>
 
     <footer>


### PR DESCRIPTION
### Motivation

- Add two call-to-action blocks to the contact page to promote testimonials and the blog and boost user engagement.
- Place the CTAs right before the closing `</main>` after the "Información adicional" section so they appear prominently above the footer.

### Description

- Inserted two HTML sections in `contacto.html`: a `cta-testimonios-wrapper` linking to `testimonios.html` and a `cta-blog-wrapper` linking to `blog/index.html`, both with AOS attributes for animation.
- The new blocks contain headings, descriptive copy and `.btn-aesthetic` links and were added immediately before the `</main>` tag.
- Only `contacto.html` was modified (about 20 lines added).

### Testing

- Confirmed the change by searching and printing the file (`rg`/`sed`/`nl`) to verify the inserted lines succeeded.
- Launched a local server with `python -m http.server 8000` and used a Playwright script to load `http://127.0.0.1:8000/contacto.html` and capture a screenshot saved as `artifacts/contacto-cta.png`; the page loaded and the screenshot was produced successfully.
- Staged and committed the change with `git add contacto.html` and `git commit` which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6988c4e6bd548332979ffbe538c467fd)