### PR TITLE
Update contact email to contacto@xolosarmy.xyz across site

### DIFF
--- a/contacto.html
+++ b/contacto.html
@@ -152,7 +152,7 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
           </article>
           <article class="card" data-aos="zoom-in" data-aos-delay="250">
             <h3>Contacto directo</h3>
-            <p><strong>Correo:</strong> fernando@xolosramirez.com</p>
+            <p><strong>Correo:</strong> contacto@xolosarmy.xyz</p>
           </article>
         </div>
       </section>

--- a/en/available-xolos.html
+++ b/en/available-xolos.html
@@ -154,7 +154,7 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
             </ul>
             <div class="puppy-card__actions">
               <a href="https://www.youtube.com/watch?v=RfcNi1zoJJA" class="btn-small btn-outline-small" target="_blank" rel="noopener">Watch video 🎥</a>
-              <a href="mailto:fernando@xolosramirez.com?subject=Interest in Tonatiuh Ramirez&body=Hello Fernando, I would like to receive information on how to reserve Tonatiuh Ramirez." class="btn-small btn-primary-small" onclick="dataLayer.push({ event: 'click_email', cachorro: 'Tonatiuh Ramirez', source: 'available_xolos_contact_en' })">Contact via Email</a>
+              <a href="mailto:contacto@xolosarmy.xyz?subject=Interest in Tonatiuh Ramirez&body=Hello Fernando, I would like to receive information on how to reserve Tonatiuh Ramirez." class="btn-small btn-primary-small" onclick="dataLayer.push({ event: 'click_email', cachorro: 'Tonatiuh Ramirez', source: 'available_xolos_contact_en' })">Contact via Email</a>
             </div>
           </div>
         </article>
@@ -183,7 +183,7 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
             </ul>
             <div class="puppy-card__actions">
               <a href="https://www.youtube.com/watch?v=HaPx8Bv3Pcg" class="btn-small btn-outline-small" target="_blank" rel="noopener">Watch video 🎥</a>
-              <a href="mailto:fernando@xolosramirez.com?subject=Interest in Ozomatli Ramirez&body=Hello Fernando, I would like to receive information on how to reserve Ozomatli Ramirez." class="btn-small btn-primary-small" onclick="dataLayer.push({ event: 'click_email', cachorro: 'Ozomatli Ramirez', source: 'available_xolos_contact_en' })">Contact via Email</a>
+              <a href="mailto:contacto@xolosarmy.xyz?subject=Interest in Ozomatli Ramirez&body=Hello Fernando, I would like to receive information on how to reserve Ozomatli Ramirez." class="btn-small btn-primary-small" onclick="dataLayer.push({ event: 'click_email', cachorro: 'Ozomatli Ramirez', source: 'available_xolos_contact_en' })">Contact via Email</a>
             </div>
           </div>
         </article>
@@ -212,7 +212,7 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
             </ul>
             <div class="puppy-card__actions">
               <a href="https://www.youtube.com/watch?v=k8YQjGDdQaM" class="btn-small btn-outline-small" target="_blank" rel="noopener">Watch video 🎥</a>
-              <a href="mailto:fernando@xolosramirez.com?subject=Interest in Nox Ramirez&body=Hello Fernando, I would like to receive information on how to reserve Nox Ramirez." class="btn-small btn-primary-small" onclick="dataLayer.push({ event: 'click_email', cachorro: 'Nox Ramirez', source: 'available_xolos_contact_en' })">Contact via Email</a>
+              <a href="mailto:contacto@xolosarmy.xyz?subject=Interest in Nox Ramirez&body=Hello Fernando, I would like to receive information on how to reserve Nox Ramirez." class="btn-small btn-primary-small" onclick="dataLayer.push({ event: 'click_email', cachorro: 'Nox Ramirez', source: 'available_xolos_contact_en' })">Contact via Email</a>
             </div>
           </div>
         </article>
@@ -241,7 +241,7 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
             </ul>
             <div class="puppy-card__actions">
               <a href="https://www.youtube.com/watch?v=dWwc4FRzI8g" class="btn-small btn-outline-small" target="_blank" rel="noopener">Watch video 🎥</a>
-              <a href="mailto:fernando@xolosramirez.com?subject=Interest in Teyolia Ramirez&body=Hello Fernando, I would like to receive information on how to reserve Teyolia Ramirez." class="btn-small btn-primary-small" onclick="dataLayer.push({ event: 'click_email', cachorro: 'Teyolia Ramirez', source: 'available_xolos_contact_en' })">Contact via Email</a>
+              <a href="mailto:contacto@xolosarmy.xyz?subject=Interest in Teyolia Ramirez&body=Hello Fernando, I would like to receive information on how to reserve Teyolia Ramirez." class="btn-small btn-primary-small" onclick="dataLayer.push({ event: 'click_email', cachorro: 'Teyolia Ramirez', source: 'available_xolos_contact_en' })">Contact via Email</a>
             </div>
           </div>
         </article>
@@ -272,7 +272,7 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
 
   <a
     class="email-float"
-    href="mailto:fernando@xolosramirez.com?subject=Inquiry about Available Xolos&body=Hello Fernando, I am visiting the Xolos Ramirez website from the US/Canada and would like more information on the available puppies."
+    href="mailto:contacto@xolosarmy.xyz?subject=Inquiry about Available Xolos&body=Hello Fernando, I am visiting the Xolos Ramirez website from the US/Canada and would like more information on the available puppies."
     data-gtm="email-floating-en"
     onclick="dataLayer.push({ event: 'click_email', cachorro: 'general', source: 'available_xolos_floating_en' })"
   >

--- a/en/contact.html
+++ b/en/contact.html
@@ -158,7 +158,7 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
           <article class="card" data-aos="zoom-in" data-aos-delay="250">
             <h3>Direct contact</h3>
             <p><strong>Phone:</strong> +52 55 18555993</p>
-            <p><strong>Email:</strong> fernando@xolosramirez.com</p>
+            <p><strong>Email:</strong> contacto@xolosarmy.xyz</p>
           </article>
         </div>
       </section>

--- a/index.html
+++ b/index.html
@@ -362,7 +362,7 @@ NFTs de Linaje Xoloitzcuintle</a></li>
     </script>
     <a
       class="email-float"
-      href="mailto:fernando@xolosramirez.com?subject=Consulta desde el Inicio&body=Hola Fernando, vengo desde la página principal de Xolos Ramírez y me gustaría obtener más información."
+      href="mailto:contacto@xolosarmy.xyz?subject=Consulta desde el Inicio&body=Hola Fernando, vengo desde la página principal de Xolos Ramírez y me gustaría obtener más información."
       data-gtm="email-floating"
       onclick="dataLayer.push({ event: 'click_email', cachorro: 'general', source: 'index_floating' })"
       aria-label="Contactar por Email"

--- a/public/xolos-disponibles.html
+++ b/public/xolos-disponibles.html
@@ -272,7 +272,7 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
 
     <a
     class="email-float"
-    href="mailto:fernando@xolosramirez.com?subject=Consulta sobre Xolos Disponibles&body=Hola Fernando, me interesa obtener más información sobre los ejemplares disponibles en la web."
+    href="mailto:contacto@xolosarmy.xyz?subject=Consulta sobre Xolos Disponibles&body=Hola Fernando, me interesa obtener más información sobre los ejemplares disponibles en la web."
     data-gtm="email-floating"
     onclick="dataLayer.push({ event: 'click_email', cachorro: 'general', source: 'xolos_disponibles_floating' })"
   >

--- a/xolos-disponibles.html
+++ b/xolos-disponibles.html
@@ -233,7 +233,7 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
       </ul>
       <div class="puppy-card__actions">
         <a href="https://www.youtube.com/watch?v=RfcNi1zoJJA" class="btn-small btn-outline-small" target="_blank" rel="noopener">Ver video 🎥</a>
-        <a href="mailto:fernando@xolosramirez.com?subject=Interés en Tonatiuh Ramirez&body=Hola, me gustaría recibir información para reservar a Tonatiuh Ramirez." class="btn-small btn-primary-small" onclick="dataLayer.push({ event: 'click_email', cachorro: 'Tonatiuh Ramirez', source: 'xolos_disponibles_contactar' })">Contactar por Email</a>
+        <a href="mailto:contacto@xolosarmy.xyz?subject=Interés en Tonatiuh Ramirez&body=Hola, me gustaría recibir información para reservar a Tonatiuh Ramirez." class="btn-small btn-primary-small" onclick="dataLayer.push({ event: 'click_email', cachorro: 'Tonatiuh Ramirez', source: 'xolos_disponibles_contactar' })">Contactar por Email</a>
       </div>
     </div>
   </article>
@@ -262,7 +262,7 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
       </ul>
       <div class="puppy-card__actions">
         <a href="https://www.youtube.com/watch?v=HaPx8Bv3Pcg" class="btn-small btn-outline-small" target="_blank" rel="noopener">Ver video 🎥</a>
-        <a href="mailto:fernando@xolosramirez.com?subject=Interés en Ozomatli Ramirez&body=Hola, me gustaría recibir información para reservar a Ozomatli Ramirez." class="btn-small btn-primary-small" onclick="dataLayer.push({ event: 'click_email', cachorro: 'Ozomatli Ramirez', source: 'xolos_disponibles_contactar' })">Contactar por Email</a>
+        <a href="mailto:contacto@xolosarmy.xyz?subject=Interés en Ozomatli Ramirez&body=Hola, me gustaría recibir información para reservar a Ozomatli Ramirez." class="btn-small btn-primary-small" onclick="dataLayer.push({ event: 'click_email', cachorro: 'Ozomatli Ramirez', source: 'xolos_disponibles_contactar' })">Contactar por Email</a>
       </div>
     </div>
   </article>
@@ -291,7 +291,7 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
       </ul>
       <div class="puppy-card__actions">
         <a href="https://www.youtube.com/watch?v=k8YQjGDdQaM" class="btn-small btn-outline-small" target="_blank" rel="noopener">Ver video 🎥</a>
-        <a href="mailto:fernando@xolosramirez.com?subject=Interés en Nox Ramirez&body=Hola, me gustaría recibir información para reservar a Nox Ramirez." class="btn-small btn-primary-small" onclick="dataLayer.push({ event: 'click_email', cachorro: 'Nox Ramirez', source: 'xolos_disponibles_contactar' })">Contactar por Email</a>
+        <a href="mailto:contacto@xolosarmy.xyz?subject=Interés en Nox Ramirez&body=Hola, me gustaría recibir información para reservar a Nox Ramirez." class="btn-small btn-primary-small" onclick="dataLayer.push({ event: 'click_email', cachorro: 'Nox Ramirez', source: 'xolos_disponibles_contactar' })">Contactar por Email</a>
       </div>
     </div>
   </article>
@@ -322,7 +322,7 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
       </ul>
       <div class="puppy-card__actions">
         <a href="https://www.youtube.com/watch?v=dWwc4FRzI8g" class="btn-small btn-outline-small" target="_blank" rel="noopener">Ver video 🎥</a>
-        <a href="mailto:fernando@xolosramirez.com?subject=Interés en Teyolia Ramirez&body=Hola, me gustaría recibir información para reservar a Teyolia Ramirez." class="btn-small btn-primary-small" onclick="dataLayer.push({ event: 'click_email', cachorro: 'Teyolia Ramirez', source: 'xolos_disponibles_contactar' })">Contactar por Email</a>
+        <a href="mailto:contacto@xolosarmy.xyz?subject=Interés en Teyolia Ramirez&body=Hola, me gustaría recibir información para reservar a Teyolia Ramirez." class="btn-small btn-primary-small" onclick="dataLayer.push({ event: 'click_email', cachorro: 'Teyolia Ramirez', source: 'xolos_disponibles_contactar' })">Contactar por Email</a>
       </div>
     </div>
   </article>
@@ -509,7 +509,7 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
     
         <a
       class="email-float"
-      href="mailto:fernando@xolosramirez.com?subject=Consulta sobre Xolos Disponibles&body=Hola Fernando, me interesa obtener más información sobre los ejemplares disponibles en la web."
+      href="mailto:contacto@xolosarmy.xyz?subject=Consulta sobre Xolos Disponibles&body=Hola Fernando, me interesa obtener más información sobre los ejemplares disponibles en la web."
       data-gtm="email-floating"
       onclick="dataLayer.push({ event: 'click_email', cachorro: 'general', source: 'xolos_disponibles_floating' })"
     >


### PR DESCRIPTION
### Motivation
- Replace legacy contact address `fernando@xolosramirez.com` with the new email `contacto@xolosarmy.xyz` so all mailto links and visible contact fields point to the current contact inbox.

### Description
- Replaced `mailto:` targets and visible email text across the site, including floating email buttons and per-item inquiry buttons.
- Updated these files: `index.html`, `contacto.html`, `en/contact.html`, `xolos-disponibles.html`, `en/available-xolos.html`, and `public/xolos-disponibles.html`.
- Performed an automated project-wide replace of `fernando@xolosramirez.com` → `contacto@xolosarmy.xyz` to ensure consistency in all affected pages.
- Preserved existing `subject` and `body` query parameters in `mailto:` links to keep analytics and prefilled messages intact.

### Testing
- Ran a project-wide search with `rg -n "fernando@xolosramirez.com"` and confirmed no remaining occurrences were found after the change.
- Verified updated `mailto:` links and floating buttons by inspecting relevant lines with `nl | rg` to ensure `contacto@xolosarmy.xyz` appears in the modified files.
- No automated unit tests exist for these static HTML changes; manual verification steps above passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d133d62b20833293e48e9d1ae6ec5f)