### PR TITLE
Update featured puppy contact links

### DIFF
--- a/xolos-disponibles.html
+++ b/xolos-disponibles.html
@@ -189,7 +189,7 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
       </ul>
       <div class="puppy-card__actions">
         <a href="https://www.youtube.com/watch?v=C261rB3ch48" class="btn-small btn-outline-small" target="_blank" rel="noopener">Ver video 🎥</a>
-        <a href="https://wa.me/message/435RTKGJLTX2J1?text=Hola,%20me%20interesa%20reservar%20a%20Humo" class="btn-small btn-primary-small" target="_blank" rel="noopener" onclick="dataLayer.push({ event: 'click_whatsapp', cachorro: 'Humo Ramirez', source: 'xolos_disponibles_reservar' })">Reservar</a>
+        <a href="mailto:fernando@xolosramirez.com?subject=Interés en Humo Ramirez&body=Hola, me gustaría recibir información para reservar a Humo Ramirez." class="btn-small btn-primary-small" onclick="dataLayer.push({ event: 'click_email', cachorro: 'Humo Ramirez', source: 'xolos_disponibles_contactar' })">Contactar por Email</a>
       </div>
     </div>
   </article>
@@ -218,7 +218,7 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
       </ul>
       <div class="puppy-card__actions">
         <a href="https://www.youtube.com/watch?v=RfcNi1zoJJA" class="btn-small btn-outline-small" target="_blank" rel="noopener">Ver video 🎥</a>
-        <a href="https://wa.me/message/435RTKGJLTX2J1?text=Hola,%20me%20interesa%20reservar%20a%20Tonatiuh" class="btn-small btn-primary-small" target="_blank" rel="noopener" onclick="dataLayer.push({ event: 'click_whatsapp', cachorro: 'Tonatiuh Ramirez', source: 'xolos_disponibles_reservar' })">Reservar</a>
+        <a href="mailto:fernando@xolosramirez.com?subject=Interés en Tonatiuh Ramirez&body=Hola, me gustaría recibir información para reservar a Tonatiuh Ramirez." class="btn-small btn-primary-small" onclick="dataLayer.push({ event: 'click_email', cachorro: 'Tonatiuh Ramirez', source: 'xolos_disponibles_contactar' })">Contactar por Email</a>
       </div>
     </div>
   </article>
@@ -247,7 +247,7 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
       </ul>
       <div class="puppy-card__actions">
         <a href="https://www.youtube.com/watch?v=HaPx8Bv3Pcg" class="btn-small btn-outline-small" target="_blank" rel="noopener">Ver video 🎥</a>
-        <a href="https://wa.me/message/435RTKGJLTX2J1?text=Hola,%20me%20interesa%20reservar%20a%20Ozomatli" class="btn-small btn-primary-small" target="_blank" rel="noopener" onclick="dataLayer.push({ event: 'click_whatsapp', cachorro: 'Ozomatli Ramirez', source: 'xolos_disponibles_reservar' })">Reservar</a>
+        <a href="mailto:fernando@xolosramirez.com?subject=Interés en Ozomatli Ramirez&body=Hola, me gustaría recibir información para reservar a Ozomatli Ramirez." class="btn-small btn-primary-small" onclick="dataLayer.push({ event: 'click_email', cachorro: 'Ozomatli Ramirez', source: 'xolos_disponibles_contactar' })">Contactar por Email</a>
       </div>
     </div>
   </article>
@@ -276,7 +276,7 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
       </ul>
       <div class="puppy-card__actions">
         <a href="https://www.youtube.com/watch?v=k8YQjGDdQaM" class="btn-small btn-outline-small" target="_blank" rel="noopener">Ver video 🎥</a>
-        <a href="https://wa.me/message/435RTKGJLTX2J1?text=Hola,%20me%20interesa%20reservar%20a%20Nox" class="btn-small btn-primary-small" target="_blank" rel="noopener" onclick="dataLayer.push({ event: 'click_whatsapp', cachorro: 'Nox Ramirez', source: 'xolos_disponibles_reservar' })">Reservar</a>
+        <a href="mailto:fernando@xolosramirez.com?subject=Interés en Nox Ramirez&body=Hola, me gustaría recibir información para reservar a Nox Ramirez." class="btn-small btn-primary-small" onclick="dataLayer.push({ event: 'click_email', cachorro: 'Nox Ramirez', source: 'xolos_disponibles_contactar' })">Contactar por Email</a>
       </div>
     </div>
   </article>
@@ -307,7 +307,7 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
       </ul>
       <div class="puppy-card__actions">
         <a href="https://www.youtube.com/watch?v=dWwc4FRzI8g" class="btn-small btn-outline-small" target="_blank" rel="noopener">Ver video 🎥</a>
-        <a href="https://wa.me/message/435RTKGJLTX2J1?text=Hola,%20me%20interesa%20reservar%20a%20Teyolia" class="btn-small btn-primary-small" target="_blank" rel="noopener" onclick="dataLayer.push({ event: 'click_whatsapp', cachorro: 'Teyolia Ramirez', source: 'xolos_disponibles_reservar' })">Reservar</a>
+        <a href="mailto:fernando@xolosramirez.com?subject=Interés en Teyolia Ramirez&body=Hola, me gustaría recibir información para reservar a Teyolia Ramirez." class="btn-small btn-primary-small" onclick="dataLayer.push({ event: 'click_email', cachorro: 'Teyolia Ramirez', source: 'xolos_disponibles_contactar' })">Contactar por Email</a>
       </div>
     </div>
   </article>


### PR DESCRIPTION
### Motivation
- Cambiar la acción de reserva en la sección “Perfiles destacados” de WhatsApp a contacto directo por correo para centralizar consultas en `fernando@xolosramirez.com`.
- Alinear la métrica de seguimiento (`dataLayer`) y el texto del CTA para que las analíticas reflejen clics de email en lugar de WhatsApp.

### Description
- Reemplacé las 5 etiquetas `<a>` de reserva en `xolos-disponibles.html` (Humo, Tonatiuh, Ozomatli, Nox, Teyolia) por `mailto:` a `fernando@xolosramirez.com` con asunto y cuerpo predefinidos para cada cachorro.
- Actualicé el texto visible del botón de `Reservar` a `Contactar por Email` en esas cinco tarjetas.
- Cambié el tracking en `onclick` de `event: 'click_whatsapp'`/`source: 'xolos_disponibles_reservar'` a `event: 'click_email'`/`source: 'xolos_disponibles_contactar'` y eliminé `target="_blank" rel="noopener"` en los enlaces modificados.
- Los cambios fueron comprometidos en Git con el commit `ab71bfe` (`Update featured puppy contact links`).

### Testing
- Ejecuté `git diff -- xolos-disponibles.html` para verificar las modificaciones y la salida fue correcta (éxito). 
- Inspeccioné el archivo con `nl -ba xolos-disponibles.html | sed -n '184,312p'` para confirmar los reemplazos en contexto (éxito). 
- Realicé `git add xolos-disponibles.html && git commit -m "Update featured puppy contact links"` y el commit se creó correctamente (éxito, `ab71bfe`).
- Verifiqué `git rev-parse --short HEAD && git status --short` para confirmar el HEAD y el estado del repositorio y ambos comandos devolvieron resultados esperados (éxito).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bef92d9ed483329c05e18f221bb36b)