### PR TITLE
Update English Available Xolos section to match Spanish layout/content

### DIFF
--- a/en/available-xolos.html
+++ b/en/available-xolos.html
@@ -105,7 +105,7 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
         <div class="live-show__content">
           <span class="live-show__eyebrow">Live</span>
           <h2>The Xolos Ramirez Show</h2>
-          <p>Tune into our live streams to meet the puppies in real-time and learn about the ancient Xoloitzcuintle culture.</p>
+          <p>Connect to our live stream to learn more about the Xolos Ramirez community, see our puppies, and keep the momentum before exploring the featured profiles.</p>
         </div>
         <div class="live-show__frame">
           <div class="live-show__badge" aria-label="Live stream">
@@ -114,8 +114,8 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
           </div>
           <div class="live-show__video">
             <iframe
-              src="https://www.youtube.com/embed/live_stream?channel=UCKtNKCavbBmxtcdHSDd9BsA&mute=1&rel=0"
-              title="Xolos Ramirez Live Stream"
+              src="https://www.youtube.com/embed/vgfZrxCzQCE?channel=UCKtNKCavbBmxtcdHSDd9BsA&mute=vgfZrxCzQCE"
+              title="The Xolos Ramirez Show Live Stream"
               loading="lazy"
               allow="accelerometer; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share"
               referrerpolicy="strict-origin-when-cross-origin"
@@ -126,74 +126,126 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
       </div>
     </section>
 
-    <section class="featured-xolos section">
-      <div class="container">
-        <h2 class="section__title">Featured Profiles</h2>
-        <div class="grid">
-          
-          <article class="card" data-aos="zoom-in">
-            <picture class="card__media">
-              <img src="https://i.imgur.com/nqOoRXL.jpeg" alt="Tane Ramirez" loading="lazy">
+    <section data-aos="fade-up" data-aos-duration="1000" data-aos-delay="100">
+      <h2>Featured Profiles</h2>
+      <div class="puppy-grid">
+        
+        <article class="puppy-card" data-aos="fade-up" data-aos-duration="800" data-aos-delay="100">
+          <div class="puppy-card__image-wrapper">
+            <span class="puppy-card__status status-disponible">Available</span>
+            <picture>
+              <img
+                src="https://i.imgur.com/CZfcZo4.jpeg"
+                alt="Xoloitzcuintle Tonatiuh Ramirez"
+                class="puppy-card__image"
+                loading="lazy"
+                width="600"
+                height="450"
+              />
             </picture>
-            <h3>Tane Ramirez</h3>
-            <p>(male xoloitzcuintle, miniature size, hairless variety, black color)</p>
-            <p>Born on October 17, 2025.</p>
-            <a href="mailto:fernando@xolosramirez.com?subject=Interest in Tane Ramirez&body=Hello Fernando, I would like to receive information on how to reserve Tane Ramirez." class="btn" onclick="dataLayer.push({ event: 'click_email', cachorro: 'Tane Ramirez', source: 'available_xolos_contact_en' })">Contact via Email</a>
-          </article>
-
-          <article class="card" data-aos="zoom-in" data-aos-delay="100">
-            <picture class="card__media">
-              <img src="https://i.imgur.com/5xGxPmU.jpeg" alt="Humo Ramirez" loading="lazy">
-            </picture>
-            <div class="video-container" style="position: relative; padding-bottom: 56.25%; height: 0; overflow: hidden; margin-top: 1rem;">
-              <iframe src="https://www.youtube.com/embed/xdWjsfQT75U?autoplay=1&mute=1&loop=1&playlist=xdWjsfQT75U" style="position: absolute; top: 0; left: 0; width: 100%; height: 100%; border: 0;" allowfullscreen></iframe>
+          </div>
+          <div class="puppy-card__content">
+            <h3 class="puppy-card__name">Tonatiuh Ramirez</h3>
+            <ul class="puppy-card__details">
+              <li><strong>Age</strong> 5 months</li>
+              <li><strong>Gender</strong> Male</li>
+              <li><strong>Size</strong> Miniature</li>
+              <li><strong>Color</strong> Black</li>
+            </ul>
+            <div class="puppy-card__actions">
+              <a href="https://www.youtube.com/watch?v=RfcNi1zoJJA" class="btn-small btn-outline-small" target="_blank" rel="noopener">Watch video 🎥</a>
+              <a href="mailto:fernando@xolosramirez.com?subject=Interest in Tonatiuh Ramirez&body=Hello Fernando, I would like to receive information on how to reserve Tonatiuh Ramirez." class="btn-small btn-primary-small" onclick="dataLayer.push({ event: 'click_email', cachorro: 'Tonatiuh Ramirez', source: 'available_xolos_contact_en' })">Contact via Email</a>
             </div>
-            <h3>Humo Ramirez</h3>
-            <p>(male xoloitzcuintle, miniature size, hairless variety, black color)</p>
-            <p>Born on October 10, 2025.</p>
-            <a href="mailto:fernando@xolosramirez.com?subject=Interest in Humo Ramirez&body=Hello Fernando, I would like to receive information on how to reserve Humo Ramirez." class="btn" onclick="dataLayer.push({ event: 'click_email', cachorro: 'Humo Ramirez', source: 'available_xolos_contact_en' })">Contact via Email</a>
-          </article>
+          </div>
+        </article>
 
-          <article class="card" data-aos="zoom-in" data-aos-delay="200">
-            <picture class="card__media">
-              <img src="https://i.imgur.com/mm59sZ7.jpeg" alt="Tonatiuh Ramirez" loading="lazy">
+        <article class="puppy-card" data-aos="fade-up" data-aos-duration="800" data-aos-delay="200">
+          <div class="puppy-card__image-wrapper">
+            <span class="puppy-card__status status-disponible">Available</span>
+            <picture>
+              <img
+                src="https://i.imgur.com/LIKvwXA.jpeg"
+                alt="Xoloitzcuintle Ozomatli Ramirez"
+                class="puppy-card__image"
+                loading="lazy"
+                width="600"
+                height="450"
+              />
             </picture>
-            <div class="video-container" style="position: relative; padding-bottom: 56.25%; height: 0; overflow: hidden; margin-top: 1rem;">
-              <iframe src="https://www.youtube.com/embed/5fdDGjSv0jA?autoplay=1&mute=1&loop=1&playlist=5fdDGjSv0jA" style="position: absolute; top: 0; left: 0; width: 100%; height: 100%; border: 0;" allowfullscreen></iframe>
+          </div>
+          <div class="puppy-card__content">
+            <h3 class="puppy-card__name">Ozomatli Ramirez</h3>
+            <ul class="puppy-card__details">
+              <li><strong>Age</strong> 2 months</li>
+              <li><strong>Gender</strong> Male</li>
+              <li><strong>Size</strong> Standard</li>
+              <li><strong>Color</strong> Black</li>
+            </ul>
+            <div class="puppy-card__actions">
+              <a href="https://www.youtube.com/watch?v=HaPx8Bv3Pcg" class="btn-small btn-outline-small" target="_blank" rel="noopener">Watch video 🎥</a>
+              <a href="mailto:fernando@xolosramirez.com?subject=Interest in Ozomatli Ramirez&body=Hello Fernando, I would like to receive information on how to reserve Ozomatli Ramirez." class="btn-small btn-primary-small" onclick="dataLayer.push({ event: 'click_email', cachorro: 'Ozomatli Ramirez', source: 'available_xolos_contact_en' })">Contact via Email</a>
             </div>
-            <h3>Tonatiuh Ramirez</h3>
-            <p>(male xoloitzcuintle, intermediate size, hairless variety, black color)</p>
-            <p>Born on October 15, 2025.</p>
-            <a href="mailto:fernando@xolosramirez.com?subject=Interest in Tonatiuh Ramirez&body=Hello Fernando, I would like to receive information on how to reserve Tonatiuh Ramirez." class="btn" onclick="dataLayer.push({ event: 'click_email', cachorro: 'Tonatiuh Ramirez', source: 'available_xolos_contact_en' })">Contact via Email</a>
-          </article>
+          </div>
+        </article>
 
-          <article class="card" data-aos="zoom-in" data-aos-delay="300">
-            <picture class="card__media">
-              <img src="https://i.imgur.com/o2137yg.jpeg" alt="Tzontli Ramirez" loading="lazy">
+        <article class="puppy-card" data-aos="fade-up" data-aos-duration="800" data-aos-delay="300">
+          <div class="puppy-card__image-wrapper">
+            <span class="puppy-card__status status-disponible">Available</span>
+            <picture>
+              <img
+                src="https://i.imgur.com/MoVX5Db.jpeg"
+                alt="Xoloitzcuintle Nox Ramirez"
+                class="puppy-card__image"
+                loading="lazy"
+                width="600"
+                height="450"
+              />
             </picture>
-            <div class="video-container" style="position: relative; padding-bottom: 56.25%; height: 0; overflow: hidden; margin-top: 1rem;">
-              <iframe src="https://www.youtube.com/embed/CZZTXGOGG_M?autoplay=1&mute=1&loop=1&playlist=CZZTXGOGG_M" style="position: absolute; top: 0; left: 0; width: 100%; height: 100%; border: 0;" allowfullscreen></iframe>
+          </div>
+          <div class="puppy-card__content">
+            <h3 class="puppy-card__name">Nox Ramirez</h3>
+            <ul class="puppy-card__details">
+              <li><strong>Age</strong> 2 months</li>
+              <li><strong>Gender</strong> Male</li>
+              <li><strong>Size</strong> Standard</li>
+              <li><strong>Color</strong> Black</li>
+            </ul>
+            <div class="puppy-card__actions">
+              <a href="https://www.youtube.com/watch?v=k8YQjGDdQaM" class="btn-small btn-outline-small" target="_blank" rel="noopener">Watch video 🎥</a>
+              <a href="mailto:fernando@xolosramirez.com?subject=Interest in Nox Ramirez&body=Hello Fernando, I would like to receive information on how to reserve Nox Ramirez." class="btn-small btn-primary-small" onclick="dataLayer.push({ event: 'click_email', cachorro: 'Nox Ramirez', source: 'available_xolos_contact_en' })">Contact via Email</a>
             </div>
-            <h3>Tzontli Ramirez</h3>
-            <p>(male xoloitzcuintle, standard size, hairless variety, black color)</p>
-            <p>Born on September 8, 2025.</p>
-            <a href="mailto:fernando@xolosramirez.com?subject=Interest in Tzontli Ramirez&body=Hello Fernando, I would like to receive information on how to reserve Tzontli Ramirez." class="btn" onclick="dataLayer.push({ event: 'click_email', cachorro: 'Tzontli Ramirez', source: 'available_xolos_contact_en' })">Contact via Email</a>
-          </article>
+          </div>
+        </article>
 
-          <article class="card" data-aos="zoom-in" data-aos-delay="400">
-            <picture class="card__media">
-              <img src="https://i.imgur.com/pDWIcED.jpeg" alt="Axia Ramirez" loading="lazy">
+        <article class="puppy-card" data-aos="fade-up" data-aos-duration="800" data-aos-delay="500">
+          <div class="puppy-card__image-wrapper">
+            <span class="puppy-card__status status-disponible">Available</span>
+            <picture>
+              <img
+                src="https://i.imgur.com/NpemhAk.jpeg"
+                alt="Xoloitzcuintle Teyolia Ramirez"
+                class="puppy-card__image"
+                loading="lazy"
+                width="600"
+                height="450"
+              />
             </picture>
-            <div class="video-container" style="position: relative; padding-bottom: 56.25%; height: 0; overflow: hidden; margin-top: 1rem;">
-              <iframe src="https://www.youtube.com/embed/ld80l8bHMz8?autoplay=1&mute=1&loop=1&playlist=ld80l8bHMz8" style="position: absolute; top: 0; left: 0; width: 100%; height: 100%; border: 0;" allowfullscreen></iframe>
+          </div>
+          <div class="puppy-card__content">
+            <h3 class="puppy-card__name">Teyolia Ramirez</h3>
+            <ul class="puppy-card__details">
+              <li><strong>Age</strong> 1.5 months</li>
+              <li><strong>Gender</strong> Female</li>
+              <li><strong>Size</strong> Miniature</li>
+              <li><strong>Color</strong> Black</li>
+            </ul>
+            <div class="puppy-card__actions">
+              <a href="https://www.youtube.com/watch?v=dWwc4FRzI8g" class="btn-small btn-outline-small" target="_blank" rel="noopener">Watch video 🎥</a>
+              <a href="mailto:fernando@xolosramirez.com?subject=Interest in Teyolia Ramirez&body=Hello Fernando, I would like to receive information on how to reserve Teyolia Ramirez." class="btn-small btn-primary-small" onclick="dataLayer.push({ event: 'click_email', cachorro: 'Teyolia Ramirez', source: 'available_xolos_contact_en' })">Contact via Email</a>
             </div>
-            <h3>Axia Ramirez</h3>
-            <p>(female xoloitzcuintle, intermediate size, hairless variety, black color)</p>
-            <p>Born on July 15, 2025.</p>
-            <a href="mailto:fernando@xolosramirez.com?subject=Interest in Axia Ramirez&body=Hello Fernando, I would like to receive information on how to reserve Axia Ramirez." class="btn" onclick="dataLayer.push({ event: 'click_email', cachorro: 'Axia Ramirez', source: 'available_xolos_contact_en' })">Contact via Email</a>
-          </article>
+          </div>
+        </article>
 
-        </div>
       </div>
     </section>
   </main>


### PR DESCRIPTION
### Motivation
- Bring the English landing page to parity with the updated Spanish page so design, content, and conversion behavior are identical.
- Use the same live stream embed and persuasive copy to maintain momentum for US/Canada traffic before visitors see featured profiles.
- Replace the old card layout with the new `puppy-card` structure to match visual and interaction improvements already shipped in Spanish.

### Description
- Replaced the `live-show` section in `en/available-xolos.html` with conversion-focused copy and the specific YouTube embed `vgfZrxCzQCE` and updated the iframe `title` accordingly.
- Replaced the previous `featured-xolos` grid with a `puppy-grid` that uses `article` elements styled as `puppy-card` and added four profiles: Tonatiuh, Ozomatli, Nox, and Teyolia with their translated details.
- Updated CTAs so each profile has separate `Watch video` and `Contact via Email` buttons and added `onclick` GTM tracking with `source: 'available_xolos_contact_en'` on email links.
- All changes were applied to and committed in the single file `en/available-xolos.html`.

### Testing
- Ran `sed -n '90,260p' en/available-xolos.html` to inspect the inserted `live-show` and `puppy-grid` blocks, which showed the new markup as expected.
- Ran `git status --short` to confirm only `en/available-xolos.html` was modified, which returned `M en/available-xolos.html`.
- Executed the Python replacement script which printed `updated` and performed an automated `git commit`, with the commit summary reporting the file change (114 insertions, 62 deletions).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c96fbe4ce88332b034ac42dcbad53f)