### PR TITLE
Actualizar CTA flotante de WhatsApp a Email en la página de inicio

### DIFF
--- a/index.html
+++ b/index.html
@@ -361,12 +361,13 @@ Perro de Servicio</h2>
       AOS.init({ once: true, duration: 700, offset: 60, easing: 'ease-out' });
     </script>
     <a
-      href="https://wa.me/message/435RTKGJLTX2J1"
-      class="sticky-xolo-cta"
-      id="cta-whatsapp-mobile"
-      aria-label="Hablar por WhatsApp"
+      class="email-float"
+      href="mailto:fernando@xolosramirez.com?subject=Consulta desde el Inicio&body=Hola Fernando, vengo desde la página principal de Xolos Ramírez y me gustaría obtener más información."
+      data-gtm="email-floating"
+      onclick="dataLayer.push({ event: 'click_email', cachorro: 'general', source: 'index_floating' })"
+      aria-label="Contactar por Email"
     >
-      Hablar por WhatsApp
+      <span>📧 Contactar por Email</span>
     </a>
     <a href="https://app.tonalli.cash" target="_blank" class="tonalli-float-btn">
         open Tonalli


### PR DESCRIPTION
### Motivation
- Cambiar el método de contacto visible en la página principal de WhatsApp a correo electrónico para usar `mailto` y registrar clics con GTM (`click_email`).

### Description
- Reemplacé el CTA flotante de WhatsApp en `index.html` por un enlace `mailto:` con `class="email-float"`, `data-gtm="email-floating"` y `onclick="dataLayer.push({ event: 'click_email', cachorro: 'general', source: 'index_floating' })"`, manteniendo el estilo existente en `css/styles.css` sin modificaciones.

### Testing
- Ejecuté `git diff -- index.html`, `git status --short` y `git log -1 --stat --oneline` para verificar los cambios y confirmarlos; los comandos devolvieron los resultados esperados y el cambio fue cometido correctamente.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c000304ee883328b0a62048ec370d6)