### PR TITLE
Replace floating email CTA with WhatsApp button

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -1463,3 +1463,31 @@ form textarea:focus {
     font-size: 0.72rem;
   }
 }
+
+/* Botón Flotante de WhatsApp - Premium */
+.wa-float {
+  position: fixed;
+  right: 1.5rem;
+  bottom: 1.5rem;
+  background-color: #2c2c2c; /* Fondo oscuro para mantener la elegancia */
+  color: #25D366; /* Verde oficial de WhatsApp */
+  padding: 0.85rem 1.5rem;
+  border: 1px solid #25D366;
+  border-radius: 999px;
+  font-weight: 700;
+  display: inline-flex;
+  align-items: center;
+  gap: 0.75rem;
+  box-shadow: 0 8px 25px rgba(0, 0, 0, 0.5);
+  z-index: 9999;
+  text-decoration: none;
+  transition: all 0.3s ease;
+}
+
+.wa-float:hover {
+  background-color: #25D366;
+  color: #111; /* Texto oscuro al hacer hover */
+  transform: translateY(-3px);
+  box-shadow: 0 12px 30px rgba(37, 211, 102, 0.3);
+  text-decoration: none;
+}

--- a/index.html
+++ b/index.html
@@ -384,13 +384,14 @@ NFTs de Linaje Xoloitzcuintle</a></li>
       AOS.init({ once: true, duration: 700, offset: 60, easing: 'ease-out' });
     </script>
     <a
-      class="email-float"
-      href="mailto:fernando@xolosramirez.com?subject=Consulta desde el Inicio&body=Hola Fernando, vengo desde la página principal de Xolos Ramírez y me gustaría obtener más información."
-      data-gtm="email-floating"
-      onclick="dataLayer.push({ event: 'click_email', cachorro: 'general', source: 'index_floating' })"
-      aria-label="Contactar por Email"
+      class="wa-float"
+      href="https://wa.me/qr/LNO2OMMH2ZKWF1"
+      target="_blank"
+      rel="noopener noreferrer"
+      data-gtm="whatsapp-floating"
+      onclick="dataLayer.push({ event: 'click_whatsapp', source: 'floating_button' })"
     >
-      <span>📧 Contactar por Email</span>
+      <span>📲 WhatsApp</span>
     </a>
     <a href="https://app.tonalli.cash" target="_blank" class="tonalli-float-btn" aria-label="Abrir Tonalli Wallet">
         Abrir Tonalli Wallet

--- a/xolos-disponibles.html
+++ b/xolos-disponibles.html
@@ -537,13 +537,15 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
       <p class="copyright">© 2025 Xolos Ramírez. Todos los derechos reservados.</p>
     </footer>
     
-        <a
-      class="email-float"
-      href="mailto:fernando@xolosramirez.com?subject=Consulta sobre Xolos Disponibles&body=Hola Fernando, me interesa obtener más información sobre los ejemplares disponibles en la web."
-      data-gtm="email-floating"
-      onclick="dataLayer.push({ event: 'click_email', cachorro: 'general', source: 'xolos_disponibles_floating' })"
+    <a
+      class="wa-float"
+      href="https://wa.me/qr/LNO2OMMH2ZKWF1"
+      target="_blank"
+      rel="noopener noreferrer"
+      data-gtm="whatsapp-floating"
+      onclick="dataLayer.push({ event: 'click_whatsapp', source: 'floating_button' })"
     >
-      <span>📧 Quiero mas información </span>
+      <span>📲 WhatsApp</span>
     </a>
     <script src="js/main.js" defer></script>
     <script src="https://unpkg.com/aos@2.3.1/dist/aos.js"></script>


### PR DESCRIPTION
### Motivation
- Modernize the site's floating CTA by replacing the email contact with a WhatsApp shortcut while keeping the premium dark aesthetic. 
- Ensure tracking continues to work by switching the dataLayer event to `click_whatsapp` and adding a `data-gtm="whatsapp-floating"` marker. 
- Keep existing email styles available because other pages still reference `.email-float`.

### Description
- Replaced the floating email anchor in `index.html` with a WhatsApp anchor that opens the QR link in a new tab and emits `dataLayer.push({ event: 'click_whatsapp', source: 'floating_button' })` and `data-gtm="whatsapp-floating"`.
- Replaced the floating email anchor in `xolos-disponibles.html` with the same WhatsApp anchor and tracking event.
- Added `.wa-float` and `.wa-float:hover` CSS rules to `css/styles.css` to preserve the premium dark look while using WhatsApp green accents and hover behavior.
- Left `.email-float` rules in place to avoid breaking other pages that still reference that class.

### Testing
- Verified the new selectors and events exist with `rg "wa-float|click_whatsapp|whatsapp-floating"` and found matches in `index.html`, `xolos-disponibles.html`, and `css/styles.css` (exit status 0).
- Inspected the updated markup locations with `nl -ba index.html | sed -n '380,405p'` and `nl -ba xolos-disponibles.html | sed -n '536,556p'` to confirm the WhatsApp anchors are placed before scripts.
- Confirmed the CSS block was appended near the end of `css/styles.css` with `nl -ba css/styles.css | sed -n '1458,1498p'` and `tail` output and observed the `.wa-float` rules present (commands exited 0).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dae29e878c83328494b4e378c49422)