### PR TITLE
Optimize media loading on testimonios page

### DIFF
--- a/testimonios.html
+++ b/testimonios.html
@@ -93,6 +93,7 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
           <iframe 
             src="https://www.youtube.com/embed/dSgxcEPBxws?si=LZZyFqWyxYAyKDkj&autoplay=1&mute=1&controls=0&loop=1&playlist=dSgxcEPBxws" 
             title="YouTube video player" 
+            loading="eager"
             frameborder="0" 
             allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" 
             allowfullscreen
@@ -150,7 +151,7 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
           
            <article class="post-card">
             <div class="video-container" style="position: relative; padding-bottom: 56.25%; height: 0; overflow: hidden;">
-              <iframe src="https://www.youtube.com/embed/CaFq2rbF4Io&si=pgbJw5bhweJfCoAh?autoplay=1&mute=1&loop=1&playlist=CaFq2rbF4Io" style="position: absolute; top: 0; left: 0; width: 100%; height: 100%; border: 0;" allowfullscreen></iframe>
+              <iframe src="https://www.youtube.com/embed/CaFq2rbF4Io&si=pgbJw5bhweJfCoAh?autoplay=1&mute=1&loop=1&playlist=CaFq2rbF4Io" style="position: absolute; top: 0; left: 0; width: 100%; height: 100%; border: 0;" loading="lazy" allowfullscreen></iframe>
             </div>
             <div class="video-info">
             <h3>Fonzi & Tizoc "Tonalli" Ramírez</h3>
@@ -176,7 +177,7 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
           
           <article class="post-card">
             <div class="video-container" style="position: relative; padding-bottom: 56.25%; height: 0; overflow: hidden;">
-              <iframe src="https://www.youtube.com/embed/MpEkLAxhe_0?autoplay=1&mute=1&loop=1&playlist=MpEkLAxhe_0" style="position: absolute; top: 0; left: 0; width: 100%; height: 100%; border: 0;" allowfullscreen></iframe>
+              <iframe src="https://www.youtube.com/embed/MpEkLAxhe_0?autoplay=1&mute=1&loop=1&playlist=MpEkLAxhe_0" style="position: absolute; top: 0; left: 0; width: 100%; height: 100%; border: 0;" loading="lazy" allowfullscreen></iframe>
             </div>
             <div class="post-card__body">
               <blockquote style="font-style: italic; margin-bottom: 1rem;">
@@ -191,7 +192,7 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
 
           <article class="post-card">
             <div class="video-container" style="position: relative; padding-bottom: 56.25%; height: 0; overflow: hidden;">
-              <iframe src="https://www.youtube.com/embed/F1A_BXLcD_Y?autoplay=1&mute=1&loop=1&playlist=F1A_BXLcD_Y" style="position: absolute; top: 0; left: 0; width: 100%; height: 100%; border: 0;" allowfullscreen></iframe>
+              <iframe src="https://www.youtube.com/embed/F1A_BXLcD_Y?autoplay=1&mute=1&loop=1&playlist=F1A_BXLcD_Y" style="position: absolute; top: 0; left: 0; width: 100%; height: 100%; border: 0;" loading="lazy" allowfullscreen></iframe>
             </div>
             <div class="post-card__body">
               <blockquote style="font-style: italic; margin-bottom: 1rem;">
@@ -205,7 +206,7 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
 
           <article class="post-card">
             <div class="video-container" style="position: relative; padding-bottom: 56.25%; height: 0; overflow: hidden;">
-              <iframe src="https://www.youtube.com/embed/tdSDNNDZn1A?autoplay=1&mute=1&loop=1&playlist=tdSDNNDZn1A" style="position: absolute; top: 0; left: 0; width: 100%; height: 100%; border: 0;" allowfullscreen></iframe>
+              <iframe src="https://www.youtube.com/embed/tdSDNNDZn1A?autoplay=1&mute=1&loop=1&playlist=tdSDNNDZn1A" style="position: absolute; top: 0; left: 0; width: 100%; height: 100%; border: 0;" loading="lazy" allowfullscreen></iframe>
             </div>
             <div class="post-card__body">
               <blockquote style="font-style: italic; margin-bottom: 1rem;">
@@ -217,7 +218,7 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
 
           <article class="post-card">
             <div class="video-container" style="position: relative; padding-bottom: 56.25%; height: 0; overflow: hidden;">
-              <iframe src="https://www.youtube.com/embed/ycDqbPtYufU?autoplay=1&mute=1&loop=1&playlist=ycDqbPtYufU" style="position: absolute; top: 0; left: 0; width: 100%; height: 100%; border: 0;" allowfullscreen></iframe>
+              <iframe src="https://www.youtube.com/embed/ycDqbPtYufU?autoplay=1&mute=1&loop=1&playlist=ycDqbPtYufU" style="position: absolute; top: 0; left: 0; width: 100%; height: 100%; border: 0;" loading="lazy" allowfullscreen></iframe>
             </div>
             <div class="post-card__body">
               <blockquote style="font-style: italic; margin-bottom: 1rem;">
@@ -229,7 +230,7 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
 
           <article class="post-card">
             <div class="video-container" style="position: relative; padding-bottom: 56.25%; height: 0; overflow: hidden;">
-              <iframe src="https://www.youtube.com/embed/cAtgDgVBycg?autoplay=1&mute=1&loop=1&playlist=cAtgDgVBycg" style="position: absolute; top: 0; left: 0; width: 100%; height: 100%; border: 0;" allowfullscreen></iframe>
+              <iframe src="https://www.youtube.com/embed/cAtgDgVBycg?autoplay=1&mute=1&loop=1&playlist=cAtgDgVBycg" style="position: absolute; top: 0; left: 0; width: 100%; height: 100%; border: 0;" loading="lazy" allowfullscreen></iframe>
             </div>
             <div class="post-card__body">
               <blockquote style="font-style: italic; margin-bottom: 1rem;">
@@ -241,7 +242,7 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
 
           <article class="post-card">
             <div class="video-container" style="position: relative; padding-bottom: 56.25%; height: 0; overflow: hidden;">
-              <iframe src="https://www.youtube.com/embed/dHM6Lpvl8qY?autoplay=1&mute=1&loop=1&playlist=dHM6Lpvl8qY" style="position: absolute; top: 0; left: 0; width: 100%; height: 100%; border: 0;" allowfullscreen></iframe>
+              <iframe src="https://www.youtube.com/embed/dHM6Lpvl8qY?autoplay=1&mute=1&loop=1&playlist=dHM6Lpvl8qY" style="position: absolute; top: 0; left: 0; width: 100%; height: 100%; border: 0;" loading="lazy" allowfullscreen></iframe>
             </div>
             <div class="post-card__body">
               <blockquote style="font-style: italic; margin-bottom: 1rem;">
@@ -253,7 +254,7 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
 
           <article class="post-card">
             <div class="video-container" style="position: relative; padding-bottom: 56.25%; height: 0; overflow: hidden;">
-              <iframe src="https://www.youtube.com/embed/_6oSyUZft4Y?autoplay=1&mute=1&loop=1&playlist=_6oSyUZft4Y" style="position: absolute; top: 0; left: 0; width: 100%; height: 100%; border: 0;" allowfullscreen></iframe>
+              <iframe src="https://www.youtube.com/embed/_6oSyUZft4Y?autoplay=1&mute=1&loop=1&playlist=_6oSyUZft4Y" style="position: absolute; top: 0; left: 0; width: 100%; height: 100%; border: 0;" loading="lazy" allowfullscreen></iframe>
             </div>
             <div class="post-card__body">
               <blockquote style="font-style: italic; margin-bottom: 1rem;">
@@ -265,7 +266,7 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
 
           <article class="post-card">
             <div class="video-container" style="position: relative; padding-bottom: 56.25%; height: 0; overflow: hidden;">
-              <iframe src="https://www.youtube.com/embed/ibvVwkalHeU?autoplay=1&mute=1&loop=1&playlist=ibvVwkalHeU" style="position: absolute; top: 0; left: 0; width: 100%; height: 100%; border: 0;" allowfullscreen></iframe>
+              <iframe src="https://www.youtube.com/embed/ibvVwkalHeU?autoplay=1&mute=1&loop=1&playlist=ibvVwkalHeU" style="position: absolute; top: 0; left: 0; width: 100%; height: 100%; border: 0;" loading="lazy" allowfullscreen></iframe>
             </div>
             <div class="post-card__body">
               <blockquote style="font-style: italic; margin-bottom: 1rem;">
@@ -280,7 +281,7 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
 
           <article class="post-card">
             <div class="video-container" style="position: relative; padding-bottom: 56.25%; height: 0; overflow: hidden;">
-              <iframe src="https://www.youtube.com/embed/o3tioapUTg8?autoplay=1&mute=1&loop=1&playlist=o3tioapUTg8" style="position: absolute; top: 0; left: 0; width: 100%; height: 100%; border: 0;" allowfullscreen></iframe>
+              <iframe src="https://www.youtube.com/embed/o3tioapUTg8?autoplay=1&mute=1&loop=1&playlist=o3tioapUTg8" style="position: absolute; top: 0; left: 0; width: 100%; height: 100%; border: 0;" loading="lazy" allowfullscreen></iframe>
             </div>
             <div class="post-card__body">
               <blockquote style="font-style: italic; margin-bottom: 1rem;">
@@ -294,7 +295,7 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
 
           <article class="post-card">
             <div class="video-container" style="position: relative; padding-bottom: 56.25%; height: 0; overflow: hidden;">
-              <iframe src="https://www.youtube.com/embed/dSgxcEPBxws?autoplay=1&mute=1&loop=1&playlist=dSgxcEPBxws" style="position: absolute; top: 0; left: 0; width: 100%; height: 100%; border: 0;" allowfullscreen></iframe>
+              <iframe src="https://www.youtube.com/embed/dSgxcEPBxws?autoplay=1&mute=1&loop=1&playlist=dSgxcEPBxws" style="position: absolute; top: 0; left: 0; width: 100%; height: 100%; border: 0;" loading="lazy" allowfullscreen></iframe>
             </div>
             <div class="post-card__body">
               <blockquote style="font-style: italic; margin-bottom: 1rem;">
@@ -308,7 +309,7 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
 
           <article class="post-card">
             <div class="video-container" style="position: relative; padding-bottom: 56.25%; height: 0; overflow: hidden;">
-              <iframe src="https://www.youtube.com/embed/bdA7eC6wfd8?autoplay=1&mute=1&loop=1&playlist=bdA7eC6wfd8" style="position: absolute; top: 0; left: 0; width: 100%; height: 100%; border: 0;" allowfullscreen></iframe>
+              <iframe src="https://www.youtube.com/embed/bdA7eC6wfd8?autoplay=1&mute=1&loop=1&playlist=bdA7eC6wfd8" style="position: absolute; top: 0; left: 0; width: 100%; height: 100%; border: 0;" loading="lazy" allowfullscreen></iframe>
             </div>
             <div class="post-card__body">
               <blockquote style="font-style: italic; margin-bottom: 1rem;">
@@ -322,7 +323,7 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
 
           <article class="post-card">
             <div class="video-container" style="position: relative; padding-bottom: 56.25%; height: 0; overflow: hidden;">
-              <iframe src="https://www.youtube.com/embed/VrUHRt_QNJg?autoplay=1&mute=1&loop=1&playlist=VrUHRt_QNJg" style="position: absolute; top: 0; left: 0; width: 100%; height: 100%; border: 0;" allowfullscreen></iframe>
+              <iframe src="https://www.youtube.com/embed/VrUHRt_QNJg?autoplay=1&mute=1&loop=1&playlist=VrUHRt_QNJg" style="position: absolute; top: 0; left: 0; width: 100%; height: 100%; border: 0;" loading="lazy" allowfullscreen></iframe>
             </div>
             <div class="post-card__body">
               <blockquote style="font-style: italic; margin-bottom: 1rem;">
@@ -335,7 +336,7 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
 
           <article class="post-card">
             <div class="video-container" style="position: relative; padding-bottom: 56.25%; height: 0; overflow: hidden;">
-              <iframe src="https://www.youtube.com/embed/Ky0cn9cuJms?autoplay=1&mute=1&loop=1&playlist=Ky0cn9cuJms" style="position: absolute; top: 0; left: 0; width: 100%; height: 100%; border: 0;" allowfullscreen></iframe>
+              <iframe src="https://www.youtube.com/embed/Ky0cn9cuJms?autoplay=1&mute=1&loop=1&playlist=Ky0cn9cuJms" style="position: absolute; top: 0; left: 0; width: 100%; height: 100%; border: 0;" loading="lazy" allowfullscreen></iframe>
             </div>
             <div class="post-card__body">
               <blockquote style="font-style: italic; margin-bottom: 1rem;">
@@ -349,7 +350,7 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
 
           <article class="post-card">
             <div class="video-container" style="position: relative; padding-bottom: 56.25%; height: 0; overflow: hidden;">
-              <iframe src="https://www.youtube.com/embed/FGe45Fc6V-U?autoplay=1&mute=1&loop=1&playlist=FGe45Fc6V-U" style="position: absolute; top: 0; left: 0; width: 100%; height: 100%; border: 0;" allowfullscreen></iframe>
+              <iframe src="https://www.youtube.com/embed/FGe45Fc6V-U?autoplay=1&mute=1&loop=1&playlist=FGe45Fc6V-U" style="position: absolute; top: 0; left: 0; width: 100%; height: 100%; border: 0;" loading="lazy" allowfullscreen></iframe>
             </div>
             <div class="post-card__body">
               <blockquote style="font-style: italic; margin-bottom: 1rem;">
@@ -362,7 +363,7 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
 
           <article class="post-card">
             <div class="video-container" style="position: relative; padding-bottom: 56.25%; height: 0; overflow: hidden;">
-              <iframe src="https://www.youtube.com/embed/q_k3bTBjdeE?autoplay=1&mute=1&loop=1&playlist=q_k3bTBjdeE" style="position: absolute; top: 0; left: 0; width: 100%; height: 100%; border: 0;" allowfullscreen></iframe>
+              <iframe src="https://www.youtube.com/embed/q_k3bTBjdeE?autoplay=1&mute=1&loop=1&playlist=q_k3bTBjdeE" style="position: absolute; top: 0; left: 0; width: 100%; height: 100%; border: 0;" loading="lazy" allowfullscreen></iframe>
             </div>
             <div class="post-card__body">
               <blockquote style="font-style: italic; margin-bottom: 1rem;">
@@ -375,7 +376,7 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
 
           <article class="post-card">
             <div class="video-container" style="position: relative; padding-bottom: 56.25%; height: 0; overflow: hidden;">
-              <iframe src="https://www.youtube.com/embed/yWazfZ2LNSs?autoplay=1&mute=1&loop=1&playlist=yWazfZ2LNSs" style="position: absolute; top: 0; left: 0; width: 100%; height: 100%; border: 0;" allowfullscreen></iframe>
+              <iframe src="https://www.youtube.com/embed/yWazfZ2LNSs?autoplay=1&mute=1&loop=1&playlist=yWazfZ2LNSs" style="position: absolute; top: 0; left: 0; width: 100%; height: 100%; border: 0;" loading="lazy" allowfullscreen></iframe>
             </div>
             <div class="post-card__body">
               <blockquote style="font-style: italic; margin-bottom: 1rem;">
@@ -389,7 +390,7 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
 
           <article class="post-card">
             <div class="video-container" style="position: relative; padding-bottom: 56.25%; height: 0; overflow: hidden;">
-              <iframe src="https://www.youtube.com/embed/PqXigXN025s?autoplay=1&mute=1&loop=1&playlist=PqXigXN025s" style="position: absolute; top: 0; left: 0; width: 100%; height: 100%; border: 0;" allowfullscreen></iframe>
+              <iframe src="https://www.youtube.com/embed/PqXigXN025s?autoplay=1&mute=1&loop=1&playlist=PqXigXN025s" style="position: absolute; top: 0; left: 0; width: 100%; height: 100%; border: 0;" loading="lazy" allowfullscreen></iframe>
             </div>
             <div class="post-card__body">
               <blockquote style="font-style: italic; margin-bottom: 1rem;">
@@ -402,7 +403,7 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
 
           <article class="post-card">
             <div class="video-container" style="position: relative; padding-bottom: 56.25%; height: 0; overflow: hidden;">
-              <iframe src="https://www.youtube.com/embed/u6GGwnYx790?autoplay=1&mute=1&loop=1&playlist=u6GGwnYx790" style="position: absolute; top: 0; left: 0; width: 100%; height: 100%; border: 0;" allowfullscreen></iframe>
+              <iframe src="https://www.youtube.com/embed/u6GGwnYx790?autoplay=1&mute=1&loop=1&playlist=u6GGwnYx790" style="position: absolute; top: 0; left: 0; width: 100%; height: 100%; border: 0;" loading="lazy" allowfullscreen></iframe>
             </div>
             <div class="post-card__body">
               <blockquote style="font-style: italic; margin-bottom: 1rem;">
@@ -415,7 +416,7 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
 
           <article class="post-card">
             <div class="video-container" style="position: relative; padding-bottom: 56.25%; height: 0; overflow: hidden;">
-              <iframe src="https://www.youtube.com/embed/A1w_jSLy0tc?autoplay=1&mute=1&loop=1&playlist=A1w_jSLy0tc" style="position: absolute; top: 0; left: 0; width: 100%; height: 100%; border: 0;" allowfullscreen></iframe>
+              <iframe src="https://www.youtube.com/embed/A1w_jSLy0tc?autoplay=1&mute=1&loop=1&playlist=A1w_jSLy0tc" style="position: absolute; top: 0; left: 0; width: 100%; height: 100%; border: 0;" loading="lazy" allowfullscreen></iframe>
             </div>
             <div class="post-card__body">
               <blockquote style="font-style: italic; margin-bottom: 1rem;">
@@ -429,7 +430,7 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
 
           <article class="post-card">
             <div class="video-container" style="position: relative; padding-bottom: 56.25%; height: 0; overflow: hidden;">
-              <iframe src="https://www.youtube.com/embed/jCTpsuSJRbE?autoplay=1&mute=1&loop=1&playlist=jCTpsuSJRbE" style="position: absolute; top: 0; left: 0; width: 100%; height: 100%; border: 0;" allowfullscreen></iframe>
+              <iframe src="https://www.youtube.com/embed/jCTpsuSJRbE?autoplay=1&mute=1&loop=1&playlist=jCTpsuSJRbE" style="position: absolute; top: 0; left: 0; width: 100%; height: 100%; border: 0;" loading="lazy" allowfullscreen></iframe>
             </div>
             <div class="post-card__body">
               <blockquote style="font-style: italic; margin-bottom: 1rem;">
@@ -443,7 +444,7 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
 
           <article class="post-card">
             <div class="video-container" style="position: relative; padding-bottom: 56.25%; height: 0; overflow: hidden;">
-              <iframe src="https://www.youtube.com/embed/xaNziAkW5t4?autoplay=1&mute=1&loop=1&playlist=xaNziAkW5t4" style="position: absolute; top: 0; left: 0; width: 100%; height: 100%; border: 0;" allowfullscreen></iframe>
+              <iframe src="https://www.youtube.com/embed/xaNziAkW5t4?autoplay=1&mute=1&loop=1&playlist=xaNziAkW5t4" style="position: absolute; top: 0; left: 0; width: 100%; height: 100%; border: 0;" loading="lazy" allowfullscreen></iframe>
             </div>
             <div class="post-card__body">
               <blockquote style="font-style: italic; margin-bottom: 1rem;">
@@ -455,7 +456,7 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
 
           <article class="post-card">
             <div class="video-container" style="position: relative; padding-bottom: 56.25%; height: 0; overflow: hidden;">
-              <iframe src="https://www.youtube.com/embed/GUN7IHP7WrU?autoplay=1&mute=1&loop=1&playlist=GUN7IHP7WrU" style="position: absolute; top: 0; left: 0; width: 100%; height: 100%; border: 0;" allowfullscreen></iframe>
+              <iframe src="https://www.youtube.com/embed/GUN7IHP7WrU?autoplay=1&mute=1&loop=1&playlist=GUN7IHP7WrU" style="position: absolute; top: 0; left: 0; width: 100%; height: 100%; border: 0;" loading="lazy" allowfullscreen></iframe>
             </div>
             <div class="post-card__body">
               <blockquote style="font-style: italic; margin-bottom: 1rem;">


### PR DESCRIPTION
### Motivation
- Reduce initial load cost and improve perceived speed by deferring non-critical media below the hero section.
- Keep above-the-fold brand and hero media prioritized so the page doesn’t appear empty on first paint.

### Description
- Updated `testimonios.html` to add `loading="eager"` to the hero `iframe` and preserved the header brand image with `loading="eager"` and `decoding="async"`.
- Applied `loading="lazy"` to all YouTube `iframe` embeds inside the "Historias Reales" / testimonial cards that appear below the hero.
- Saved the changes and created a commit with the message `Optimize testimonios media loading` (commit `b5ca7bf`).

### Testing
- Ran `git diff -- testimonios.html` to review the diff and validate the applied changes, which succeeded.
- Executed a small Python check that verified the hero contains `loading="eager"` and counted `23` `loading="lazy"` testimonial embeds, which returned `hero_eager=True` and `lazy_iframes=23`.
- Performed `git status`, `git add testimonios.html` and `git commit -m "Optimize testimonios media loading"`, which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c021876ab4833290c5104587f92e74)