### PR TITLE
Actualizar tarjeta de Ozomatli Ramirez con carrusel de tres imágenes

### DIFF
--- a/xolos-disponibles.html
+++ b/xolos-disponibles.html
@@ -243,16 +243,35 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
   <article class="puppy-card" data-aos="fade-up" data-aos-duration="800" data-aos-delay="200">
     <div class="puppy-card__image-wrapper">
       <span class="puppy-card__status status-disponible">Disponible</span>
-      <picture>
+      
+      <div style="display: flex; overflow-x: auto; scroll-snap-type: x mandatory; scrollbar-width: none; -ms-overflow-style: none;">
+        <style>
+          /* Ocultar barra de scroll para mantener la estética limpia */
+          .puppy-card__image-wrapper div::-webkit-scrollbar { display: none; }
+        </style>
+        
         <img
           src="https://i.imgur.com/SGG6yte.jpeg"
-          alt="Xoloitzcuintle Ozomatli Ramirez"
+          alt="Xoloitzcuintle Ozomatli Ramirez 1"
           class="puppy-card__image"
           loading="lazy"
-          width="600"
-          height="450"
+          style="flex: 0 0 100%; scroll-snap-align: start; object-fit: cover;"
         />
-      </picture>
+        <img
+          src="https://i.imgur.com/e4z2vS9.jpeg"
+          alt="Xoloitzcuintle Ozomatli Ramirez 2"
+          class="puppy-card__image"
+          loading="lazy"
+          style="flex: 0 0 100%; scroll-snap-align: start; object-fit: cover;"
+        />
+        <img
+          src="https://i.imgur.com/zyRGNA6.jpeg"
+          alt="Xoloitzcuintle Ozomatli Ramirez 3"
+          class="puppy-card__image"
+          loading="lazy"
+          style="flex: 0 0 100%; scroll-snap-align: start; object-fit: cover;"
+        />
+      </div>
     </div>
     <div class="puppy-card__content">
       <h3 class="puppy-card__name">Ozomatli Ramirez</h3>


### PR DESCRIPTION
### Motivation
- Mostrar las dos nuevas fotos de Ozomatli Ramirez en la tarjeta usando el mismo estilo de carrusel empleado para Teyolia, mejorando la navegación y la estética de la galería.

### Description
- Reemplacé el bloque `<picture>` en `xolos-disponibles.html` por un contenedor horizontal con `display: flex`, `overflow-x: auto` y `scroll-snap-type: x mandatory` para permitir el desplazamiento entre imágenes.
- Añadí dos imágenes adicionales (ahora 3 en total) y actualicé los `alt` para distinguir cada foto, aplicando `style="flex: 0 0 100%; scroll-snap-align: start; object-fit: cover;"` a cada `img`.
- Agregué un bloque `<style>` inline que oculta la barra de desplazamiento para mantener la estética y conservé la información y acciones del cachorro (edad, género, talla, color, video y contacto).

### Testing
- Ejecuté `rg -n "Ozomatli Ramirez|puppy-card" xolos-disponibles.html` para localizar el bloque modificado y la consulta devolvió resultados exitosos.
- Verifiqué el fragmento modificado con `sed -n '236,276p' xolos-disponibles.html` y confirmé la nueva estructura HTML.
- Comprobé las líneas afectadas con `nl -ba xolos-disponibles.html | sed -n '240,305p'` y confirmé que las tres imágenes y el contenedor aparecen correctamente.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dc1e88edf48332a0a26d2c194a9c7c)