### PR TITLE
Remove language switch UI and script handling

### DIFF
--- a/index.html
+++ b/index.html
@@ -84,9 +84,6 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
             <li><a href="contacto.html">Contacto</a></li>
           </ul>
         </nav>
-        <div class="lang-switch">
-          <a href="en/index.html" lang="en" aria-label="Ver sitio en inglés">EN</a>
-        </div>
       </div>
     </header>
 

--- a/js/main.js
+++ b/js/main.js
@@ -50,26 +50,3 @@ if (navMenu) {
     }
   });
 }
-
-document.addEventListener('DOMContentLoaded', () => {
-  const langLinks = document.querySelectorAll('.lang-switch a');
-
-  langLinks.forEach((link) => {
-    link.addEventListener('click', () => {
-      const selectedLang = link.getAttribute('lang');
-      if (!selectedLang) return;
-
-      localStorage.setItem('preferredLang', selectedLang);
-    });
-  });
-
-  const savedLang = localStorage.getItem('preferredLang');
-  const pageLang = document.documentElement.getAttribute('lang');
-
-  if (savedLang && savedLang !== pageLang) {
-    const preferredLink = document.querySelector(`.lang-switch a[lang="${savedLang}"]`);
-    if (preferredLink) {
-      window.location.href = preferredLink.href;
-    }
-  }
-});


### PR DESCRIPTION
### Motivation
- Remove the language switch UI and client-side language preference/redirect logic to prevent console errors and unwanted automatic locale redirects.

### Description
- Removed the `<div class="lang-switch">` block from `index.html`.
- Deleted the `DOMContentLoaded` handler that stored `preferredLang` and performed a redirect from `js/main.js`.

### Testing
- Verified occurrences with `rg` to confirm the markup and script references were removed.
- Served the site locally with `python -m http.server 8000` and captured a screenshot with a Playwright script which completed and produced `artifacts/index-no-lang-switch.png`.
- Committed the changes with `git commit` which succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6988e9e18db4833291fd40ebcbbdcb32)