### PR TITLE
Add Teyolia MVP landing page with CSS, JS and implementation README

### DIFF
--- a/README_IMPLEMENTACION.md
+++ b/README_IMPLEMENTACION.md
@@ -1,0 +1,117 @@
+# README_IMPLEMENTACION.md
+
+## MVP Teyolia · Landing de Guardianía Xoloitzcuintle
+
+Esta implementación está diseñada como página independiente (`teyolia.html`) con su propio CSS y JS para poder integrarse después al sitio principal sin contaminar estilos globales.
+
+## 1) Cómo cambiar meta y depósito
+Edita `teyolia.js` en `CONFIG.campaign`:
+
+- `goalXec`: meta total de la campaña (actual: `400000000`).
+- `depositXec`: depósito requerido para aspirantes (actual: `50000000`).
+- `deadline`: fecha de referencia del piloto.
+
+También puedes ajustar:
+- `campaign.budgetBreakdown` para desglose conceptual.
+- `campaign.pilotCode` para etiqueta de campaña.
+
+## 2) Cómo conectar Formspree
+En `teyolia.js` > `CONFIG.wallet`:
+
+- `formspreeStep1`: endpoint del Formspree para pre-postulación.
+- `formspreeStep2`: endpoint del Formspree para verificación de depósito.
+- ID configurado actualmente: `xbdzegwj` (`https://formspree.io/f/xbdzegwj`).
+
+En `teyolia.html`, ambos formularios incluyen:
+- `_subject`
+- `_language=es`
+
+### Recomendación
+Usar dos endpoints (uno por paso) para separar claramente pre-postulación y verificación de depósito. Si prefieres uno solo, agrega un hidden tipo `etapa` y reutiliza `setupFormSubmission`.
+
+## 3) Cómo reemplazar imágenes
+En `teyolia.js` > `CONFIG.puppy.imageUrl` reemplaza el placeholder.
+
+También puedes cambiar directamente el `src` inicial en `teyolia.html` si deseas fallback estático sin JS.
+
+## 4) Cómo conectar backend de verificación
+La validación de TXID y dirección en frontend es **soft**. Para verificación real:
+
+- Implementar `POST /api/verify-xec-tx` para validar:
+  - existencia del TX,
+  - monto,
+  - dirección destino,
+  - confirmaciones,
+  - OP_RETURN (cuando aplique).
+
+Además:
+- `GET /api/support-feed` para alimentar apoyos comunitarios.
+- `GET /api/applicant-status` para actualizar bandas de validación.
+- `POST /api/nft-eligibility` o `GET /api/nft-eligibility` para snapshot de elegibilidad NFT.
+
+## 5) Cómo activar analytics (opcional)
+En `setupFormSubmission`, ya hay un hook comentado:
+
+```js
+// window.dispatchEvent(new CustomEvent('teyolia_form_success', { detail: { formId } }));
+```
+
+Puedes conectarlo a:
+- GA4 (eventos custom)
+- Segment
+- PostHog
+- DataLayer propio
+
+Mantener eventos mínimos:
+- `teyolia_cta_click`
+- `teyolia_form_step1_submit`
+- `teyolia_form_step2_submit`
+- `teyolia_copy_address`
+- `teyolia_txid_validate`
+
+## 6) Comparativa de modelos de campaña
+
+| Modelo | Ventajas | Riesgos | Complejidad operativa | Encaje para piloto |
+|---|---|---|---|---|
+| A) Aportaciones irrevocables | Simple de ejecutar, caja inmediata | Percepción dura para aspirantes no idóneos, fricción reputacional | Baja | Media |
+| B) Aportación comunitaria + depósito con opciones de devolución/saldo | Balance entre seriedad y confianza, mejor narrativa de cuidado | Requiere reglas claras, conciliación y trazabilidad rigurosa | Media | **Alta (recomendada)** |
+| C) Reserva competitiva curada | Alta señal de compromiso económico | Riesgo de parecer mercado competitivo, contradicción de tono ceremonial | Media/Alta | Baja |
+
+### Recomendación para el piloto
+**Modelo B**. Conserva el principio de responsabilidad, evita estética de competencia y permite una ruta ética para aspirantes no confirmados, siempre que las reglas de tratamiento de depósitos se publiquen con precisión legal.
+
+## 7) Cronograma MVP (Mermaid)
+
+```mermaid
+gantt
+  title Cronograma MVP Teyolia (referencial)
+  dateFormat  YYYY-MM-DD
+  section Diseño y copy
+  UX/UI ceremonial + revisión de tono      :done, a1, 2026-04-18, 5d
+  section Desarrollo
+  Integración frontend estática             :active, a2, 2026-04-23, 4d
+  Integración Formspree + QA accesibilidad :a3, 2026-04-27, 3d
+  section Validación
+  Revisión legal preliminar                 :a4, 2026-04-30, 4d
+  Pruebas piloto cerradas                   :a5, 2026-05-04, 5d
+  section Lanzamiento
+  Publicación MVP                           :milestone, a6, 2026-05-10, 1d
+```
+
+## 8) Legal / jurisdiction flags para revisión con asesoría
+- Definir jurisdicción aplicable (actualmente placeholder, no afirmación final).
+- Definir tratamiento exacto de depósitos (devolución, saldo, plazos y condiciones).
+- Definir política AML/KYC proporcional al riesgo de operación.
+- Definir retención de datos personales por categoría y finalidad.
+- Definir consentimiento para comunicaciones de seguimiento.
+- Definir límites de responsabilidad y términos de campaña.
+- Validar redacción pública para evitar interpretación como subasta, rifa o promesa automática.
+- Alinear aviso de privacidad integral con legislación aplicable.
+
+## 9) Checklist rápido antes de lanzar
+- [ ] Confirmar que `sampleAddress` apunte al enlace oficial de campaña con dirección XEC vigente.
+- [ ] Configurar endpoints reales de Formspree.
+- [ ] Publicar aviso integral de privacidad y URL final.
+- [ ] Confirmar copy legal sobre depósitos.
+- [ ] Conectar backend de verificación de TX.
+- [ ] Sustituir imagen placeholder por foto oficial del cachorro.

--- a/teyolia.css
+++ b/teyolia.css
@@ -1,0 +1,488 @@
+:root {
+  --bg: #0e0d0b;
+  --surface: #171513;
+  --surface-2: #201d1a;
+  --text: #f7f3eb;
+  --muted: #cfbea0;
+  --accent: #c49a63;
+  --accent-strong: #e2b173;
+  --ok: #84d4a4;
+  --warn: #e9c47a;
+  --danger: #f28b82;
+  --focus: #9dd9ff;
+  --border: #3a322b;
+  --radius: 14px;
+  --shadow: 0 10px 30px rgba(0, 0, 0, 0.35);
+  --font-heading: "Cormorant Garamond", "Times New Roman", serif;
+  --font-body: Inter, "Segoe UI", Roboto, Arial, sans-serif;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+html,
+body {
+  margin: 0;
+  padding: 0;
+  background: radial-gradient(circle at top, #1b1713 0%, var(--bg) 55%);
+  color: var(--text);
+  font-family: var(--font-body);
+  line-height: 1.55;
+}
+
+a {
+  color: var(--accent-strong);
+}
+
+a:focus-visible,
+button:focus-visible,
+input:focus-visible,
+textarea:focus-visible,
+summary:focus-visible {
+  outline: 3px solid var(--focus);
+  outline-offset: 3px;
+}
+
+.skip-link {
+  position: absolute;
+  left: -9999px;
+  top: 1rem;
+  background: #fff;
+  color: #111;
+  padding: 0.65rem 0.85rem;
+  border-radius: 10px;
+  z-index: 1000;
+}
+
+.skip-link:focus {
+  left: 1rem;
+}
+
+.container {
+  width: min(1120px, calc(100% - 2rem));
+  margin: 0 auto;
+}
+
+.narrow {
+  width: min(800px, calc(100% - 2rem));
+}
+
+.site-header,
+.site-footer {
+  border-bottom: 1px solid var(--border);
+  background: rgba(10, 9, 8, 0.7);
+  backdrop-filter: blur(8px);
+}
+
+.site-footer {
+  border-top: 1px solid var(--border);
+  border-bottom: none;
+  margin-top: 2rem;
+}
+
+.header-inner {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 0.9rem 0;
+}
+
+.brand {
+  margin: 0;
+  color: var(--muted);
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  font-size: 0.86rem;
+}
+
+.section {
+  padding: 3.5rem 0;
+}
+
+h1,
+h2,
+h3 {
+  margin-top: 0;
+  font-family: var(--font-heading);
+  letter-spacing: 0.01em;
+}
+
+h1 {
+  font-size: clamp(2rem, 4vw, 3.8rem);
+  margin-bottom: 0.75rem;
+}
+
+h2 {
+  font-size: clamp(1.55rem, 3vw, 2.45rem);
+}
+
+h3 {
+  font-size: clamp(1.25rem, 2vw, 1.7rem);
+}
+
+.eyebrow {
+  color: var(--accent-strong);
+  font-size: 0.92rem;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+}
+
+.hero-grid {
+  display: grid;
+  gap: 1.25rem;
+}
+
+.hero-media img {
+  width: 100%;
+  height: auto;
+  border-radius: var(--radius);
+  border: 1px solid var(--border);
+}
+
+.hero-media figcaption {
+  color: var(--muted);
+  font-size: 0.9rem;
+  margin-top: 0.55rem;
+}
+
+.hero-state {
+  background: linear-gradient(180deg, #1e1914, #15120f);
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  padding: 1rem;
+}
+
+.hero-note {
+  color: var(--accent-strong);
+  font-weight: 600;
+}
+
+.hero-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.7rem;
+  margin-top: 1rem;
+}
+
+.btn {
+  border: 1px solid transparent;
+  border-radius: 12px;
+  padding: 0.75rem 1rem;
+  font-weight: 600;
+  min-height: 44px;
+  min-width: 44px;
+  cursor: pointer;
+  text-decoration: none;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  transition: transform 180ms ease, opacity 180ms ease, background-color 180ms ease;
+}
+
+.btn:hover {
+  transform: translateY(-1px);
+}
+
+.btn:disabled {
+  cursor: not-allowed;
+  opacity: 0.6;
+  transform: none;
+}
+
+.btn-primary {
+  background: linear-gradient(120deg, #ad8450, var(--accent-strong));
+  color: #140f0a;
+}
+
+.btn-secondary {
+  background: transparent;
+  border-color: var(--accent);
+  color: var(--accent-strong);
+}
+
+.text-link {
+  color: var(--muted);
+}
+
+.card {
+  background: linear-gradient(180deg, var(--surface), var(--surface-2));
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  padding: 1rem;
+  box-shadow: var(--shadow);
+}
+
+.info-grid dl {
+  margin: 0;
+  display: grid;
+  gap: 0.65rem;
+}
+
+.info-grid dt {
+  color: var(--muted);
+  font-size: 0.95rem;
+}
+
+.info-grid dd {
+  margin: 0.2rem 0 0;
+  font-weight: 600;
+}
+
+.budget-list {
+  margin: 0;
+  padding-left: 1.1rem;
+}
+
+.timeline {
+  list-style: none;
+  padding: 0;
+  margin: 1rem 0 0;
+  display: grid;
+  gap: 0.8rem;
+}
+
+.timeline li {
+  border-left: 3px solid var(--accent);
+  padding: 0.8rem 0.8rem 0.8rem 1rem;
+  background: rgba(255, 255, 255, 0.02);
+  border-radius: 0 10px 10px 0;
+}
+
+.note-banner {
+  margin-top: 1rem;
+  color: var(--accent-strong);
+}
+
+.legend {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+  margin-bottom: 0.5rem;
+}
+
+.badge {
+  display: inline-block;
+  padding: 0.2rem 0.65rem;
+  border-radius: 999px;
+  border: 1px solid transparent;
+  font-size: 0.88rem;
+}
+
+.prioridad-alta {
+  background: rgba(132, 212, 164, 0.12);
+  border-color: rgba(132, 212, 164, 0.4);
+  color: #acf0c3;
+}
+
+.prioridad-media {
+  background: rgba(233, 196, 122, 0.12);
+  border-color: rgba(233, 196, 122, 0.4);
+  color: #f5d597;
+}
+
+.activa {
+  background: rgba(157, 217, 255, 0.11);
+  border-color: rgba(157, 217, 255, 0.38);
+  color: #bae6ff;
+}
+
+.aspirants-grid {
+  display: grid;
+  gap: 1rem;
+}
+
+.aspirant-card h3 {
+  margin-bottom: 0.4rem;
+}
+
+.status-row {
+  display: flex;
+  gap: 0.45rem;
+  align-items: center;
+  flex-wrap: wrap;
+}
+
+.deposit-ok {
+  color: var(--ok);
+}
+
+.deposit-pending {
+  color: var(--warn);
+}
+
+.copy-boxes {
+  display: grid;
+  gap: 0.7rem;
+}
+
+.copy-box {
+  border: 1px dashed var(--accent);
+  border-radius: 10px;
+  padding: 0.85rem;
+  background: rgba(255, 255, 255, 0.02);
+}
+
+.copy-box code {
+  display: block;
+  margin-bottom: 0.55rem;
+  word-break: break-all;
+}
+
+.wallet-grid {
+  display: grid;
+  gap: 1rem;
+}
+
+.wallet-address {
+  background: #0c0b09;
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  padding: 0.7rem;
+  font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+  overflow-wrap: anywhere;
+}
+
+.qr-placeholder {
+  margin-top: 0.8rem;
+  width: min(220px, 100%);
+  aspect-ratio: 1;
+  border: 1px dashed var(--accent);
+  border-radius: 12px;
+  display: grid;
+  place-content: center;
+  color: var(--muted);
+}
+
+.form-grid {
+  display: grid;
+  gap: 0.8rem;
+}
+
+.form-group {
+  display: grid;
+  gap: 0.35rem;
+}
+
+label {
+  font-weight: 600;
+}
+
+input,
+textarea {
+  width: 100%;
+  border: 1px solid #5a4d3f;
+  border-radius: 10px;
+  padding: 0.7rem;
+  background: #13110e;
+  color: var(--text);
+}
+
+input[aria-invalid="true"],
+textarea[aria-invalid="true"] {
+  border-color: var(--danger);
+}
+
+.error {
+  margin: 0;
+  color: var(--danger);
+  min-height: 1.2em;
+}
+
+.feedback {
+  min-height: 1.3em;
+  color: var(--accent-strong);
+}
+
+.check-group {
+  display: grid;
+  gap: 0.6rem;
+  margin: 0.9rem 0;
+}
+
+.check-group label {
+  display: flex;
+  align-items: flex-start;
+  gap: 0.6rem;
+  font-weight: 500;
+}
+
+.steps {
+  display: flex;
+  gap: 0.5rem;
+  margin-bottom: 1rem;
+  flex-wrap: wrap;
+}
+
+.step-tab {
+  border: 1px solid var(--border);
+  background: transparent;
+  color: var(--muted);
+  border-radius: 999px;
+  padding: 0.5rem 0.9rem;
+}
+
+.step-tab.active {
+  border-color: var(--accent);
+  color: var(--accent-strong);
+}
+
+.rules-list {
+  padding-left: 1.2rem;
+  display: grid;
+  gap: 0.4rem;
+}
+
+.accordion details {
+  border: 1px solid var(--border);
+  border-radius: 10px;
+  padding: 0.8rem;
+  margin-bottom: 0.65rem;
+  background: rgba(255, 255, 255, 0.02);
+}
+
+.accordion summary {
+  cursor: pointer;
+  font-weight: 700;
+}
+
+.muted {
+  color: var(--muted);
+}
+
+.small {
+  font-size: 0.9rem;
+}
+
+@media (min-width: 860px) {
+  .hero-grid {
+    grid-template-columns: 1.1fr 0.9fr;
+    align-items: center;
+  }
+
+  .wallet-grid {
+    grid-template-columns: 1fr 1fr;
+  }
+
+  .aspirants-grid {
+    grid-template-columns: repeat(3, minmax(0, 1fr));
+  }
+
+  .form-grid {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+
+  .form-group:has(textarea) {
+    grid-column: span 2;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  *,
+  *::before,
+  *::after {
+    animation: none !important;
+    transition: none !important;
+    scroll-behavior: auto !important;
+  }
+}

--- a/teyolia.html
+++ b/teyolia.html
@@ -1,0 +1,462 @@
+<!doctype html>
+<html lang="es">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Teyolia de Guardianía Xoloitzcuintle | Xolos Ramírez</title>
+    <meta
+      name="description"
+      content="Piloto de guardianía Xoloitzcuintle: validación comunitaria y confirmación final por Xolos Ramírez."
+    />
+    <link rel="stylesheet" href="teyolia.css" />
+  </head>
+  <body>
+    <a class="skip-link" href="#contenido-principal">Saltar al contenido principal</a>
+
+    <header class="site-header" aria-label="Encabezado de la campaña Teyolia">
+      <div class="container header-inner">
+        <p class="brand">Xolos Ramírez · Teyolia</p>
+        <a class="text-link" href="#reglas-base">Reglas base</a>
+      </div>
+    </header>
+
+    <main id="contenido-principal">
+      <section class="hero section" aria-labelledby="hero-titulo">
+        <div class="container hero-grid">
+          <div class="hero-copy">
+            <p class="eyebrow">Piloto activo · Guardianía curada de un solo cachorro</p>
+            <h1 id="hero-titulo" data-field="puppyName">Teyolia del Linaje: Atemoztli Ramírez</h1>
+            <p class="hero-subtitle">
+              Una convocatoria ceremonial de guardianía responsable. No es subasta, rifa ni remate.
+              La comunidad valida y Xolos Ramírez confirma.
+            </p>
+
+            <div class="hero-state" role="status" aria-live="polite">
+              <p><strong>Estado del piloto:</strong> Postulaciones abiertas con validación comunitaria activa.</p>
+              <p>
+                <strong>Meta pública:</strong>
+                <span data-field="goalXecText">400,000,000 XEC</span>
+                ·
+                <strong>Depósito de aspirante:</strong>
+                <span data-field="depositXecText">50,000,000 XEC</span>
+              </p>
+              <p class="hero-note">La aportación da prioridad de consideración, no asignación automática.</p>
+            </div>
+
+            <div class="hero-actions">
+              <a class="btn btn-primary" href="#postulacion">Iniciar postulación</a>
+              <a class="btn btn-secondary" href="#reglas-base">Ver reglas de guardianía</a>
+            </div>
+          </div>
+
+          <figure class="hero-media">
+            <img
+              src="https://placehold.co/900x1100/121212/C6A56B?text=Imagen+principal+del+cachorro"
+              alt="Placeholder de la imagen principal del cachorro del piloto Teyolia"
+              id="puppy-image"
+            />
+            <figcaption>
+              Imagen referencial del cachorro piloto. Reemplazar por fotografía oficial antes del lanzamiento.
+            </figcaption>
+          </figure>
+        </div>
+      </section>
+
+      <section class="section manifesto" aria-labelledby="manifiesto-titulo">
+        <div class="container narrow">
+          <h2 id="manifiesto-titulo">Manifiesto de guardianía</h2>
+          <p>
+            Esta Teyolia no funciona como subasta ni como dinámica de competencia económica. Es un proceso
+            de cuidado colectivo donde la comunidad sostiene, acompaña y valida señales de seriedad.
+          </p>
+          <p>
+            Las aportaciones de aspirantes generan prioridad de consideración. La asignación final depende
+            de evaluación humana integral por Xolos Ramírez: entorno, compromiso, experiencia, tiempo,
+            trazabilidad y afinidad con la responsabilidad del linaje.
+          </p>
+          <p>
+            Si no se identifican aspirantes idóneos, la campaña puede declararse desierta para proteger el
+            bienestar del cachorro y la integridad cultural del proyecto.
+          </p>
+          <blockquote>
+            “La comunidad valida y Xolos Ramírez confirma.”
+          </blockquote>
+        </div>
+      </section>
+
+      <section class="section" aria-labelledby="ficha-titulo">
+        <div class="container">
+          <h2 id="ficha-titulo">Ficha del cachorro</h2>
+          <div class="card info-grid">
+            <dl>
+              <div>
+                <dt>Nombre</dt>
+                <dd data-field="puppyName">Atemoztli Ramírez</dd>
+              </div>
+              <div>
+                <dt>Talla</dt>
+                <dd data-field="puppySize">Miniatura</dd>
+              </div>
+              <div>
+                <dt>Color</dt>
+                <dd data-field="puppyColor">Negro obsidiana</dd>
+              </div>
+              <div>
+                <dt>Fecha de nacimiento</dt>
+                <dd data-field="birthDate">2026-02-11</dd>
+              </div>
+              <div>
+                <dt>Vacunas / estado veterinario</dt>
+                <dd data-field="healthStatus">Esquema inicial al día · revisión integral favorable</dd>
+              </div>
+              <div>
+                <dt>Fecha estimada de entrega</dt>
+                <dd data-field="deliveryDate">2026-07-15 (estimada, sujeta a evaluación final)</dd>
+              </div>
+              <div>
+                <dt>Personalidad</dt>
+                <dd data-field="personality">Curioso, sereno y atento al vínculo humano</dd>
+              </div>
+              <div>
+                <dt>Historia de linaje</dt>
+                <dd data-field="lineageStory">
+                  Descendiente de línea registrada con foco en salud, temple y preservación cultural.
+                </dd>
+              </div>
+            </dl>
+          </div>
+
+          <div class="card budget-card" aria-labelledby="desglose-titulo">
+            <h3 id="desglose-titulo">Meta económica y desglose conceptual</h3>
+            <p class="muted">
+              Meta total de la campaña: <strong data-field="goalXecText">400,000,000 XEC</strong>
+            </p>
+            <ul class="budget-list" id="budget-list" aria-live="polite"></ul>
+          </div>
+        </div>
+      </section>
+
+      <section class="section" aria-labelledby="proceso-titulo">
+        <div class="container">
+          <h2 id="proceso-titulo">Cómo funciona</h2>
+          <ol class="timeline" id="how-it-works"></ol>
+          <p class="note-banner">
+            El depósito filtra seriedad, no compra el cachorro. La guardianía final emerge entre aspirantes idóneos.
+          </p>
+        </div>
+      </section>
+
+      <section class="section" aria-labelledby="validacion-titulo">
+        <div class="container">
+          <h2 id="validacion-titulo">Validación comunitaria (bandas referenciales)</h2>
+          <p>
+            Estas bandas de validación no son podio ni ranking competitivo. Son señales públicas de respaldo y
+            trazabilidad para acompañar la evaluación humana final.
+          </p>
+          <div class="legend">
+            <span class="badge prioridad-alta">Prioridad alta</span>
+            <span class="badge prioridad-media">Prioridad media</span>
+            <span class="badge activa">Activa</span>
+          </div>
+          <p class="muted">
+            La validación comunitaria respalda, no obliga. El estado es referencial y no garantiza asignación automática.
+          </p>
+          <div class="aspirants-grid" id="aspirants-grid" aria-live="polite"></div>
+        </div>
+      </section>
+
+      <section class="section" aria-labelledby="opreturn-titulo">
+        <div class="container narrow">
+          <h2 id="opreturn-titulo">Apoyo comunitario con OP_RETURN</h2>
+          <p>
+            Si deseas respaldar simbólicamente a un aspirante, puedes enviar una aportación comunitaria acompañada de
+            un mensaje OP_RETURN corto con nombre del aspirante y motivo. Esta estructura es una convención de campaña.
+          </p>
+          <p>
+            La compatibilidad del wallet puede variar. La verificación final del apoyo ocurre por sistema, backend y/o
+            revisión manual.
+          </p>
+
+          <div class="copy-boxes" id="opreturn-examples"></div>
+          <p class="muted">
+            Usa un mensaje corto, legible y consistente. Si tu wallet no soporta OP_RETURN, tu apoyo puede requerir
+            validación alternativa.
+          </p>
+        </div>
+      </section>
+
+      <section class="section" aria-labelledby="wallet-titulo">
+        <div class="container">
+          <h2 id="wallet-titulo">Pago y trazabilidad en XEC</h2>
+          <div class="wallet-grid">
+            <article class="card">
+              <h3>Enlace oficial del piloto (fuente de dirección XEC)</h3>
+              <p class="muted">
+                Verifica la dirección XEC vigente dentro de este enlace oficial antes de realizar cualquier envío.
+              </p>
+              <p id="wallet-address" class="wallet-address" data-field="sampleAddress">
+                https://www.teyolia.cash/campaigns/campaign-1776451063035
+              </p>
+              <button class="btn btn-secondary" id="copy-address" type="button">Copiar enlace</button>
+              <p class="feedback" id="copy-feedback" aria-live="polite"></p>
+              <div class="qr-placeholder" role="img" aria-label="Área para código QR de dirección XEC">
+                QR PLACEHOLDER
+              </div>
+              <p>
+                Conserva tu TXID para trazabilidad. Si necesitas trazabilidad personal, evita enviar desde exchange.
+              </p>
+              <p class="muted small">
+                Nota de política: esta advertencia debe ajustarse a la política final del proyecto antes del lanzamiento.
+              </p>
+            </article>
+
+            <article class="card">
+              <h3>Verificación rápida de datos</h3>
+              <form id="tx-verify-form" novalidate>
+                <div class="form-group">
+                  <label for="sender-address">Dirección remitente (opcional)</label>
+                  <input
+                    id="sender-address"
+                    name="senderAddress"
+                    type="text"
+                    autocomplete="off"
+                    placeholder="ecash:..."
+                  />
+                  <p id="sender-address-error" class="error" role="alert"></p>
+                </div>
+
+                <div class="form-group">
+                  <label for="txid-input">TXID del depósito</label>
+                  <input
+                    id="txid-input"
+                    name="txid"
+                    type="text"
+                    inputmode="latin"
+                    autocomplete="off"
+                    placeholder="64 caracteres hexadecimales"
+                    required
+                    aria-describedby="txid-help txid-error"
+                  />
+                  <p id="txid-help" class="small muted">Se normaliza automáticamente en minúsculas.</p>
+                  <p id="txid-error" class="error" role="alert"></p>
+                </div>
+
+                <button class="btn btn-primary" type="submit">Validar en navegador</button>
+                <p id="txid-feedback" class="feedback" aria-live="polite"></p>
+              </form>
+              <p class="small muted">
+                Validación soft en frontend. La validación definitiva debe hacerse en backend o vía Chronik/API.
+              </p>
+            </article>
+          </div>
+        </div>
+      </section>
+
+      <section class="section" id="postulacion" aria-labelledby="postulacion-titulo">
+        <div class="container">
+          <h2 id="postulacion-titulo">Postulación en 2 pasos</h2>
+          <p>
+            Paso 1 para pre-postulación y revisión inicial. Paso 2 para verificar depósito cuando ya fue realizado.
+          </p>
+
+          <div class="steps" role="tablist" aria-label="Flujo de postulación">
+            <button id="tab-step-1" class="step-tab active" type="button" role="tab" aria-selected="true" aria-controls="panel-step-1">
+              Paso 1 · Pre-postulación
+            </button>
+            <button id="tab-step-2" class="step-tab" type="button" role="tab" aria-selected="false" aria-controls="panel-step-2">
+              Paso 2 · Verificación de depósito
+            </button>
+          </div>
+
+          <section id="panel-step-1" role="tabpanel" aria-labelledby="tab-step-1">
+            <form
+              id="form-step-1"
+              class="card"
+              method="post"
+              action="https://formspree.io/f/xbdzegwj"
+              novalidate
+            >
+              <input type="hidden" name="_subject" value="Teyolia | Pre-postulación" />
+              <input type="hidden" name="_language" value="es" />
+
+              <div class="form-grid">
+                <div class="form-group">
+                  <label for="nombre">Nombre completo</label>
+                  <input id="nombre" name="nombre" type="text" required />
+                </div>
+                <div class="form-group">
+                  <label for="email">Correo electrónico</label>
+                  <input id="email" name="email" type="email" required />
+                </div>
+                <div class="form-group">
+                  <label for="telefono">Teléfono (opcional)</label>
+                  <input id="telefono" name="telefono" type="tel" />
+                </div>
+                <div class="form-group">
+                  <label for="ciudad-pais">Ciudad / País</label>
+                  <input id="ciudad-pais" name="ciudad_pais" type="text" required />
+                </div>
+                <div class="form-group">
+                  <label for="tipo-hogar">Tipo de hogar</label>
+                  <input id="tipo-hogar" name="tipo_hogar" type="text" required />
+                </div>
+                <div class="form-group">
+                  <label for="experiencia-raza">Experiencia con la raza</label>
+                  <textarea id="experiencia-raza" name="experiencia_raza" rows="3" required></textarea>
+                </div>
+                <div class="form-group">
+                  <label for="motivo-guardian">¿Por qué deseas ser guardián?</label>
+                  <textarea id="motivo-guardian" name="motivo_guardian" rows="4" required></textarea>
+                </div>
+                <div class="form-group">
+                  <label for="tiempo-disponible">Disponibilidad de tiempo</label>
+                  <textarea id="tiempo-disponible" name="tiempo_disponible" rows="3" required></textarea>
+                </div>
+              </div>
+
+              <div class="check-group">
+                <label>
+                  <input type="checkbox" name="acepta_reglas" required />
+                  Acepto reglas base de guardianía.
+                </label>
+                <label>
+                  <input type="checkbox" name="acepta_privacidad" required />
+                  Acepto aviso de privacidad y contacto de seguimiento.
+                </label>
+              </div>
+
+              <button class="btn btn-primary" type="submit" data-submit-label="Enviar pre-postulación">
+                Enviar pre-postulación
+              </button>
+              <p class="feedback" aria-live="polite" id="step1-feedback"></p>
+            </form>
+          </section>
+
+          <section id="panel-step-2" role="tabpanel" aria-labelledby="tab-step-2" hidden>
+            <form
+              id="form-step-2"
+              class="card"
+              method="post"
+              action="https://formspree.io/f/xbdzegwj"
+              novalidate
+            >
+              <input type="hidden" name="_subject" value="Teyolia | Verificación de depósito" />
+              <input type="hidden" name="_language" value="es" />
+
+              <div class="form-grid">
+                <div class="form-group">
+                  <label for="aspirante-nombre">Nombre del aspirante</label>
+                  <input id="aspirante-nombre" name="aspirante_nombre" type="text" required />
+                </div>
+                <div class="form-group">
+                  <label for="wallet-remitente">Wallet / dirección remitente (opcional)</label>
+                  <input id="wallet-remitente" name="wallet_remitente" type="text" placeholder="ecash:..." />
+                </div>
+                <div class="form-group">
+                  <label for="txid-form">TXID del depósito</label>
+                  <input id="txid-form" name="txid_deposito" type="text" minlength="64" maxlength="64" required />
+                </div>
+                <div class="form-group">
+                  <label for="monto-enviado">Monto enviado (XEC)</label>
+                  <input id="monto-enviado" name="monto_enviado" type="number" min="1" required />
+                </div>
+              </div>
+
+              <div class="check-group">
+                <label>
+                  <input type="checkbox" name="confirmacion_direccion" required />
+                  Confirmo que el depósito fue realizado a la dirección oficial del piloto.
+                </label>
+                <label>
+                  <input type="checkbox" name="entendimiento_prioridad" required />
+                  El depósito me da prioridad de consideración, no asignación automática.
+                </label>
+              </div>
+
+              <button class="btn btn-primary" type="submit" data-submit-label="Enviar verificación">
+                Enviar verificación
+              </button>
+              <p class="feedback" aria-live="polite" id="step2-feedback"></p>
+            </form>
+          </section>
+
+          <p class="small muted">
+            Implementación sugerida: usar dos formularios de Formspree (uno por paso) o un único endpoint con campo
+            hidden de etapa. Esta plantilla incluye ambos pasos separados para trazabilidad clara.
+          </p>
+        </div>
+      </section>
+
+      <section class="section" aria-labelledby="nft-titulo">
+        <div class="container narrow">
+          <h2 id="nft-titulo">Próximamente · Flujo conmemorativo NFT</h2>
+          <div class="card">
+            <p>
+              Después del cierre del piloto se propondrá un snapshot de participantes elegibles para reclamo de
+              NFT conmemorativo Teyolia.
+            </p>
+            <ul>
+              <li>Snapshot de elegibilidad (aportantes y/o aspirantes con verificación completa).</li>
+              <li>NFT conmemorativo del ciclo Teyolia.</li>
+              <li>Badge digital de participación validada.</li>
+              <li>Posible prioridad futura en campañas autorizadas.</li>
+            </ul>
+            <p class="muted" data-field="nftClaimNote">
+              Claim placeholder: sujeto a infraestructura posterior, política de elegibilidad y revisión legal.
+            </p>
+            <button class="btn btn-secondary" type="button" disabled>Claim NFT (Próximamente)</button>
+          </div>
+        </div>
+      </section>
+
+      <section class="section" id="reglas-base" aria-labelledby="reglas-titulo">
+        <div class="container">
+          <h2 id="reglas-titulo">Reglas base de la Teyolia</h2>
+          <ul class="rules-list">
+            <li>La Teyolia financia crianza, cuidado, registro, preparación y conservación cultural del linaje.</li>
+            <li>Cualquier persona puede aportar como comunidad de respaldo.</li>
+            <li>Las personas aspirantes deben registrarse y cumplir criterios de idoneidad definidos por Xolos Ramírez.</li>
+            <li>La aportación da prioridad de consideración, no asignación automática.</li>
+            <li>La decisión final corresponde a Xolos Ramírez tras evaluación humana integral.</li>
+            <li>Aportaciones y depósitos se tratarán según reglas publicadas y revisiones vigentes.</li>
+            <li>La campaña puede declararse desierta si no hay perfiles idóneos.</li>
+          </ul>
+        </div>
+      </section>
+
+      <section class="section" aria-labelledby="faq-titulo">
+        <div class="container narrow">
+          <h2 id="faq-titulo">FAQ de claridad anti-subasta</h2>
+          <div class="accordion" id="faq-accordion"></div>
+        </div>
+      </section>
+
+      <section class="section" aria-labelledby="privacidad-titulo">
+        <div class="container narrow">
+          <h2 id="privacidad-titulo">Privacidad y revisión legal</h2>
+          <div class="card">
+            <p>
+              Recabamos datos para gestionar postulaciones, validar trazabilidad y coordinar seguimiento de guardianía.
+              Responsable provisional: equipo de Xolos Ramírez.
+            </p>
+            <p>
+              Se publicará aviso integral de privacidad con finalidades, conservación y derechos de revisión. Retención,
+              tratamiento y jurisdicción final permanecen como marcadores sujetos a asesoría legal especializada.
+            </p>
+            <a class="text-link" href="#" aria-label="Placeholder para aviso integral de privacidad">
+              Ver aviso integral (placeholder)
+            </a>
+          </div>
+        </div>
+      </section>
+    </main>
+
+    <footer class="site-footer">
+      <div class="container">
+        <p>La comunidad valida y Xolos Ramírez confirma.</p>
+      </div>
+    </footer>
+
+    <script src="teyolia.js" defer></script>
+  </body>
+</html>

--- a/teyolia.js
+++ b/teyolia.js
@@ -1,0 +1,439 @@
+/**
+ * Landing Teyolia MVP
+ * Frontend sin dependencias. Ajustar configuración antes de producción.
+ * Hooks futuros de backend:
+ * - /api/verify-xec-tx
+ * - /api/support-feed
+ * - /api/applicant-status
+ * - /api/nft-eligibility
+ */
+
+const CONFIG = {
+  puppy: {
+    name: "Atemoztli Ramírez",
+    size: "Miniatura",
+    color: "Negro obsidiana",
+    birthDate: "2026-02-11",
+    healthStatus: "Esquema inicial al día · revisión integral favorable",
+    deliveryDate: "2026-07-15 (estimada, sujeta a evaluación final)",
+    personality: "Curioso, sereno y atento al vínculo humano",
+    lineageStory:
+      "Descendiente de línea registrada con foco en salud, temple y preservación cultural.",
+    imageUrl: "https://placehold.co/900x1100/121212/C6A56B?text=Imagen+principal+del+cachorro"
+  },
+  campaign: {
+    goalXec: 400000000,
+    depositXec: 50000000,
+    deadline: "2026-08-30", // Placeholder editable
+    pilotCode: "PILOTO-001",
+    budgetBreakdown: [
+      { label: "Crianza", amountXec: 90000000 },
+      { label: "Cuidados", amountXec: 60000000 },
+      { label: "Vacunas", amountXec: 35000000 },
+      { label: "Registro", amountXec: 30000000 },
+      { label: "Certificados", amountXec: 25000000 },
+      { label: "Logística", amountXec: 45000000 },
+      { label: "Conservación del linaje", amountXec: 70000000 },
+      { label: "Documentación cultural", amountXec: 45000000 }
+    ]
+  },
+  wallet: {
+    sampleAddress: "https://www.teyolia.cash/campaigns/campaign-1776451063035",
+    // Formspree endpoint activo (ID proporcionado: xbdzegwj)
+    // Nota: para el piloto actual se reutiliza el mismo endpoint en ambos pasos.
+    formspreeStep1: "https://formspree.io/f/xbdzegwj",
+    formspreeStep2: "https://formspree.io/f/xbdzegwj"
+  },
+  aspirants: [
+    {
+      name: "Andrea M.",
+      city: "Puebla, MX",
+      statusBand: "Prioridad alta",
+      depositStatus: "verificado",
+      supportCount: 38,
+      excerpt: "Perfil familiar estable y compromiso de acompañamiento veterinario continuo."
+    },
+    {
+      name: "Iker T.",
+      city: "Monterrey, MX",
+      statusBand: "Prioridad media",
+      depositStatus: "pendiente",
+      supportCount: 21,
+      excerpt: "Disponibilidad diaria alta y experiencia previa con razas de energía sensible."
+    },
+    {
+      name: "Rocío L.",
+      city: "Querétaro, MX",
+      statusBand: "Activa",
+      depositStatus: "verificado",
+      supportCount: 14,
+      excerpt: "Entorno tranquilo, enfoque en socialización temprana y bienestar sostenido."
+    }
+  ],
+  supportMessages: [
+    "TEYOLIA|PILOTO-001|ASP=andrea|POR=hogar_calmo",
+    "TGX|P1|ASP:andrea|WHY:cuidado_y_tiempo",
+    "TEYOLIA|ASP=andrea|POR=linaje_y_compromiso"
+  ],
+  nftPlaceholder: {
+    claimNote: "Claim placeholder: sujeto a infraestructura posterior, política de elegibilidad y revisión legal."
+  },
+  legalFlags: {
+    privacyNoticeUrl: "#",
+    jurisdictionStatus: "Pendiente de definición legal",
+    retentionPolicy: "Pendiente de revisión legal"
+  }
+};
+
+const FAQ_ITEMS = [
+  {
+    q: "¿Esto es una subasta?",
+    a: "No. Esta Teyolia es un proceso curado de guardianía. No hay remate, puja ni competencia de estilo mercado."
+  },
+  {
+    q: "¿La mayor aportación garantiza la asignación?",
+    a: "No. La aportación otorga prioridad de consideración, pero no define por sí sola la guardianía final."
+  },
+  {
+    q: "¿Qué pasa si un aspirante no es apto?",
+    a: "Se descarta su asignación potencial aunque tenga respaldo. El bienestar del cachorro y la idoneidad del hogar prevalecen."
+  },
+  {
+    q: "¿Qué pasa si ningún aspirante resulta idóneo?",
+    a: "La campaña puede declararse desierta. No hay selección forzada cuando no se cumplen criterios de guardianía."
+  },
+  {
+    q: "¿Qué pasa con mi depósito?",
+    a: "Se trata conforme a reglas publicadas del piloto. Las condiciones de devolución o saldo deberán informarse de forma explícita."
+  },
+  {
+    q: "¿Cómo funciona el apoyo comunitario?",
+    a: "La comunidad respalda con aportaciones y mensajes de trazabilidad. Ese respaldo orienta, pero no obliga la decisión final."
+  },
+  {
+    q: "¿El OP_RETURN es obligatorio?",
+    a: "Es recomendado para trazabilidad del apoyo comunitario. Si tu wallet no lo soporta, se puede requerir validación alternativa."
+  },
+  {
+    q: "¿Cómo se protege mi información?",
+    a: "La información se usa para evaluación y seguimiento. Se publicará aviso integral de privacidad con reglas formales de tratamiento."
+  },
+  {
+    q: "¿Cuándo se confirma el guardián final?",
+    a: "Tras cierre de validación comunitaria, revisión de documentación y evaluación humana final por Xolos Ramírez."
+  }
+];
+
+const HOW_IT_WORKS = [
+  "Presentación pública del cachorro del piloto.",
+  "Aportación comunitaria para sostener la Teyolia.",
+  "Depósito del aspirante para filtrar seriedad.",
+  "Validación comunitaria en bandas referenciales.",
+  "Evaluación final de idoneidad por Xolos Ramírez.",
+  "Cierre curado y confirmación de guardianía."
+];
+
+function formatXec(amount) {
+  return `${new Intl.NumberFormat("es-MX").format(amount)} XEC`;
+}
+
+function query(id) {
+  return document.getElementById(id);
+}
+
+function setTextByDataField(field, value) {
+  document.querySelectorAll(`[data-field="${field}"]`).forEach((node) => {
+    node.textContent = value;
+  });
+}
+
+function hydrateConfig() {
+  setTextByDataField("puppyName", CONFIG.puppy.name);
+  setTextByDataField("puppySize", CONFIG.puppy.size);
+  setTextByDataField("puppyColor", CONFIG.puppy.color);
+  setTextByDataField("birthDate", CONFIG.puppy.birthDate);
+  setTextByDataField("healthStatus", CONFIG.puppy.healthStatus);
+  setTextByDataField("deliveryDate", CONFIG.puppy.deliveryDate);
+  setTextByDataField("personality", CONFIG.puppy.personality);
+  setTextByDataField("lineageStory", CONFIG.puppy.lineageStory);
+  setTextByDataField("goalXecText", formatXec(CONFIG.campaign.goalXec));
+  setTextByDataField("depositXecText", formatXec(CONFIG.campaign.depositXec));
+  setTextByDataField("sampleAddress", CONFIG.wallet.sampleAddress);
+  setTextByDataField("nftClaimNote", CONFIG.nftPlaceholder.claimNote);
+
+  const image = query("puppy-image");
+  if (image) image.src = CONFIG.puppy.imageUrl;
+
+  const formStep1 = query("form-step-1");
+  const formStep2 = query("form-step-2");
+  if (formStep1) formStep1.action = CONFIG.wallet.formspreeStep1;
+  if (formStep2) formStep2.action = CONFIG.wallet.formspreeStep2;
+}
+
+function renderBudget() {
+  const list = query("budget-list");
+  if (!list) return;
+
+  list.innerHTML = "";
+  CONFIG.campaign.budgetBreakdown.forEach((item) => {
+    const li = document.createElement("li");
+    li.textContent = `${item.label}: ${formatXec(item.amountXec)}`;
+    list.appendChild(li);
+  });
+}
+
+function renderTimeline() {
+  const root = query("how-it-works");
+  if (!root) return;
+
+  root.innerHTML = "";
+  HOW_IT_WORKS.forEach((step, idx) => {
+    const li = document.createElement("li");
+    li.innerHTML = `<strong>Paso ${idx + 1}.</strong> ${step}`;
+    root.appendChild(li);
+  });
+}
+
+function badgeClassByStatus(status) {
+  if (status === "Prioridad alta") return "prioridad-alta";
+  if (status === "Prioridad media") return "prioridad-media";
+  return "activa";
+}
+
+function renderAspirants() {
+  const grid = query("aspirants-grid");
+  if (!grid) return;
+
+  grid.innerHTML = "";
+  CONFIG.aspirants.forEach((aspirant) => {
+    const article = document.createElement("article");
+    article.className = "card aspirant-card";
+
+    const depositClass = aspirant.depositStatus === "verificado" ? "deposit-ok" : "deposit-pending";
+    const depositText =
+      aspirant.depositStatus === "verificado" ? "Depósito verificado" : "Depósito pendiente";
+
+    article.innerHTML = `
+      <h3>${aspirant.name}</h3>
+      <p class="muted">${aspirant.city}</p>
+      <div class="status-row">
+        <span class="badge ${badgeClassByStatus(aspirant.statusBand)}">${aspirant.statusBand}</span>
+        <span class="${depositClass}">${depositText}</span>
+      </div>
+      <p>${aspirant.excerpt}</p>
+      <p class="small muted">Apoyos verificados: ${aspirant.supportCount}</p>
+    `;
+    grid.appendChild(article);
+  });
+}
+
+function renderOpReturnExamples() {
+  const root = query("opreturn-examples");
+  if (!root) return;
+
+  root.innerHTML = "";
+  CONFIG.supportMessages.forEach((text, index) => {
+    const box = document.createElement("div");
+    box.className = "copy-box";
+    box.innerHTML = `
+      <code id="op-msg-${index}">${text}</code>
+      <button type="button" class="btn btn-secondary" data-copy-text="${text}">Copiar ejemplo ${index + 1}</button>
+    `;
+    root.appendChild(box);
+  });
+}
+
+function renderFaq() {
+  const root = query("faq-accordion");
+  if (!root) return;
+
+  root.innerHTML = "";
+  FAQ_ITEMS.forEach((item) => {
+    const details = document.createElement("details");
+    details.innerHTML = `
+      <summary>${item.q}</summary>
+      <p>${item.a}</p>
+    `;
+    root.appendChild(details);
+  });
+}
+
+function attachCopyHandlers() {
+  document.addEventListener("click", async (event) => {
+    const target = event.target;
+    if (!(target instanceof HTMLElement)) return;
+
+    if (target.id === "copy-address") {
+      await copyText(CONFIG.wallet.sampleAddress, query("copy-feedback"));
+    }
+
+    if (target.matches("[data-copy-text]")) {
+      const txt = target.getAttribute("data-copy-text") || "";
+      await copyText(txt, query("copy-feedback"));
+    }
+  });
+}
+
+async function copyText(text, feedbackNode) {
+  if (!feedbackNode) return;
+  try {
+    await navigator.clipboard.writeText(text);
+    feedbackNode.textContent = "Copiado al portapapeles.";
+  } catch {
+    feedbackNode.textContent = "No fue posible copiar automáticamente. Copia manualmente el texto.";
+  }
+}
+
+function isValidTxid(value) {
+  return /^[a-f0-9]{64}$/i.test(value);
+}
+
+function isSoftValidEcashAddress(value) {
+  // Validación soft de UI. No reemplaza validación backend/Chronik.
+  return /^ecash:[a-z0-9]{20,}$/i.test(value.trim());
+}
+
+function setupTxValidation() {
+  const form = query("tx-verify-form");
+  if (!form) return;
+
+  form.addEventListener("submit", (event) => {
+    event.preventDefault();
+
+    const txidInput = query("txid-input");
+    const senderInput = query("sender-address");
+    const txidError = query("txid-error");
+    const senderError = query("sender-address-error");
+    const feedback = query("txid-feedback");
+
+    if (!txidInput || !txidError || !feedback || !senderInput || !senderError) return;
+
+    txidError.textContent = "";
+    senderError.textContent = "";
+
+    const txid = txidInput.value.trim().toLowerCase();
+    txidInput.value = txid;
+
+    let isValid = true;
+
+    if (!isValidTxid(txid)) {
+      txidError.textContent = "TXID inválido: usa exactamente 64 caracteres hexadecimales.";
+      txidInput.setAttribute("aria-invalid", "true");
+      isValid = false;
+    } else {
+      txidInput.setAttribute("aria-invalid", "false");
+    }
+
+    const senderAddress = senderInput.value.trim();
+    if (senderAddress && !isSoftValidEcashAddress(senderAddress)) {
+      senderError.textContent = "Dirección no válida en verificación básica. Debe iniciar con ecash:.";
+      senderInput.setAttribute("aria-invalid", "true");
+      isValid = false;
+    } else {
+      senderInput.setAttribute("aria-invalid", "false");
+    }
+
+    if (!isValid) {
+      feedback.textContent = "Corrige los campos marcados para continuar.";
+      return;
+    }
+
+    feedback.textContent = "Formato válido en navegador. Pendiente validación definitiva en backend.";
+
+    // Hook futuro (ejemplo):
+    // fetch('/api/verify-xec-tx', { method: 'POST', body: JSON.stringify({ txid, senderAddress }) })
+    //   .then(...)
+  });
+}
+
+function setupStepTabs() {
+  const tab1 = query("tab-step-1");
+  const tab2 = query("tab-step-2");
+  const panel1 = query("panel-step-1");
+  const panel2 = query("panel-step-2");
+  if (!tab1 || !tab2 || !panel1 || !panel2) return;
+
+  const activate = (step) => {
+    const isOne = step === 1;
+    tab1.classList.toggle("active", isOne);
+    tab2.classList.toggle("active", !isOne);
+    tab1.setAttribute("aria-selected", String(isOne));
+    tab2.setAttribute("aria-selected", String(!isOne));
+    panel1.hidden = !isOne;
+    panel2.hidden = isOne;
+  };
+
+  tab1.addEventListener("click", () => activate(1));
+  tab2.addEventListener("click", () => activate(2));
+}
+
+function setupFormSubmission(formId, feedbackId) {
+  const form = query(formId);
+  const feedback = query(feedbackId);
+  if (!form || !feedback) return;
+
+  form.addEventListener("submit", async (event) => {
+    event.preventDefault();
+
+    if (!form.checkValidity()) {
+      form.reportValidity();
+      feedback.textContent = "Completa los campos obligatorios antes de enviar.";
+      return;
+    }
+
+    const submitBtn = form.querySelector('button[type="submit"]');
+    const defaultLabel = submitBtn?.getAttribute("data-submit-label") || "Enviar";
+
+    if (submitBtn) {
+      submitBtn.disabled = true;
+      submitBtn.textContent = "Enviando...";
+    }
+    feedback.textContent = "Procesando envío...";
+
+    const formData = new FormData(form);
+
+    try {
+      const response = await fetch(form.action, {
+        method: "POST",
+        headers: { Accept: "application/json" },
+        body: formData
+      });
+
+      if (response.ok) {
+        feedback.textContent =
+          "Envío recibido. Gracias por participar en este proceso de guardianía responsable.";
+        form.reset();
+        // Hook opcional de analytics:
+        // window.dispatchEvent(new CustomEvent('teyolia_form_success', { detail: { formId } }));
+      } else {
+        feedback.textContent =
+          "No fue posible completar el envío en este momento. Intenta de nuevo o usa contacto directo.";
+      }
+    } catch {
+      feedback.textContent =
+        "Error de conexión. Como fallback, puedes enviar el formulario con envío tradicional al endpoint configurado.";
+      // Fallback opcional: form.submit(); // Descomentar si se prefiere fallback automático.
+    } finally {
+      if (submitBtn) {
+        submitBtn.disabled = false;
+        submitBtn.textContent = defaultLabel;
+      }
+    }
+  });
+}
+
+function init() {
+  hydrateConfig();
+  renderBudget();
+  renderTimeline();
+  renderAspirants();
+  renderOpReturnExamples();
+  renderFaq();
+  attachCopyHandlers();
+  setupTxValidation();
+  setupStepTabs();
+  setupFormSubmission("form-step-1", "step1-feedback");
+  setupFormSubmission("form-step-2", "step2-feedback");
+}
+
+document.addEventListener("DOMContentLoaded", init);


### PR DESCRIPTION
### Motivation
- Provide a standalone MVP landing for the Teyolia guardianía pilot so it can be integrated later without affecting global styles or scripts.
- Offer a configurable, accessible front-end for a two-step application flow, deposit verification and community support signals while keeping backend verification as a planned hook.
- Ship clear operational guidance, legal flags and a launch checklist to help run the pilot safely and reproducibly.

### Description
- Add `teyolia.html`, a self-contained accessible landing page that includes a hero, puppy profile, budget breakdown, how-it-works timeline, community OP_RETURN examples, two-step Formspree forms for pre-postulation and deposit verification, wallet display and FAQ/rules sections.
- Add `teyolia.css` with theme variables, component styles and responsive rules for the landing's layout and UI states.
- Add `teyolia.js` which exposes a `CONFIG` object, hydrates UI fields, renders dynamic lists (budget, timeline, aspirants, OP_RETURN examples, FAQ), provides client-side TXID and ecash address soft validation, copy-to-clipboard handlers, step tab logic and Formspree submission handling with simple feedback.
- Add `README_IMPLEMENTACION.md` documenting configuration points (goal, deposit, deadlines, Formspree endpoints), image replacement, recommended backend endpoints, campaign model comparison and a pre-launch checklist.

### Testing
- No automated tests were run as part of this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e2728ff9908332b99095d99f40c5ef)