### PR TITLE
Update contact forms to use new Formspree endpoint and correct contact details

### DIFF
--- a/contacto.html
+++ b/contacto.html
@@ -109,7 +109,7 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
       <section data-aos="fade-up" data-aos-duration="1000">
         <h2>Formulario de contacto</h2>
         <form
-          action="https://formspree.io/f/mwvpewrz"
+          action="https://formspree.io/f/xbdzegwj"
           method="POST"
           aria-label="Formulario de contacto general"
           data-aos="fade-up"
@@ -153,7 +153,7 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
           <article class="card" data-aos="zoom-in" data-aos-delay="250">
             <h3>Contacto directo</h3>
             <p><strong>Teléfono:</strong> +52 55 18555993</p>
-            <p><strong>Correo:</strong> contacto@xolosarmy.xyz</p> <br> <p> fernando@xolosramirez.com </p>
+            <p><strong>Correo:</strong> fernando@xolosramirez.com</p>
           </article>
         </div>
       </section>

--- a/en/contact.html
+++ b/en/contact.html
@@ -113,6 +113,8 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
       <section data-aos="fade-up" data-aos-duration="1000">
         <h2>Contact form</h2>
         <form
+          action="https://formspree.io/f/xbdzegwj"
+          method="POST"
           aria-label="General contact form"
           data-aos="fade-up"
           data-aos-delay="150"
@@ -155,8 +157,8 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
           </article>
           <article class="card" data-aos="zoom-in" data-aos-delay="250">
             <h3>Direct contact</h3>
-            <p><strong>Phone:</strong> +52 55 1234 5678</p>
-            <p><strong>Email:</strong> hola@xolosramirez.mx</p>
+            <p><strong>Phone:</strong> +52 55 18555993</p>
+            <p><strong>Email:</strong> fernando@xolosramirez.com</p>
           </article>
         </div>
       </section>


### PR DESCRIPTION
### Motivation
- Point both Spanish and English contact forms to the requested Formspree endpoint and ensure the English form submits via POST while preserving GTM tracking.
- Replace placeholder direct-contact data with the production phone and email for both language pages.

### Description
- Set the form `action` to `https://formspree.io/f/xbdzegwj` and `method="POST"` in `contacto.html`.
- Add `action="https://formspree.io/f/xbdzegwj"` and `method="POST"` to the form in `en/contact.html` while keeping the existing `onsubmit="dataLayer.push(...)"` handler and GTM attributes.
- Replace the direct contact cards in `contacto.html` and `en/contact.html` to use `+52 55 18555993` and `fernando@xolosramirez.com`.

### Testing
- Executed `rg -n "formspree.io/f/xbdzegwj|fernando@xolosramirez.com|55 18555993|submit_contact" contacto.html en/contact.html` and all expected patterns were found (passed).
- Verified the updated sections with `nl -ba contacto.html | sed -n '108,160p'` and `nl -ba en/contact.html | sed -n '113,165p'` to confirm the form attributes and contact lines were updated (passed).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69becd7b76d88332a5249411405a2dcb)