### PR TITLE
Actualizar correo de contacto a contacto@xolosarmy.xyz en páginas principales

### DIFF
--- a/contacto.html
+++ b/contacto.html
@@ -152,7 +152,7 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
           </article>
           <article class="card" data-aos="zoom-in" data-aos-delay="250">
             <h3>Contacto directo</h3>
-            <p><strong>Correo:</strong> fernando@xolosramirez.com</p>
+            <p><strong>Correo:</strong> contacto@xolosarmy.xyz</p>
           </article>
         </div>
       </section>

--- a/en/available-xolos.html
+++ b/en/available-xolos.html
@@ -154,7 +154,7 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
             </ul>
             <div class="puppy-card__actions">
               <a href="https://www.youtube.com/watch?v=RfcNi1zoJJA" class="btn-small btn-outline-small" target="_blank" rel="noopener">Watch video 🎥</a>
-              <a href="mailto:fernando@xolosramirez.com?subject=Interest in Tonatiuh Ramirez&body=Hello Fernando, I would like to receive information on how to reserve Tonatiuh Ramirez." class="btn-small btn-primary-small" onclick="dataLayer.push({ event: 'click_email', cachorro: 'Tonatiuh Ramirez', source: 'available_xolos_contact_en' })">Contact via Email</a>
+              <a href="mailto:contacto@xolosarmy.xyz?subject=Interest in Tonatiuh Ramirez&body=Hello Fernando, I would like to receive information on how to reserve Tonatiuh Ramirez." class="btn-small btn-primary-small" onclick="dataLayer.push({ event: 'click_email', cachorro: 'Tonatiuh Ramirez', source: 'available_xolos_contact_en' })">Contact via Email</a>
             </div>
           </div>
         </article>
@@ -183,7 +183,7 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
             </ul>
             <div class="puppy-card__actions">
               <a href="https://www.youtube.com/watch?v=HaPx8Bv3Pcg" class="btn-small btn-outline-small" target="_blank" rel="noopener">Watch video 🎥</a>
-              <a href="mailto:fernando@xolosramirez.com?subject=Interest in Ozomatli Ramirez&body=Hello Fernando, I would like to receive information on how to reserve Ozomatli Ramirez." class="btn-small btn-primary-small" onclick="dataLayer.push({ event: 'click_email', cachorro: 'Ozomatli Ramirez', source: 'available_xolos_contact_en' })">Contact via Email</a>
+              <a href="mailto:contacto@xolosarmy.xyz?subject=Interest in Ozomatli Ramirez&body=Hello Fernando, I would like to receive information on how to reserve Ozomatli Ramirez." class="btn-small btn-primary-small" onclick="dataLayer.push({ event: 'click_email', cachorro: 'Ozomatli Ramirez', source: 'available_xolos_contact_en' })">Contact via Email</a>
             </div>
           </div>
         </article>
@@ -212,7 +212,7 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
             </ul>
             <div class="puppy-card__actions">
               <a href="https://www.youtube.com/watch?v=k8YQjGDdQaM" class="btn-small btn-outline-small" target="_blank" rel="noopener">Watch video 🎥</a>
-              <a href="mailto:fernando@xolosramirez.com?subject=Interest in Nox Ramirez&body=Hello Fernando, I would like to receive information on how to reserve Nox Ramirez." class="btn-small btn-primary-small" onclick="dataLayer.push({ event: 'click_email', cachorro: 'Nox Ramirez', source: 'available_xolos_contact_en' })">Contact via Email</a>
+              <a href="mailto:contacto@xolosarmy.xyz?subject=Interest in Nox Ramirez&body=Hello Fernando, I would like to receive information on how to reserve Nox Ramirez." class="btn-small btn-primary-small" onclick="dataLayer.push({ event: 'click_email', cachorro: 'Nox Ramirez', source: 'available_xolos_contact_en' })">Contact via Email</a>
             </div>
           </div>
         </article>
@@ -241,7 +241,7 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
             </ul>
             <div class="puppy-card__actions">
               <a href="https://www.youtube.com/watch?v=dWwc4FRzI8g" class="btn-small btn-outline-small" target="_blank" rel="noopener">Watch video 🎥</a>
-              <a href="mailto:fernando@xolosramirez.com?subject=Interest in Teyolia Ramirez&body=Hello Fernando, I would like to receive information on how to reserve Teyolia Ramirez." class="btn-small btn-primary-small" onclick="dataLayer.push({ event: 'click_email', cachorro: 'Teyolia Ramirez', source: 'available_xolos_contact_en' })">Contact via Email</a>
+              <a href="mailto:contacto@xolosarmy.xyz?subject=Interest in Teyolia Ramirez&body=Hello Fernando, I would like to receive information on how to reserve Teyolia Ramirez." class="btn-small btn-primary-small" onclick="dataLayer.push({ event: 'click_email', cachorro: 'Teyolia Ramirez', source: 'available_xolos_contact_en' })">Contact via Email</a>
             </div>
           </div>
         </article>
@@ -272,7 +272,7 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
 
   <a
     class="email-float"
-    href="mailto:fernando@xolosramirez.com?subject=Inquiry about Available Xolos&body=Hello Fernando, I am visiting the Xolos Ramirez website from the US/Canada and would like more information on the available puppies."
+    href="mailto:contacto@xolosarmy.xyz?subject=Inquiry about Available Xolos&body=Hello Fernando, I am visiting the Xolos Ramirez website from the US/Canada and would like more information on the available puppies."
     data-gtm="email-floating-en"
     onclick="dataLayer.push({ event: 'click_email', cachorro: 'general', source: 'available_xolos_floating_en' })"
   >

--- a/en/contact.html
+++ b/en/contact.html
@@ -158,7 +158,7 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
           <article class="card" data-aos="zoom-in" data-aos-delay="250">
             <h3>Direct contact</h3>
             <p><strong>Phone:</strong> +52 55 18555993</p>
-            <p><strong>Email:</strong> fernando@xolosramirez.comz</p>
+            <p><strong>Email:</strong> contacto@xolosarmy.xyz</p>
           </article>
         </div>
       </section>

--- a/xolos-disponibles.html
+++ b/xolos-disponibles.html
@@ -235,7 +235,7 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
       </ul>
       <div class="puppy-card__actions">
         <a href="https://www.youtube.com/watch?v=mwlofFThWwA" class="btn-small btn-outline-small" target="_blank" rel="noopener">Ver video Personalidad Xolo 🎥</a>
-        <a href="mailto:fernando@xolosramirez.com?subject=Interés en Tonatiuh Ramirez&body=Hola, me gustaría recibir información para reservar a Tonatiuh Ramirez." class="btn-small btn-primary-small" onclick="dataLayer.push({ event: 'click_email', cachorro: 'Tonatiuh Ramirez', source: 'xolos_disponibles_contactar' })">Contactar por Email</a>
+        <a href="mailto:contacto@xolosarmy.xyz?subject=Interés en Tonatiuh Ramirez&body=Hola, me gustaría recibir información para reservar a Tonatiuh Ramirez." class="btn-small btn-primary-small" onclick="dataLayer.push({ event: 'click_email', cachorro: 'Tonatiuh Ramirez', source: 'xolos_disponibles_contactar' })">Contactar por Email</a>
       </div>
     </div>
   </article>
@@ -277,7 +277,7 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
       </ul>
       <div class="puppy-card__actions">
         <a href="https://youtube.com/shorts/V0Z_qj4GMsY" class="btn-small btn-outline-small" target="_blank" rel="noopener">Ver video Personalidad Xolo 🎥</a>
-        <a href="mailto:fernando@xolosramirez.com?subject=Interés en Ozomatli Ramirez&body=Hola, me gustaría recibir información para reservar a Ozomatli Ramirez." class="btn-small btn-primary-small" onclick="dataLayer.push({ event: 'click_email', cachorro: 'Ozomatli Ramirez', source: 'xolos_disponibles_contactar' })">Contactar por Email</a>
+        <a href="mailto:contacto@xolosarmy.xyz?subject=Interés en Ozomatli Ramirez&body=Hola, me gustaría recibir información para reservar a Ozomatli Ramirez." class="btn-small btn-primary-small" onclick="dataLayer.push({ event: 'click_email', cachorro: 'Ozomatli Ramirez', source: 'xolos_disponibles_contactar' })">Contactar por Email</a>
       </div>
     </div>
   </article>
@@ -324,7 +324,7 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
       </ul>
       <div class="puppy-card__actions">
         <a href="https://youtube.com/shorts/V0Z_qj4GMsY" class="btn-small btn-outline-small" target="_blank" rel="noopener">Ver video Personalidad Xolo 🎥</a>
-        <a href="mailto:fernando@xolosramirez.com?subject=Interés en Nox Ramirez&body=Hola, me gustaría recibir información para reservar a Nox Ramirez." class="btn-small btn-primary-small" onclick="dataLayer.push({ event: 'click_email', cachorro: 'Nox Ramirez', source: 'xolos_disponibles_contactar' })">Contactar por Email</a>
+        <a href="mailto:contacto@xolosarmy.xyz?subject=Interés en Nox Ramirez&body=Hola, me gustaría recibir información para reservar a Nox Ramirez." class="btn-small btn-primary-small" onclick="dataLayer.push({ event: 'click_email', cachorro: 'Nox Ramirez', source: 'xolos_disponibles_contactar' })">Contactar por Email</a>
       </div>
     </div>
   </article>
@@ -368,7 +368,7 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
       </ul>
       <div class="puppy-card__actions">
         <a href="https://www.youtube.com/shorts/cAfWi5e2Xx8" class="btn-small btn-outline-small" target="_blank" rel="noopener">Ver video Personalidad Xolo 🎥</a>
-        <a href="mailto:fernando@xolosramirez.com?subject=Interés en Teyolia Ramirez&body=Hola, me gustaría recibir información para reservar a Teyolia Ramirez." class="btn-small btn-primary-small" onclick="dataLayer.push({ event: 'click_email', cachorro: 'Teyolia Ramirez', source: 'xolos_disponibles_contactar' })">Contactar por Email</a>
+        <a href="mailto:contacto@xolosarmy.xyz?subject=Interés en Teyolia Ramirez&body=Hola, me gustaría recibir información para reservar a Teyolia Ramirez." class="btn-small btn-primary-small" onclick="dataLayer.push({ event: 'click_email', cachorro: 'Teyolia Ramirez', source: 'xolos_disponibles_contactar' })">Contactar por Email</a>
       </div>
     </div>
   </article>


### PR DESCRIPTION
### Motivation
- Centralizar la dirección de contacto reemplazando `fernando@xolosramirez.com` (y la variante con typo `fernando@xolosramirez.comz`) por `contacto@xolosarmy.xyz` en las páginas principales del sitio. 
- Evitar enlaces `mailto:` rotos o información visible incorrecta en las versiones en español e inglés de las páginas de contacto y disponibilidad. 

### Description
- Reemplacé la dirección en la sección “Contacto directo” de `contacto.html` por `contacto@xolosarmy.xyz`. 
- Corregí el typo y actualicé el correo en `en/contact.html` a `contacto@xolosarmy.xyz`. 
- Actualicé todos los enlaces `mailto:` de los botones de contacto por ejemplar en `xolos-disponibles.html` y en `en/available-xolos.html` para usar `contacto@xolosarmy.xyz`. 
- Actualicé el botón flotante de correo en `en/available-xolos.html` y verifiqué que `index.html` ya tenía la dirección correcta por lo que no requirió cambio. 

### Testing
- Local búsqueda con `rg` se usó para localizar ocurrencias antes y después de la modificación y confirmar los objetivos de reemplazo. 
- Ejecuté un script de reemplazo en Python y luego una comprobación con otro snippet Python que aserta que `fernando@xolosramirez.com` y `fernando@xolosramirez.comz` no aparecen ya en `index.html`, `contacto.html`, `en/contact.html`, `xolos-disponibles.html` y `en/available-xolos.html`, y la verificación devolvió OK. 
- Confirmé el estado de cambios en el árbol de trabajo con `git status --short` para asegurar que los archivos esperados fueron modificados.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dff3f55c288332a2dbbb9ec5a888f7)