### PR TITLE
Add CTA footer block to Xolo size guide

### DIFF
--- a/blog/guia-tallas-xoloitzcuintle.html
+++ b/blog/guia-tallas-xoloitzcuintle.html
@@ -295,6 +295,20 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
             </div>
         </section>
 
+        <div class="cta-blog-footer" style="background: linear-gradient(145deg, rgba(24, 20, 18, 0.95), rgba(40, 28, 26, 0.95)); border: 1px solid var(--color-dorado, #d4af37); border-radius: 12px; padding: 2.5rem 1.5rem; text-align: center; margin: 3rem auto; max-width: 800px; box-shadow: 0 15px 35px rgba(0, 0, 0, 0.4);">
+  
+  <h3 style="color: var(--color-dorado, #d4af37); font-family: 'Cinzel', serif; margin-top: 0; margin-bottom: 1rem; font-size: clamp(1.5rem, 4vw, 2rem);">¿Ya sabes qué talla es ideal para tu hogar?</h3>
+  
+  <p style="color: var(--color-texto, #f1e6d6); font-size: 1.1rem; margin-bottom: 2rem; max-width: 600px; margin-left: auto; margin-right: auto; line-height: 1.6;">
+    Conoce a los ejemplares que tenemos listos para integrarse a tu familia. Todos se entregan con certificado de salud, esquema de vacunación y su exclusivo <strong>registro NFT de linaje</strong>.
+  </p>
+  
+  <a href="../xolos-disponibles.html" class="btn" style="padding: 1rem 2.5rem; font-size: 1.1rem; border-radius: 999px; box-shadow: 0 10px 25px rgba(212, 175, 55, 0.3); display: inline-block;">
+    Ver Xolos Disponibles 🐾
+  </a>
+
+</div>
+
         <!-- Footer -->
         <footer class="text-center text-xolo-500 text-sm py-8 border-t border-xolo-200">
             <p>Datos basados en el Estándar de la Federación Canófila Internacional (FCI).</p>


### PR DESCRIPTION
### Motivation
- Add a persuasive call-to-action at the end of the article to guide readers to the "Xolos disponibles" page and reinforce trust signals (health certificate, vaccination and NFT lineage).

### Description
- Inserted a `div` with class `cta-blog-footer` just before the page footer in `blog/guia-tallas-xoloitzcuintle.html` containing the provided HTML snippet with inline styles and the `../xolos-disponibles.html` link.
- This is a content-only update and did not modify JavaScript or external stylesheet files.

### Testing
- Verified the edit with repository checks using `git diff -- blog/guia-tallas-xoloitzcuintle.html` and `git status --short`, and the output confirmed the intended file change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c952193d348332b0c6607b0b3af14f)