### PR TITLE
Move live show section to xolos-disponibles and add responsive styles

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -1322,3 +1322,130 @@ form textarea:focus {
   transform: translateY(-3px);
   text-decoration: none;
 }
+
+
+.live-show{
+  padding-top: clamp(2rem, 5vw, 3.5rem);
+}
+
+.live-show__container{
+  display:grid;
+  grid-template-columns: minmax(0, 0.9fr) minmax(0, 1.1fr);
+  gap: clamp(1.5rem, 4vw, 3rem);
+  align-items:center;
+  padding: clamp(1.5rem, 4vw, 2.5rem);
+  background: linear-gradient(145deg, rgba(34, 27, 31, 0.94), rgba(17, 17, 17, 0.96));
+  border: 1px solid var(--color-borde);
+  border-radius: 1.5rem;
+  box-shadow: var(--sombra-suave);
+}
+
+.live-show__content h2{
+  margin: 0.4rem 0 1rem;
+}
+
+.live-show__content p{
+  margin: 0;
+  max-width: 54ch;
+  color: var(--color-texto-suave);
+}
+
+.live-show__eyebrow{
+  display:inline-flex;
+  align-items:center;
+  gap:0.45rem;
+  color: var(--color-dorado);
+  text-transform: uppercase;
+  letter-spacing: 0.18em;
+  font-size: 0.82rem;
+  font-weight: 600;
+}
+
+.live-show__eyebrow::before{
+  content: '';
+  width: 2.5rem;
+  height: 1px;
+  background: linear-gradient(90deg, transparent, var(--color-dorado));
+}
+
+.live-show__frame{
+  position:relative;
+}
+
+.live-show__badge{
+  position:absolute;
+  top: 1rem;
+  right: 1rem;
+  z-index: 2;
+  display:inline-flex;
+  align-items:center;
+  gap:0.5rem;
+  padding: 0.5rem 0.9rem;
+  border-radius: 999px;
+  background: rgba(15, 15, 15, 0.92);
+  border: 1px solid rgba(212, 175, 55, 0.45);
+  color: var(--color-dorado);
+  font-size: 0.78rem;
+  font-weight: 700;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  box-shadow: 0 10px 25px rgba(0, 0, 0, 0.35);
+}
+
+.live-show__dot{
+  width: 0.65rem;
+  height: 0.65rem;
+  border-radius: 50%;
+  background: #ff4d4f;
+  box-shadow: 0 0 0 0 rgba(255, 77, 79, 0.65);
+  animation: livePulse 1.6s infinite;
+}
+
+.live-show__video{
+  position:relative;
+  width:100%;
+  aspect-ratio: 16 / 9;
+  overflow:hidden;
+  border-radius: 1.2rem;
+  border: 1px solid rgba(212, 175, 55, 0.35);
+  background: #000;
+  box-shadow: var(--sombra-profunda);
+}
+
+.live-show__video iframe{
+  position:absolute;
+  inset:0;
+  width:100%;
+  height:100%;
+  border:0;
+}
+
+@keyframes livePulse{
+  0%{ box-shadow: 0 0 0 0 rgba(255, 77, 79, 0.65); }
+  70%{ box-shadow: 0 0 0 12px rgba(255, 77, 79, 0); }
+  100%{ box-shadow: 0 0 0 0 rgba(255, 77, 79, 0); }
+}
+
+@media (max-width: 900px){
+  .live-show__container{
+    grid-template-columns: 1fr;
+  }
+
+  .live-show__content p{
+    max-width: none;
+  }
+}
+
+@media (max-width: 640px){
+  .live-show__container{
+    padding: 1.25rem;
+    border-radius: 1.1rem;
+  }
+
+  .live-show__badge{
+    top: 0.75rem;
+    right: 0.75rem;
+    padding: 0.45rem 0.75rem;
+    font-size: 0.72rem;
+  }
+}

--- a/testimonios.html
+++ b/testimonios.html
@@ -466,37 +466,6 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
             </div>
           </article>
 
-          <article class="post-card live-session" data-aos="zoom-in" style="border: 2px solid #ff0000; box-shadow: 0 0 15px rgba(255, 0, 0, 0.2); position: relative;">
-  
-  <div class="live-badge" style="position: absolute; top: 10px; right: 10px; background: #ff0000; color: #fff; padding: 4px 12px; border-radius: 4px; font-weight: bold; font-size: 0.8rem; z-index: 10; display: flex; align-items: center; gap: 5px; text-transform: uppercase; letter-spacing: 1px;">
-    <span style="width: 8px; height: 8px; background: white; border-radius: 50%; display: inline-block; animation: pulse 1.5s infinite;"></span>
-    En Vivo
-  </div>
-
-  <div class="video-container" style="position: relative; padding-bottom: 56.25%; height: 0; overflow: hidden;">
-    <iframe 
-      src="https://www.youtube.com/embed/vgfZrxCzQCE?autoplay=1&mute=1&loop=1&playlist=vgfZrxCzQCE" 
-      style="position: absolute; top: 0; left: 0; width: 100%; height: 100%; border: 0;" 
-      allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" 
-      allowfullscreen>
-    </iframe>
-  </div>
-  
-  <div class="post-card__body" style="background: linear-gradient(180deg, rgba(255,0,0,0.05) 0%, transparent 100%);">
-    <blockquote style="font-style: italic; margin-bottom: 1rem;">
-      <p>“Ve aquí nuestra última <strong>Emisión en Vivo</strong>”</p>
-    </blockquote>
-    <cite style="color: #ff0000; font-weight: bold;">— Xolos Ramírez Comunidad</cite>
-  </div>
-</article>
-
-<style>
-  @keyframes pulse {
-    0% { opacity: 1; transform: scale(1); }
-    50% { opacity: 0.4; transform: scale(1.2); }
-    100% { opacity: 1; transform: scale(1); }
-  }
-</style>
 
         </div>
       </section>

--- a/xolos-disponibles.html
+++ b/xolos-disponibles.html
@@ -161,6 +161,32 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
         </div>
       </section>
 
+      <section class="live-show section" data-aos="fade-up" data-aos-duration="1000" data-aos-delay="90">
+        <div class="container live-show__container">
+          <div class="live-show__content">
+            <span class="live-show__eyebrow">En vivo</span>
+            <h2>The Xolos Ramirez Show</h2>
+            <p>Conéctate con nuestra transmisión en vivo para conocer más de la comunidad Xolos Ramírez, ver a nuestros ejemplares y mantener el impulso antes de explorar los perfiles destacados.</p>
+          </div>
+          <div class="live-show__frame">
+            <div class="live-show__badge" aria-label="Transmisión en vivo">
+              <span class="live-show__dot" aria-hidden="true"></span>
+              En Vivo
+            </div>
+            <div class="live-show__video">
+              <iframe
+                src="https://www.youtube.com/embed/live_stream?channel=UCKtNKCavbBmxtcdHSDd9BsA&mute=1&rel=0"
+                title="The Xolos Ramirez Show en vivo"
+                loading="lazy"
+                allow="accelerometer; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share"
+                referrerpolicy="strict-origin-when-cross-origin"
+                allowfullscreen
+              ></iframe>
+            </div>
+          </div>
+        </div>
+      </section>
+
       <section data-aos="fade-up" data-aos-duration="1000" data-aos-delay="100">
         <h2>Perfiles destacados</h2>
         <div class="puppy-grid">


### PR DESCRIPTION
### Motivation
- Consolidate the live broadcast promo into the primary adoption page so visitors see `The Xolos Ramirez Show` between the trust/guarantees block and the featured puppy profiles. 
- Preserve the current dark + gold visual identity and AOS animations while ensuring the embed is responsive, accessible and non-disruptive to conversion flows. 

### Description
- Removed the legacy inline live block from `testimonios.html` so the testimonials page no longer contains the old live embed. 
- Inserted a new `The Xolos Ramirez Show / En Vivo` section into `xolos-disponibles.html` immediately after the `Confianza y garantías` (`trust`) section and before `Perfiles destacados`, keeping the existing `data-aos` attributes. 
- Added responsive dark-and-gold styles to `css/styles.css` under the `.live-show*` class set (16:9 video via `aspect-ratio: 16 / 9`, badge/pulse styling, mobile grid fallback). 
- The embedded iframe uses the exact URL `https://www.youtube.com/embed/live_stream?channel=UCKtNKCavbBmxtcdHSDd9BsA&mute=1&rel=0`, includes `loading="lazy"`, does not enable autoplay, and preserves `mute=1` and `rel=0` query params. 
- Modified files: `testimonios.html`, `xolos-disponibles.html`, and `css/styles.css`.

### Testing
- Verified presence/absence with a recursive search using `rg` for markers (`The Xolos Ramirez Show`, `live_stream`, `loading="lazy"`, `rel=0`, `mute=1`, `live-show`) which returned the new styles and embed only in `xolos-disponibles.html` and `css/styles.css` and not in `testimonios.html`. 
- Inspected the source diff with `git diff -- testimonios.html xolos-disponibles.html css/styles.css` to confirm the old block was removed and the new section + styles were added as intended. 
- Ran a workspace status check to ensure the three files are staged/modified and the repository is in a consistent state; automated checks completed without errors. 
- No browser screenshot test was executed in this environment (visual QA recommended before deployment).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c01fd55a24833281c5db2f76db2f0a)