### PR TITLE
Add horizontal swipeable image carousel to Teyolia Ramirez profile card

### DIFF
--- a/xolos-disponibles.html
+++ b/xolos-disponibles.html
@@ -303,16 +303,35 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
   <article class="puppy-card" data-aos="fade-up" data-aos-duration="800" data-aos-delay="500">
     <div class="puppy-card__image-wrapper">
       <span class="puppy-card__status status-disponible">Disponible</span>
-      <picture>
+      
+      <div style="display: flex; overflow-x: auto; scroll-snap-type: x mandatory; scrollbar-width: none; -ms-overflow-style: none;">
+        <style>
+          /* Ocultar barra de scroll en navegadores webkit para que luzca limpio */
+          .puppy-card__image-wrapper div::-webkit-scrollbar { display: none; }
+        </style>
+        
         <img
           src="https://i.imgur.com/5GRa8Wn.png"
-          alt="Xoloitzcuintle Teyolia Ramirez"
+          alt="Xoloitzcuintle Teyolia Ramirez 1"
           class="puppy-card__image"
           loading="lazy"
-          width="600"
-          height="450"
+          style="flex: 0 0 100%; scroll-snap-align: start; object-fit: cover;"
         />
-      </picture>
+        <img
+          src="https://i.imgur.com/pkkgjsh.jpeg"
+          alt="Xoloitzcuintle Teyolia Ramirez 2"
+          class="puppy-card__image"
+          loading="lazy"
+          style="flex: 0 0 100%; scroll-snap-align: start; object-fit: cover;"
+        />
+        <img
+          src="https://i.imgur.com/rTEISm2.jpeg"
+          alt="Xoloitzcuintle Teyolia Ramirez 3"
+          class="puppy-card__image"
+          loading="lazy"
+          style="flex: 0 0 100%; scroll-snap-align: start; object-fit: cover;"
+        />
+      </div>
     </div>
     <div class="puppy-card__content">
       <h3 class="puppy-card__name">Teyolia Ramirez</h3>


### PR DESCRIPTION
### Motivation
- Improve the Teyolia Ramirez profile card to show the original and two new photos without altering the overall page layout by using an inline horizontal carousel.

### Description
- Replaced the `<article>` image block for Teyolia Ramirez with a flex container that holds three `<img>` elements and enables horizontal scrolling.
- Added inline styles for `display: flex`, `overflow-x: auto`, `scroll-snap-type: x mandatory`, `scroll-snap-align: start`, and `object-fit: cover` so each image snaps to the card width.
- Included a small webkit scrollbar-hiding rule to keep the carousel visually clean on supported browsers.
- Left all profile metadata and action links (video and contact email) unchanged.

### Testing
- Verified the HTML diff shows only the intended profile-card replacement and the three new image elements were added (succeeded).
- Inspected the updated file content to confirm the inline flex and scroll-snap styles are present and correctly scoped to the Teyolia card (succeeded).
- Ran repository status/diff checks to ensure no unintended files were modified (succeeded).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dc1b37996083329af8c076dece9fe5)