### PR TITLE
Reemplazar botón flotante de WhatsApp por contacto por email

### DIFF
--- a/xolos-disponibles.html
+++ b/xolos-disponibles.html
@@ -493,15 +493,11 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
     </footer>
     
     <a
-      class="whatsapp-float"
-      href="https://wa.me/message/435RTKGJLTX2J1"
-      target="_blank"
-      rel="noopener"
-      data-gtm="whatsapp"
-      data-cachorro="general"
-      onclick="dataLayer.push({ event: 'click_whatsapp', cachorro: 'general', source: 'xolos_disponibles_floating' })"
+      href="mailto:fernando@xolosramirez.com?subject=Inter%C3%A9s%20en%20Xoloitzcuintle&body=Hola,%20me%20gustar%C3%ADa%20recibir%20informaci%C3%B3n%20sobre%20los%20xoloitzcuintles%20disponibles."
+      class="floating-contact-btn"
+      onclick="dataLayer.push({ event: 'click_email', source: 'xolos_disponibles_floating_contact' })"
     >
-      📲 WhatsApp directo
+      ✉️ Email
     </a>
     <script src="js/main.js" defer></script>
     <script src="https://unpkg.com/aos@2.3.1/dist/aos.js"></script>


### PR DESCRIPTION
### Motivation
- Dirigir el CTA flotante a correo electrónico para que los interesados escriban a `fernando@xolosramirez.com` y registrar clics como `click_email` en lugar de WhatsApp.

### Description
- En `xolos-disponibles.html` se reemplazó el anchor flotante que apuntaba a `https://wa.me/...` por el enlace `mailto:` solicitado, se ajustó la clase a `floating-contact-btn`, se cambió la etiqueta visible a `✉️ Email` y se actualizó el evento de analítica a `click_email` con `source: 'xolos_disponibles_floating_contact'`.

### Testing
- Se verificó programáticamente el contenido del archivo y se revisó el diff para confirmar que el `mailto:` y el evento `click_email` están presentes en `xolos-disponibles.html` (inspección del marcado y comprobación del diff exitosa).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bff818bb6083329fc4d4efc3a530c0)