### PR TITLE
Add “Naturals” header/footer links and GTM click tracking

### DIFF
--- a/index.html
+++ b/index.html
@@ -81,6 +81,16 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
             <li><a href="galeria.html">Galería</a></li>
             <li><a href="testimonios.html">Testimonios</a></li>
             <li><a href="blog/index.html">Blog</a></li>
+            <li>
+              <a
+                href="https://xolosarmy.xyz/productos-xoloitzcuintle/"
+                data-gtm="naturals-nav"
+                data-gtm-origin="nav"
+                title="xolosArmy Naturals — cuidado ancestral"
+              >
+                Naturals
+              </a>
+            </li>
             <li><a href="contacto.html">Contacto</a></li>
           </ul>
         </nav>
@@ -338,6 +348,16 @@ NFTs de Linaje Xoloitzcuintle</a></li>
             <li><a href="xolos-disponibles.html">Xolos disponibles</a></li>
             <li><a href="blog/index.html">Blog</a></li>
             <li><a href="contacto.html">Contacto</a></li>
+            <li>
+              <a
+                href="https://xolosarmy.xyz/productos-xoloitzcuintle/"
+                data-gtm="naturals-footer"
+                data-gtm-origin="footer"
+                title="xolosArmy Naturals — cuidado ancestral"
+              >
+                Naturals
+              </a>
+            </li>
             <li>
               <a
                 href="https://xolosarmy.xyz"

--- a/js/main.js
+++ b/js/main.js
@@ -50,3 +50,19 @@ if (navMenu) {
     }
   });
 }
+
+document.addEventListener('click', (event) => {
+  const target = event.target;
+  if (!(target instanceof Element)) return;
+
+  const naturalsLink = target.closest('a[data-gtm^="naturals"]');
+  if (!naturalsLink) return;
+
+  window.dataLayer = window.dataLayer || [];
+  window.dataLayer.push({
+    event: 'click_naturals',
+    element: naturalsLink.dataset.gtm || '',
+    origin: naturalsLink.dataset.gtmOrigin || '',
+    href: naturalsLink.getAttribute('href') || '',
+  });
+});


### PR DESCRIPTION
### Motivation
- Add a prominent link to the xolosArmy “Naturals” product page in both the site header and footer and capture click signals for analytics.

### Description
- Inserted a `Naturals` navigation item in the header with `href`, `data-gtm`, `data-gtm-origin`, and `title` attributes.
- Added a matching `Naturals` link to the footer with the same `data-gtm` and `data-gtm-origin` attributes and `title` text.
- Implemented a global click handler in `js/main.js` that detects clicks on `a[data-gtm^="naturals"]` and pushes an event to `window.dataLayer` with `event: 'click_naturals'` and payload fields `element`, `origin`, and `href`.

### Testing
- No automated tests were added or executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69da8520eba8833295a266bf596e7374)