### PR TITLE
Actualizar tarjeta de Nox Ramirez con carrusel de 4 imágenes

### DIFF
--- a/xolos-disponibles.html
+++ b/xolos-disponibles.html
@@ -291,16 +291,42 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
   <article class="puppy-card" data-aos="fade-up" data-aos-duration="800" data-aos-delay="300">
     <div class="puppy-card__image-wrapper">
       <span class="puppy-card__status status-disponible">Disponible</span>
-      <picture>
+      
+      <div style="display: flex; overflow-x: auto; scroll-snap-type: x mandatory; scrollbar-width: none; -ms-overflow-style: none;">
+        <style>
+          /* Ocultar barra de scroll para mantener la estética limpia */
+          .puppy-card__image-wrapper div::-webkit-scrollbar { display: none; }
+        </style>
+        
         <img
           src="https://i.imgur.com/Pb9YiKo.jpeg"
-          alt="Xoloitzcuintle Nox Ramirez"
+          alt="Xoloitzcuintle Nox Ramirez 1"
           class="puppy-card__image"
           loading="lazy"
-          width="600"
-          height="450"
+          style="flex: 0 0 100%; scroll-snap-align: start; object-fit: cover;"
         />
-      </picture>
+        <img
+          src="https://i.imgur.com/WismZ1k.jpeg"
+          alt="Xoloitzcuintle Nox Ramirez 2"
+          class="puppy-card__image"
+          loading="lazy"
+          style="flex: 0 0 100%; scroll-snap-align: start; object-fit: cover;"
+        />
+        <img
+          src="https://i.imgur.com/RcfZ1h2.jpeg"
+          alt="Xoloitzcuintle Nox Ramirez 3"
+          class="puppy-card__image"
+          loading="lazy"
+          style="flex: 0 0 100%; scroll-snap-align: start; object-fit: cover;"
+        />
+        <img
+          src="https://i.imgur.com/wi4yptD.jpeg"
+          alt="Xoloitzcuintle Nox Ramirez 4"
+          class="puppy-card__image"
+          loading="lazy"
+          style="flex: 0 0 100%; scroll-snap-align: start; object-fit: cover;"
+        />
+      </div>
     </div>
     <div class="puppy-card__content">
       <h3 class="puppy-card__name">Nox Ramirez</h3>


### PR DESCRIPTION
### Motivation
- Mejorar la tarjeta de Nox Ramirez para mostrar las cuatro fotos disponibles en un carrusel deslizable y mantener consistencia visual con otras tarjetas destacadas.

### Description
- Reemplacé el bloque HTML de Nox en `xolos-disponibles.html` pasando de una única `picture` a un contenedor horizontal con `flex` y `scroll-snap` que actúa como carrusel.
- Añadí tres imágenes nuevas para un total de cuatro `img` con `loading="lazy"` y `alt` actualizados (`1` a `4`).
- Incluí reglas en línea para ocultar la barra de scroll en WebKit y estilos `object-fit`/`scroll-snap-align` para asegurar comportamiento y apariencia consistente.
- Conservé el contenido y las acciones existentes (estado, detalles, enlace a video y enlace de email con `dataLayer` onclick) sin cambios funcionales.

### Testing
- Localizado el bloque objetivo con `rg` para confirmar la posición del reemplazo, y la comprobación devolvió la ubicación esperada (exit code 0).
- Inspeccioné el fragmento modificado con `nl -ba xolos-disponibles.html | sed -n '288,355p'` para verificar que el nuevo carrusel y las 4 imágenes están presentes.
- Apliqué el parche al archivo y confirmé que la modificación se reflejó correctamente en el repositorio de trabajo (aplicación de parche exitosa y archivo actualizado).
- Generé la metadata del PR mediante la herramienta interna para describir los cambios y validaciones realizadas (operación completada correctamente).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dc202aae148332a0e92cb47ece9cd0)