### PR TITLE
Ajusta tarjeta de Nox para evitar recorte en carrusel

### DIFF
--- a/xolos-disponibles.html
+++ b/xolos-disponibles.html
@@ -283,7 +283,7 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
   </article>
 
   <article class="puppy-card" data-aos="fade-up" data-aos-duration="800" data-aos-delay="300">
-    <div class="puppy-card__image-wrapper">
+    <div class="puppy-card__image-wrapper" style="background-color: #111;">
       <span class="puppy-card__status status-disponible">Disponible</span>
       
       <div style="display: flex; overflow-x: auto; scroll-snap-type: x mandatory; scrollbar-width: none; -ms-overflow-style: none;">
@@ -291,28 +291,26 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
           /* Ocultar barra de scroll para mantener la estética limpia */
           .puppy-card__image-wrapper div::-webkit-scrollbar { display: none; }
         </style>
-        
-        <
         <img
           src="https://i.imgur.com/WismZ1k.jpeg"
           alt="Xoloitzcuintle Nox Ramirez 2"
           class="puppy-card__image"
           loading="lazy"
-          style="flex: 0 0 100%; scroll-snap-align: start; object-fit: cover;"
+          style="flex: 0 0 100%; scroll-snap-align: start; object-fit: contain;"
         />
         <img
           src="https://i.imgur.com/RcfZ1h2.jpeg"
           alt="Xoloitzcuintle Nox Ramirez 3"
           class="puppy-card__image"
           loading="lazy"
-          style="flex: 0 0 100%; scroll-snap-align: start; object-fit: cover;"
+          style="flex: 0 0 100%; scroll-snap-align: start; object-fit: contain;"
         />
         <img
           src="https://i.imgur.com/wi4yptD.jpeg"
           alt="Xoloitzcuintle Nox Ramirez 4"
           class="puppy-card__image"
           loading="lazy"
-          style="flex: 0 0 100%; scroll-snap-align: start; object-fit: cover;"
+          style="flex: 0 0 100%; scroll-snap-align: start; object-fit: contain;"
         />
       </div>
     </div>


### PR DESCRIPTION
### Motivation
- Evitar que las fotos de la tarjeta de Nox se recorten en el carrusel para que se vean completas independientemente de su proporción. 
- Mejorar la apariencia al integrar los espacios vacíos con un fondo oscuro que armonice con la tarjeta.

### Description
- Actualicé `xolos-disponibles.html` para añadir `style="background-color: #111;"` al contenedor `.puppy-card__image-wrapper` de Nox. 
- Cambié las tres imágenes del carrusel de Nox para usar `object-fit: contain` en lugar de `cover` (inline `style` en cada `img`).
- Eliminé un carácter suelto (`<`) que estaba dentro del bloque del carrusel y limpié el HTML relacionado.

### Testing
- Verifiqué la presencia de `object-fit: contain` en las tres `img` del bloque de Nox con `rg` y confirmé las líneas afectadas con `nl`/`sed`. 
- Comprobé que `background-color: #111;` fue agregado al `div.puppy-card__image-wrapper` de Nox mediante búsqueda de texto. 
- Todas las comprobaciones automáticas de contenido local terminaron con resultados esperados (los cambios aparecen en el archivo modificado).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dc2338126c833287cb68d09e323ea7)