### PR TITLE
Add Teyolia guardianía campaign pages and update site navigation/content

### DIFF
--- a/index.html
+++ b/index.html
@@ -214,17 +214,18 @@ Selección de Ejemplares de Calidad: Seleccionamos cuidadosamente a los perros q
 
       <section class="grid grid-2" data-aos="fade-up" data-aos-duration="1000" data-aos-delay="150">
         <article class="card" data-aos="zoom-in" data-aos-delay="200">
-          <h3>Actividades comunitarias</h3>
+          <h3>Teyolia de Guardianía</h3>
           <p>
-            Organizamos recorridos culturales, charlas con especialistas y
-            encuentros familiares donde los xolos son protagonistas.
+            Conoce nuestro piloto activo de <strong>validación comunitaria</strong> para la
+            campaña de Teyolia Ramírez y su subpágina dedicada.
           </p>
+          <a href="teyolias-guardiania.html">Explorar Teyolia y campañas activas</a>
           <p class="callout">
-            <a href="mailto:contacto@xolosarmy.xyz?subject=Suscripción al Boletín&body=Hola, me gustaría suscribirme a su lista de correos electrónicos para recibir noticias sobre los xolos." 
+            <a href="mailto:contacto@xolosarmy.xyz?subject=Suscripción al Boletín&body=Hola, me gustaría suscribirme a su lista de correos electrónicos para recibir noticias sobre pilotos Teyolia." 
                style="color: var(--accent-color); text-underline-offset: 4px;">
                Suscríbete al boletín por email
             </a> 
-            para recibir invitaciones y contenido exclusivo de la comunidad.
+            para recibir notificaciones sobre nuevas Teyolias.
           </p>
         </article>
         <article class="card" data-aos="zoom-in" data-aos-delay="300">

--- a/teyolia.html
+++ b/teyolia.html
@@ -24,8 +24,8 @@
       <section class="hero section" aria-labelledby="hero-titulo">
         <div class="container hero-grid">
           <div class="hero-copy">
-            <p class="eyebrow">Piloto activo · Guardianía curada de un solo cachorro</p>
-            <h1 id="hero-titulo" data-field="puppyName">Teyolia del Linaje: Atemoztli Ramírez</h1>
+            <p class="eyebrow">Piloto activo #001 · Guardianía validada on-chain</p>
+            <h1 id="hero-titulo" data-field="puppyName">Teyolia de Guardianía: Teyolia Ramírez</h1>
             <p class="hero-subtitle">
               Una convocatoria ceremonial de guardianía responsable. No es subasta, rifa ni remate.
               La comunidad valida y Xolos Ramírez confirma.
@@ -51,12 +51,13 @@
 
           <figure class="hero-media">
             <img
-              src="https://placehold.co/900x1100/121212/C6A56B?text=Imagen+principal+del+cachorro"
-              alt="Placeholder de la imagen principal del cachorro del piloto Teyolia"
+              src="https://i.imgur.com/IodKgs0.jpeg"
+              alt="Teyolia Ramírez, xoloitzcuintle miniatura color negro"
               id="puppy-image"
+              style="border-radius: 12px; box-shadow: 0 4px 20px rgba(0,0,0,0.15); width: 100%; object-fit: cover;"
             />
             <figcaption>
-              Imagen referencial del cachorro piloto. Reemplazar por fotografía oficial antes del lanzamiento.
+              Teyolia Ramírez, protagonista de nuestra primera campaña fundacional.
             </figcaption>
           </figure>
         </div>
@@ -79,7 +80,7 @@
             bienestar del cachorro y la integridad cultural del proyecto.
           </p>
           <blockquote>
-            “La comunidad valida y Xolos Ramírez confirma.”
+            “Teyolia no busca comprador. Busca guardián.”
           </blockquote>
         </div>
       </section>
@@ -91,7 +92,7 @@
             <dl>
               <div>
                 <dt>Nombre</dt>
-                <dd data-field="puppyName">Atemoztli Ramírez</dd>
+                <dd data-field="puppyName">Teyolia Ramírez</dd>
               </div>
               <div>
                 <dt>Talla</dt>
@@ -99,7 +100,7 @@
               </div>
               <div>
                 <dt>Color</dt>
-                <dd data-field="puppyColor">Negro obsidiana</dd>
+                <dd data-field="puppyColor">Negro sólido</dd>
               </div>
               <div>
                 <dt>Fecha de nacimiento</dt>
@@ -115,7 +116,7 @@
               </div>
               <div>
                 <dt>Personalidad</dt>
-                <dd data-field="personality">Curioso, sereno y atento al vínculo humano</dd>
+                <dd data-field="personality">Alerta, sumamente leal y de carácter firme</dd>
               </div>
               <div>
                 <dt>Historia de linaje</dt>
@@ -380,10 +381,6 @@
             </form>
           </section>
 
-          <p class="small muted">
-            Implementación sugerida: usar dos formularios de Formspree (uno por paso) o un único endpoint con campo
-            hidden de etapa. Esta plantilla incluye ambos pasos separados para trazabilidad clara.
-          </p>
         </div>
       </section>
 
@@ -443,9 +440,6 @@
               Se publicará aviso integral de privacidad con finalidades, conservación y derechos de revisión. Retención,
               tratamiento y jurisdicción final permanecen como marcadores sujetos a asesoría legal especializada.
             </p>
-            <a class="text-link" href="#" aria-label="Placeholder para aviso integral de privacidad">
-              Ver aviso integral (placeholder)
-            </a>
           </div>
         </div>
       </section>

--- a/teyolias-guardiania.html
+++ b/teyolias-guardiania.html
@@ -1,84 +1,40 @@
 <!DOCTYPE html>
 <html lang="es">
   <head>
-    <!-- Google Tag Manager -->
     <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
 new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
 j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
 'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
 })(window,document,'script','dataLayer','GTM-MGTMWN7T');</script>
-    <!-- End Google Tag Manager -->
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>Galería fotográfica de xoloitzcuintles | Xolos Ramirez</title>
+    <title>Teyolias de Guardianía y Galería | Xolos Ramirez</title>
     <meta
       name="description"
-      content="Explora la galería de Xolos Ramirez con fotografías en alta calidad de eventos, adopciones y artesanías inspiradas en el xoloitzcuintle."
+      content="El hogar de las campañas de guardianía Proof-of-Community de Xolos Ramírez y la galería histórica de nuestro linaje."
     />
-    <meta
-      name="keywords"
-      content="galería xoloitzcuintle, fotos xolo, eventos xolo, cultura mexicana, comunidad xolo"
-    />
-    <meta property="og:title" content="Galería fotográfica de xoloitzcuintles | Xolos Ramírez" />
-    <meta
-      property="og:description"
-      content="Explora la galería de Xolos Ramírez con fotografías en alta calidad de eventos, adopciones y artesanías inspiradas en el xoloitzcuintle."
-    />
-    <meta property="og:image" content="https://www.xolosramirez.com/img/hero/site-hero.jpg" />
-    <meta property="og:type" content="website" />
-    <meta name="twitter:card" content="summary_large_image" />
-    <meta name="twitter:title" content="Galería fotográfica de xoloitzcuintles | Xolos Ramírez" />
-    <meta
-      name="twitter:description"
-      content="Explora la galería de Xolos Ramírez con fotografías en alta calidad de eventos, adopciones y artesanías inspiradas en el xoloitzcuintle."
-    />
-    <meta name="twitter:image" content="https://www.xolosramirez.com/img/hero/site-hero.jpg" />
-    <link rel="alternate" hreflang="es" href="https://www.xolosramirez.com/galeria.html" />
-    <link rel="alternate" hreflang="en" href="https://www.xolosramirez.com/en/gallery.html" />
-    <link rel="alternate" hreflang="x-default" href="https://www.xolosramirez.com/index.html" />
-    <link rel="preconnect" href="https://fonts.googleapis.com" />
-    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
-    <link
-      href="https://fonts.googleapis.com/css2?family=Cinzel:wght@400;700&family=Poppins:wght@400;600&display=swap"
-      rel="stylesheet"
-    />
-    <link href="https://unpkg.com/aos@2.3.1/dist/aos.css" rel="stylesheet" />
     <link rel="stylesheet" href="css/styles.css" />
+    <link href="https://unpkg.com/aos@2.3.1/dist/aos.css" rel="stylesheet" />
     <link rel="icon" type="image/x-icon" href="assets/xolosramirez.ico" />
   </head>
   <body>
-    <!-- Google Tag Manager (noscript) -->
     <noscript>
-      <iframe
-        src="https://www.googletagmanager.com/ns.html?id=GTM-MGTMWN7T"
-        height="0"
-        width="0"
-        style="display: none; visibility: hidden"
-      ></iframe>
+      <iframe src="https://www.googletagmanager.com/ns.html?id=GTM-MGTMWN7T" height="0" width="0" style="display: none; visibility: hidden"></iframe>
     </noscript>
-    <!-- End Google Tag Manager (noscript) -->
     <a class="skip-link" href="#contenido-principal">Saltar al contenido principal</a>
+    
     <header class="site-header">
       <div class="container header-row">
         <a class="brand" href="index.html">
-          <img
-            src="img/brand/XolosRamirez.jpg"
-            alt="Xolos Ramírez"
-            width="44"
-            height="44"
-            loading="eager"
-            decoding="async"
-          />
+          <img src="img/brand/XolosRamirez.jpg" alt="Xolos Ramírez" width="44" height="44" loading="eager" />
           <span>Xolos Ramírez</span>
         </a>
-
         <button class="hamburger" aria-expanded="false" aria-controls="menu">☰</button>
-
         <nav id="menu" class="nav-menu" data-visible="false">
           <ul>
             <li><a href="index.html">Inicio</a></li>
             <li><a href="xolos-disponibles.html">Xolos disponibles</a></li>
-            <li><a href="galeria.html">Galería</a></li>
+            <li><a href="teyolias-guardiania.html" class="active">Teyolias</a></li>
             <li><a href="testimonios.html">Testimonios</a></li>
             <li><a href="blog/index.html">Blog</a></li>
             <li><a href="contacto.html">Contacto</a></li>
@@ -95,35 +51,35 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
             width="1600"
             height="900"
             loading="eager"
-            decoding="async"
             alt="Xoloitzcuintle socializando en el Criadero Xolos Ramirez"
           />
         </picture>
         <div class="container">
-          <h1>Xolos Ramirez</h1>
-          <p>Xoloitzcuintle socializando en el Criadero Xolos Ramirez</p>
-          <a
-            class="btn"
-            href="#adopciones"
-            data-gtm="cta-home"
-            onclick="dataLayer.push({ event: 'click_home_cta', label: 'hero_adopta_xolo' })"
-          >Adopta un Xolo</a>
+          <h1>Teyolias de Guardianía</h1>
+          <p>Mecanismos de validación comunitaria on-chain y archivo fotográfico del linaje.</p>
         </div>
       </section>
 
-      <section data-aos="fade-up" data-aos-duration="1000">
-        <h2>Momentos destacados</h2>
+      <section class="guardiania-hub" data-aos="fade-up" data-aos-duration="1000" style="padding: 4rem 1rem; background-color: var(--bg-color); text-align: center;">
+        <div class="container">
+          <h2>Campañas de Guardianía (Proof-of-Community)</h2>
+          <p style="max-width: 700px; margin: 0 auto 2rem;">Hemos evolucionado la forma en que nuestros ejemplares encuentran su hogar. Las Teyolias son nuestro mecanismo de validación donde la comunidad respalda a los aspirantes a guardianes de manera transparente.</p>
+          
+          <div class="card" style="margin: 0 auto; max-width: 800px; padding: 2.5rem; border: 2px solid var(--accent-color); background: var(--card-bg); text-align: center;">
+            <span style="color: var(--accent-color); font-weight: bold; text-transform: uppercase; font-size: 0.85rem; letter-spacing: 1px;">Piloto #001 Activo</span>
+            <h3 style="margin-top: 1rem;">La Teyolia para Teyolia Ramírez</h3>
+            <p>Conoce a Teyolia, postúlate como guardián oficial con tu depósito de compromiso o respalda on-chain a tu candidato favorito utilizando eCash (XEC).</p>
+            <a href="teyolia.html" class="btn btn-primary" style="margin-top: 1.5rem; display: inline-block;">Ver Campaña Activa</a>
+          </div>
+        </div>
+      </section>
+
+      <section data-aos="fade-up" data-aos-duration="1000" style="padding-top: 2rem;">
+        <h2>Archivo Histórico</h2>
         <div class="grid grid-2">
           <figure class="card" data-aos="zoom-in" data-aos-delay="150">
             <picture class="card__media">
-              <img
-                src="https://i.imgur.com/D3F0UxU.jpeg"
-                width="1200"
-                height="800"
-                loading="lazy"
-                decoding="async"
-                alt="Ceremonia por Día de Muertos en Grecia con Tecuani Ramirez"
-              />
+              <img src="https://i.imgur.com/D3F0UxU.jpeg" width="1200" height="800" loading="lazy" alt="Ceremonia por Día de Muertos en Grecia con Tecuani Ramirez" />
             </picture>
             <figcaption style="padding: 1rem; text-align: center; font-family: var(--font-secondary);">
               Ceremonia por Día de Muertos en Grecia con Tecuani Ramirez
@@ -131,14 +87,7 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
           </figure>
           <figure class="card" data-aos="zoom-in" data-aos-delay="250">
             <picture class="card__media">
-              <img
-                src="https://i.imgur.com/7O0FXNi.jpeg"
-                width="1200"
-                height="800"
-                loading="lazy"
-                decoding="async"
-                alt="Xoloitzcuintles Sesasi y Ameyalli Ramirez"
-              />
+              <img src="https://i.imgur.com/7O0FXNi.jpeg" width="1200" height="800" loading="lazy" alt="Xoloitzcuintles Sesasi y Ameyalli Ramirez" />
             </picture>
             <figcaption style="padding: 1rem; text-align: center; font-family: var(--font-secondary);">
               Xoloitzcuintles Sesasi y Ameyalli Ramirez quienes viven en Guadalajara
@@ -146,14 +95,7 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
           </figure>
           <figure class="card" data-aos="zoom-in" data-aos-delay="350">
             <picture class="card__media">
-              <img
-                src="https://i.imgur.com/fqKjMzU.jpeg"
-                width="1200"
-                height="800"
-                loading="lazy"
-                decoding="async"
-                alt="Entrega de Chimani Ramírez a Sarai en su nuevo hogar"
-              />
+              <img src="https://i.imgur.com/fqKjMzU.jpeg" width="1200" height="800" loading="lazy" alt="Entrega de Chimani Ramírez a Sarai en su nuevo hogar" />
             </picture>
             <figcaption style="padding: 1rem; text-align: center; font-family: var(--font-secondary);">
               Entrega del xoloitzcuintle Chimani Ramírez a Sarai, quien es bacterióloga y pintora
@@ -161,14 +103,7 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
           </figure>
           <figure class="card" data-aos="zoom-in" data-aos-delay="450">
             <picture class="card__media">
-              <img
-                src="https://i.imgur.com/zeXJpKO.jpeg"
-                width="1200"
-                height="800"
-                loading="lazy"
-                decoding="async"
-                alt="Xoloitzcuintle representado en el arte"
-              />
+              <img src="https://i.imgur.com/zeXJpKO.jpeg" width="1200" height="800" loading="lazy" alt="Xoloitzcuintle representado en el arte" />
             </picture>
             <figcaption style="padding: 1rem; text-align: center; font-family: var(--font-secondary);">
               Xolo en la Cultura y el Arte
@@ -198,6 +133,7 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
           <h4>Enlaces</h4>
           <ul>
             <li><a href="xolos-disponibles.html">Xolos disponibles</a></li>
+            <li><a href="teyolias-guardiania.html">Teyolias (Campaña Activa)</a></li>
             <li><a href="blog/index.html">Blog</a></li>
             <li><a href="contacto.html">Contacto</a></li>
           </ul>


### PR DESCRIPTION
### Motivation
- Introduce and promote a new community-validation campaign concept called “Teyolia de Guardianía” and surface the active pilot on the site. 
- Replace legacy gallery focus with a dedicated hub for guardianía campaigns and link the index to the new campaign page. 

### Description
- Updated `index.html` to rename a community card to "Teyolia de Guardianía", change its copy, update the mailto subscription text, and point the CTA to `teyolias-guardiania.html`. 
- Modified `teyolia.html` to rebrand the pilot (titles, hero copy, hero image, personality/color/name fields), adjust manifesto and milestone copy, remove a placeholder implementation note, and omit the privacy placeholder link. 
- Renamed `galeria.html` to `teyolias-guardiania.html` and refocused the page as a guardianía hub by changing metadata, hero text, navigation (activate `Teyolias` link), removing some commented GTM blocks, reworking the layout to include a campaign card linking to `teyolia.html`, and cleaning up image attributes and structure. 
- Added/adjusted stylesheet and AOS inclusion in the renamed page and updated footer/navigation links to reference the new guardianía page. 

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e2904ef3bc8332a63d2e2bb6ad7dda)