### PR TITLE
Improve English 'Available Xolos' landing for US/Canada conversions

### DIFF
--- a/en/available-xolos.html
+++ b/en/available-xolos.html
@@ -71,6 +71,61 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
       </div>
     </section>
 
+
+
+    <section class="trust" data-aos="fade-up" data-aos-duration="1000" data-aos-delay="80">
+      <h2>Trust & Guarantees</h2>
+      <div class="trust-grid">
+        <article class="card trust-card">
+          <span class="trust-icon" aria-hidden="true">💉🩺</span>
+          <h4>Health Guarantee</h4>
+          <p>
+            Each Xolo is delivered with a health certificate, up-to-date vaccination schedule, deworming, microchip, and their exclusive <strong>NFT lineage registration</strong>.
+          </p>
+        </article>
+        <article class="card trust-card">
+          <span class="trust-icon" aria-hidden="true">🔒💳</span>
+          <h4>Secure Payment</h4>
+          <p>
+            Safe methods with official receipts (bank transfer or cryptocurrency) and continuous guidance throughout the process.
+          </p>
+        </article>
+        <article class="card trust-card">
+          <span class="trust-icon" aria-hidden="true">✈️🌎</span>
+          <h4>International Shipping</h4>
+          <p>
+            Safe and reliable shipping to the United States, Canada, and worldwide, strictly fulfilling all veterinary and travel requirements.
+          </p>
+        </article>
+      </div>
+    </section>
+
+    <section class="live-show section" data-aos="fade-up" data-aos-duration="1000" data-aos-delay="90">
+      <div class="container live-show__container">
+        <div class="live-show__content">
+          <span class="live-show__eyebrow">Live</span>
+          <h2>The Xolos Ramirez Show</h2>
+          <p>Tune into our live streams to meet the puppies in real-time and learn about the ancient Xoloitzcuintle culture.</p>
+        </div>
+        <div class="live-show__frame">
+          <div class="live-show__badge" aria-label="Live stream">
+            <span class="live-show__dot" aria-hidden="true"></span>
+            Live
+          </div>
+          <div class="live-show__video">
+            <iframe
+              src="https://www.youtube.com/embed/live_stream?channel=UCKtNKCavbBmxtcdHSDd9BsA&mute=1&rel=0"
+              title="Xolos Ramirez Live Stream"
+              loading="lazy"
+              allow="accelerometer; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share"
+              referrerpolicy="strict-origin-when-cross-origin"
+              allowfullscreen
+            ></iframe>
+          </div>
+        </div>
+      </div>
+    </section>
+
     <section class="featured-xolos section">
       <div class="container">
         <h2 class="section__title">Featured Profiles</h2>
@@ -83,8 +138,7 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
             <h3>Tane Ramirez</h3>
             <p>(male xoloitzcuintle, miniature size, hairless variety, black color)</p>
             <p>Born on October 17, 2025.</p>
-            <a href="contact.html" class="btn">Apply for Adoption</a>
-            <a class="btn-whatsapp" href="https://wa.me/message/435RTKGJLTX2J1" target="_blank">📲 Inquiry via WhatsApp</a>
+            <a href="mailto:fernando@xolosramirez.com?subject=Interest in Tane Ramirez&body=Hello Fernando, I would like to receive information on how to reserve Tane Ramirez." class="btn" onclick="dataLayer.push({ event: 'click_email', cachorro: 'Tane Ramirez', source: 'available_xolos_contact_en' })">Contact via Email</a>
           </article>
 
           <article class="card" data-aos="zoom-in" data-aos-delay="100">
@@ -97,8 +151,7 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
             <h3>Humo Ramirez</h3>
             <p>(male xoloitzcuintle, miniature size, hairless variety, black color)</p>
             <p>Born on October 10, 2025.</p>
-            <a href="contact.html" class="btn">Apply for Adoption</a>
-            <a class="btn-whatsapp" href="https://wa.me/message/435RTKGJLTX2J1" target="_blank">📲 Inquiry via WhatsApp</a>
+            <a href="mailto:fernando@xolosramirez.com?subject=Interest in Humo Ramirez&body=Hello Fernando, I would like to receive information on how to reserve Humo Ramirez." class="btn" onclick="dataLayer.push({ event: 'click_email', cachorro: 'Humo Ramirez', source: 'available_xolos_contact_en' })">Contact via Email</a>
           </article>
 
           <article class="card" data-aos="zoom-in" data-aos-delay="200">
@@ -111,8 +164,7 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
             <h3>Tonatiuh Ramirez</h3>
             <p>(male xoloitzcuintle, intermediate size, hairless variety, black color)</p>
             <p>Born on October 15, 2025.</p>
-            <a href="contact.html" class="btn">Apply for Adoption</a>
-            <a class="btn-whatsapp" href="https://wa.me/message/435RTKGJLTX2J1" target="_blank">📲 Inquiry via WhatsApp</a>
+            <a href="mailto:fernando@xolosramirez.com?subject=Interest in Tonatiuh Ramirez&body=Hello Fernando, I would like to receive information on how to reserve Tonatiuh Ramirez." class="btn" onclick="dataLayer.push({ event: 'click_email', cachorro: 'Tonatiuh Ramirez', source: 'available_xolos_contact_en' })">Contact via Email</a>
           </article>
 
           <article class="card" data-aos="zoom-in" data-aos-delay="300">
@@ -125,8 +177,7 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
             <h3>Tzontli Ramirez</h3>
             <p>(male xoloitzcuintle, standard size, hairless variety, black color)</p>
             <p>Born on September 8, 2025.</p>
-            <a href="contact.html" class="btn">Apply for Adoption</a>
-            <a class="btn-whatsapp" href="https://wa.me/message/435RTKGJLTX2J1" target="_blank">📲 Inquiry via WhatsApp</a>
+            <a href="mailto:fernando@xolosramirez.com?subject=Interest in Tzontli Ramirez&body=Hello Fernando, I would like to receive information on how to reserve Tzontli Ramirez." class="btn" onclick="dataLayer.push({ event: 'click_email', cachorro: 'Tzontli Ramirez', source: 'available_xolos_contact_en' })">Contact via Email</a>
           </article>
 
           <article class="card" data-aos="zoom-in" data-aos-delay="400">
@@ -139,8 +190,7 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
             <h3>Axia Ramirez</h3>
             <p>(female xoloitzcuintle, intermediate size, hairless variety, black color)</p>
             <p>Born on July 15, 2025.</p>
-            <a href="contact.html" class="btn">Apply for Adoption</a>
-            <a class="btn-whatsapp" href="https://wa.me/message/435RTKGJLTX2J1" target="_blank">📲 Inquiry via WhatsApp</a>
+            <a href="mailto:fernando@xolosramirez.com?subject=Interest in Axia Ramirez&body=Hello Fernando, I would like to receive information on how to reserve Axia Ramirez." class="btn" onclick="dataLayer.push({ event: 'click_email', cachorro: 'Axia Ramirez', source: 'available_xolos_contact_en' })">Contact via Email</a>
           </article>
 
         </div>
@@ -167,6 +217,15 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
       </div>
     </div>
   </footer>
+
+  <a
+    class="email-float"
+    href="mailto:fernando@xolosramirez.com?subject=Inquiry about Available Xolos&body=Hello Fernando, I am visiting the Xolos Ramirez website from the US/Canada and would like more information on the available puppies."
+    data-gtm="email-floating-en"
+    onclick="dataLayer.push({ event: 'click_email', cachorro: 'general', source: 'available_xolos_floating_en' })"
+  >
+    <span>📧 Contact via Email</span>
+  </a>
 
   <script src="https://unpkg.com/aos@2.3.1/dist/aos.js"></script>
   <script src="../js/main.js"></script>


### PR DESCRIPTION
### Motivation
- Align the English landing page with a direct-response flow targeted at US/Canada buyers to increase email leads and preserve the Spanish SEO experience.
- Surface trust signals (health, payment, shipping) and live streaming to improve credibility and real-time engagement for prospective buyers.

### Description
- Added a new `Trust & Guarantees` section to `en/available-xolos.html` with Health Guarantee, Secure Payment, and International Shipping messaging (includes NFT lineage mention). 
- Inserted a `The Xolos Ramirez Show` live-show section before the featured profiles using a lazy-loaded YouTube live embed and existing `live-show` styles.
- Replaced each featured puppy primary CTA with English `mailto:` links that include `subject`/`body` prefill text and `dataLayer.push(...)` events for per-puppy lead tracking, removing the prior `contact.html` + WhatsApp primary pattern on this page.
- Added an English floating email CTA near the bottom of the page with `data-gtm="email-floating-en"` and a `dataLayer.push(...)` source tag for ad conversion attribution.

### Testing
- Verified the updated HTML content with `sed -n '1,260p' en/available-xolos.html` and `nl -ba en/available-xolos.html | sed -n '70,260p'`, confirming the new sections and updated CTAs were present.
- Searched repository files with `rg` to confirm target file location and style hooks were already present; CSS selectors used by the new sections match existing styles.
- Inspected the diff to ensure only `en/available-xolos.html` was modified and the intended substitutions were applied; all validation commands completed successfully.
- No automated browser screenshot was taken in this environment, so front-end rendering was not captured as part of these tests.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c96bbe79188332b0dd835ce5d5baf1)