### PR TITLE
Refina copy premium de pagos y añade guía de eCash (XEC)

### DIFF
--- a/index.html
+++ b/index.html
@@ -144,9 +144,12 @@ Selección de Ejemplares de Calidad: Seleccionamos cuidadosamente a los perros q
           </article>
           <article class="card trust-card">
             <span class="trust-icon" aria-hidden="true">🔒💳</span>
-            <h4>Pago seguro</h4>
+            <h4>Métodos de pago alternativos</h4>
             <p>
-              Métodos de pago seguros con comprobante (transferencia bancaria o criptomonedas) y acompañamiento en el proceso.
+              Aceptamos efectivo y eCash (XEC) como opciones de pago con
+              comprobante, claridad en cada paso y acompañamiento profesional
+              para una experiencia serena, confiable y a la altura de tu
+              elección.
             </p>
           </article>
           <article class="card trust-card">

--- a/xolos-disponibles.html
+++ b/xolos-disponibles.html
@@ -162,9 +162,11 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
           </article>
           <article class="card trust-card">
             <span class="trust-icon" aria-hidden="true">🔒💳</span>
-            <h4>Pago seguro</h4>
+            <h4>Métodos de pago alternativos</h4>
             <p>
-              Métodos seguros con comprobante (transferencia bancaria o pago con criptomonedas) y acompañamiento continuo.
+              Aceptamos efectivo y eCash (XEC) como opciones de pago con
+              comprobante, acompañamiento continuo y una gestión clara,
+              elegante y profesional durante todo el proceso.
             </p>
           </article>
           <article class="card trust-card">
@@ -433,6 +435,33 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
             <p><strong>3. Reserva:</strong> Confirma el anticipo y coordinamos la entrega contigo.</p>
           </div>
         </div>
+      </section>
+
+      <section class="card" data-aos="fade-up" data-aos-duration="1000" style="margin-top: 1.5rem; border: 1px solid rgba(212, 175, 55, 0.35); background: linear-gradient(145deg, rgba(16,16,16,0.95), rgba(28,28,28,0.95)); box-shadow: 0 14px 34px rgba(0, 0, 0, 0.35);">
+        <p class="eyebrow" style="letter-spacing: .12em; text-transform: uppercase; color: #d4af37; margin-bottom: .35rem;">Tradición y tecnología</p>
+        <h2 style="margin-top: 0;">Cómo pagar con eCash (XEC)</h2>
+        <p>
+          Si deseas realizar tu reserva con eCash (XEC), te ofrecemos una
+          opción digital directa y de innovación financiera, integrada con el
+          mismo estándar de confianza y acompañamiento que distingue a
+          Xolos Ramírez.
+        </p>
+        <div class="pasos-reserva">
+          <div class="paso">
+            <p><strong>1. Adquiere XEC:</strong> Compra eCash (XEC) en una plataforma confiable y prepara el monto acordado para tu reserva.</p>
+          </div>
+          <div class="paso">
+            <p><strong>2. Gestiona tu autocustodia:</strong> Utiliza Tonalli Wallet para recibir, resguardar y enviar tus fondos con control directo.</p>
+          </div>
+          <div class="paso">
+            <p><strong>3. Realiza tu pago:</strong> Te compartimos la dirección de pago, confirmamos recepción y emitimos el comprobante correspondiente.</p>
+          </div>
+        </div>
+        <p style="margin-top: 1rem;">
+          Nuestro equipo te acompaña en cada etapa para asegurar claridad en el
+          proceso y una experiencia alineada con nuestra visión: ancestral en
+          origen, contemporánea en ejecución.
+        </p>
       </section>
 
       <section data-aos="fade-up" data-aos-duration="1000">


### PR DESCRIPTION
### Motivation
- Comunicar con tono premium y culturalmente alineado que ahora aceptamos efectivo y eCash (XEC) como métodos de pago alternativos, enfatizando autocustodia, acompañamiento y claridad. 
- Evitar cualquier lenguaje que sugiera evasión o elusión, manteniendo la confianza y profesionalismo de la marca.

### Description
- Reemplacé la tarjeta de pago en `index.html` por una versión con título `Métodos de pago alternativos` y copy que menciona efectivo, eCash (XEC), comprobante y acompañamiento. 
- Reemplacé la tarjeta equivalente en `xolos-disponibles.html` manteniendo las clases existentes y ajustando el copy a un tono más elegante y profesional. 
- Agregué una nueva sección premium `Cómo pagar con eCash (XEC)` en `xolos-disponibles.html`, ubicada entre `¿Cómo reservo?` y `Calendario de seguimientos`, con pasos claros (adquirir XEC, autocustodia con Tonalli Wallet, realizar pago) y estilos inline moderados para consistencia visual inmediata. 

### Testing
- Ejecuté `git diff --check` y no arrojó errores, lo que valida que no hay problemas básicos de formato en el diff.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d5306aa96083329490152f5beb60a0)