### PR TITLE
Increase contrast and weight of CTA button on Xolo size guide

### DIFF
--- a/blog/guia-tallas-xoloitzcuintle.html
+++ b/blog/guia-tallas-xoloitzcuintle.html
@@ -303,7 +303,7 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
     Conoce a los ejemplares que tenemos listos para integrarse a tu familia. Todos se entregan con certificado de salud, esquema de vacunación y su exclusivo <strong>registro NFT de linaje</strong>.
   </p>
   
-  <a href="../xolos-disponibles.html" class="btn" style="padding: 1rem 2.5rem; font-size: 1.1rem; border-radius: 999px; box-shadow: 0 10px 25px rgba(212, 175, 55, 0.3); display: inline-block;">
+  <a href="../xolos-disponibles.html" class="btn" style="padding: 1rem 2.5rem; font-size: 1.1rem; border-radius: 999px; box-shadow: 0 10px 25px rgba(212, 175, 55, 0.3); display: inline-block; color: #181412; font-weight: 700;">
     Ver Xolos Disponibles 🐾
   </a>
 


### PR DESCRIPTION
### Motivation
- Improve legibility and emphasis of the call-to-action button by increasing text contrast and weight for better visibility and accessibility.

### Description
- Add inline styles `color: #181412; font-weight: 700;` to the CTA anchor in `blog/guia-tallas-xoloitzcuintle.html` so the "Ver Xolos Disponibles 🐾" button uses darker, bold text.

### Testing
- No automated tests were added or run for this markup-only change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c958f44ee483328fa3ee9ef57f8e60)