### PR TITLE
Update floating email CTA styling

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -1295,3 +1295,30 @@ form textarea:focus {
   border-color: #2c2c2c;
   background-color: #f9f9f9;
 }
+
+/* Botón Flotante de Email - Xolos Ramirez */
+.email-float {
+  position: fixed;
+  right: 1.5rem;
+  bottom: 1.5rem;
+  background-color: #2c2c2c; /* Fondo oscuro elegante */
+  color: #d4af37;           /* Dorado Xolo */
+  padding: 0.85rem 1.5rem;
+  border: 1px solid #d4af37;
+  border-radius: 999px;
+  font-weight: 700;
+  display: inline-flex;
+  align-items: center;
+  gap: 0.75rem;
+  box-shadow: 0 8px 25px rgba(0, 0, 0, 0.5);
+  z-index: 9999;            /* Asegura que esté por encima de todo */
+  text-decoration: none;
+  transition: all 0.3s ease;
+}
+
+.email-float:hover {
+  background-color: #d4af37;
+  color: #111;
+  transform: translateY(-3px);
+  text-decoration: none;
+}

--- a/public/xolos-disponibles.html
+++ b/public/xolos-disponibles.html
@@ -270,16 +270,13 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
     <p class="copyright">© 2025 Xolos Ramírez. Todos los derechos reservados.</p>
   </footer>
 
-  <a
-    class="whatsapp-float"
-    href="https://wa.me/message/435RTKGJLTX2J1"
-    target="_blank"
-    rel="noopener"
-    data-gtm="whatsapp"
-    data-cachorro="general"
-    onclick="dataLayer.push({ event: 'click_whatsapp', cachorro: 'general', source: 'xolos_disponibles_public_floating' })"
+    <a
+    class="email-float"
+    href="mailto:fernando@xolosramirez.com?subject=Consulta sobre Xolos Disponibles&body=Hola Fernando, me interesa obtener más información sobre los ejemplares disponibles en la web."
+    data-gtm="email-floating"
+    onclick="dataLayer.push({ event: 'click_email', cachorro: 'general', source: 'xolos_disponibles_floating' })"
   >
-    📲 WhatsApp directo
+    <span>📧 Contactar por Email</span>
   </a>
 
   <!-- Script de filtrado -->

--- a/xolos-disponibles.html
+++ b/xolos-disponibles.html
@@ -492,12 +492,13 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
       <p class="copyright">© 2025 Xolos Ramírez. Todos los derechos reservados.</p>
     </footer>
     
-    <a
-      href="mailto:fernando@xolosramirez.com?subject=Inter%C3%A9s%20en%20Xoloitzcuintle&body=Hola,%20me%20gustar%C3%ADa%20recibir%20informaci%C3%B3n%20sobre%20los%20xoloitzcuintles%20disponibles."
-      class="floating-contact-btn"
-      onclick="dataLayer.push({ event: 'click_email', source: 'xolos_disponibles_floating_contact' })"
+        <a
+      class="email-float"
+      href="mailto:fernando@xolosramirez.com?subject=Consulta sobre Xolos Disponibles&body=Hola Fernando, me interesa obtener más información sobre los ejemplares disponibles en la web."
+      data-gtm="email-floating"
+      onclick="dataLayer.push({ event: 'click_email', cachorro: 'general', source: 'xolos_disponibles_floating' })"
     >
-      ✉️ Mas informacion
+      <span>📧 Contactar por Email</span>
     </a>
     <script src="js/main.js" defer></script>
     <script src="https://unpkg.com/aos@2.3.1/dist/aos.js"></script>


### PR DESCRIPTION
### Motivation
- Replace the previous WhatsApp floating action with an email-focused CTA and ensure it matches the site's gold/black visual identity.
- Ensure GTM/dataLayer events track email clicks consistently instead of the old WhatsApp event.

### Description
- Added the `.email-float` styling block to `css/styles.css` to create the gold-and-black floating button with hover state and elevated `z-index`.
- Replaced the floating contact link in `xolos-disponibles.html` with the requested `mailto:` snippet that includes `data-gtm="email-floating"` and a `dataLayer.push` of `event: 'click_email'`.
- Applied the same replacement in `public/xolos-disponibles.html` to keep the public copy consistent with the main page.

### Testing
- Ran `git diff --check` to validate there are no whitespace/errors in the diff and it succeeded.
- Searched files with `rg -n "email-float|click_email|email-floating" css/styles.css xolos-disponibles.html public/xolos-disponibles.html` to confirm the new selectors and tracking strings are present and it succeeded.
- No visual screenshot was generated because a browser capture tool was not available in this environment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bffd8a40b48332a37e5ca347264c5f)