### PR TITLE
Add linked eCash guide CTAs to payment content

### DIFF
--- a/index.html
+++ b/index.html
@@ -146,7 +146,7 @@ Selección de Ejemplares de Calidad: Seleccionamos cuidadosamente a los perros q
             <span class="trust-icon" aria-hidden="true">🔒💳</span>
             <h4>Métodos de pago alternativos</h4>
             <p>
-              Aceptamos efectivo y eCash (XEC) como opciones de pago con
+              Aceptamos efectivo y <a href="blog/guia-pago-con-tonalli-wallet.html" style="color: var(--accent-color); font-weight: 600; text-decoration: none; border-bottom: 1px solid rgba(212, 175, 55, 0.3);">eCash (XEC)</a> como opciones de pago con
               comprobante, claridad en cada paso y acompañamiento profesional
               para una experiencia serena, confiable y a la altura de tu
               elección.

--- a/xolos-disponibles.html
+++ b/xolos-disponibles.html
@@ -164,7 +164,7 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
             <span class="trust-icon" aria-hidden="true">🔒💳</span>
             <h4>Métodos de pago alternativos</h4>
             <p>
-              Aceptamos efectivo y eCash (XEC) como opciones de pago con
+              Aceptamos efectivo y <a href="blog/guia-pago-con-tonalli-wallet.html" style="color: var(--accent-color); font-weight: 600; text-decoration: none; border-bottom: 1px solid rgba(212, 175, 55, 0.3);">eCash (XEC)</a> como opciones de pago con
               comprobante, acompañamiento continuo y una gestión clara,
               elegante y profesional durante todo el proceso.
             </p>
@@ -441,7 +441,7 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
         <p class="eyebrow" style="letter-spacing: .12em; text-transform: uppercase; color: #d4af37; margin-bottom: .35rem;">Tradición y tecnología</p>
         <h2 style="margin-top: 0;">Cómo pagar con eCash (XEC)</h2>
         <p>
-          Si deseas realizar tu reserva con eCash (XEC), te ofrecemos una
+          Si deseas realizar tu reserva con <a href="blog/guia-pago-con-tonalli-wallet.html" style="color: #d4af37; font-weight: 600; text-decoration: none; border-bottom: 1px solid rgba(212, 175, 55, 0.5);">eCash (XEC)</a>, te ofrecemos una
           opción digital directa y de innovación financiera, integrada con el
           mismo estándar de confianza y acompañamiento que distingue a
           Xolos Ramírez.
@@ -451,16 +451,17 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
             <p><strong>1. Adquiere XEC:</strong> Compra eCash (XEC) en una plataforma confiable y prepara el monto acordado para tu reserva.</p>
           </div>
           <div class="paso">
-            <p><strong>2. Gestiona tu autocustodia:</strong> Utiliza Tonalli Wallet para recibir, resguardar y enviar tus fondos con control directo.</p>
+            <p><strong>2. Gestiona tu autocustodia:</strong> Utiliza <a href="blog/guia-pago-con-tonalli-wallet.html" style="color: #d4af37; text-decoration: none; border-bottom: 1px solid rgba(212, 175, 55, 0.5);">Tonalli Wallet</a> para recibir, resguardar y enviar tus fondos con control directo.</p>
           </div>
           <div class="paso">
             <p><strong>3. Realiza tu pago:</strong> Te compartimos la dirección de pago, confirmamos recepción y emitimos el comprobante correspondiente.</p>
           </div>
         </div>
-        <p style="margin-top: 1rem;">
-          Nuestro equipo te acompaña en cada etapa para asegurar claridad en el
-          proceso y una experiencia alineada con nuestra visión: ancestral en
-          origen, contemporánea en ejecución.
+        <p style="margin-top: 1.5rem; text-align: center;">
+          <a href="blog/guia-pago-con-tonalli-wallet.html" class="btn-aesthetic" style="display: inline-flex; align-items: center; padding: 10px 25px; font-size: 0.8rem;">
+            <span>Consultar Guía Interactiva</span>
+            <span style="margin-left: 10px;">→</span>
+          </a>
         </p>
       </section>
 


### PR DESCRIPTION
### Motivation
- Hacer que las menciones de eCash (XEC) y Tonalli Wallet en las secciones de pago apunten a la guía interactiva para mejorar la conversión y mantener la estética premium del sitio.

### Description
- En `index.html` se actualizó la tarjeta “Métodos de pago alternativos” para enlazar `eCash (XEC)` a `blog/guia-pago-con-tonalli-wallet.html` con estilos inline dorados.
- En `xolos-disponibles.html` se aplicó el mismo enlace y estilo a la tarjeta equivalente de confianza y garantías.
- En la sección “Cómo pagar con eCash (XEC)” de `xolos-disponibles.html` se enlazó `eCash (XEC)` en el párrafo inicial, se enlazó `Tonalli Wallet` en el paso 2 y se reemplazó el párrafo final por un CTA centrado `Consultar Guía Interactiva`.
- Todos los enlaces usan la ruta relativa `blog/guia-pago-con-tonalli-wallet.html` y se añadieron sutiles `border-bottom` para señalizar los links sin romper la estética.

### Testing
- Se localizó el contenido objetivo con `rg` para verificar ubicaciones antes y después del cambio, y la verificación devolvió las líneas esperadas.
- El script de reemplazo Python se ejecutó y devolvió `done` indicando que las sustituciones se aplicaron correctamente.
- Se ejecutó `git diff --check` para validar que no hay errores de espacio en blanco o problemas en el diff y la comprobación pasó correctamente.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d53716d1d4833298a01a2d9484f0ba)