### PR TITLE
Añade tutorial explicativo de Teyolia en el hub principal

### DIFF
--- a/teyolias-guardiania.html
+++ b/teyolias-guardiania.html
@@ -74,6 +74,51 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
         </div>
       </section>
 
+      <section class="tutorial-teyolia" data-aos="fade-up" data-aos-duration="1000" style="padding: 4rem 1rem; background-color: var(--bg-color);">
+        <div class="container">
+          <h2 style="text-align: center; margin-bottom: 1rem;">¿Qué es una Teyolia de Guardianía?</h2>
+          <p style="text-align: center; max-width: 800px; margin: 0 auto 3rem; line-height: 1.6;">
+            En Xolos Ramírez no vendemos mascotas; consagramos guardianes. Una <strong>Teyolia de Guardianía</strong> es nuestro mecanismo pionero de <em>Proof-of-Community</em> (Prueba de Comunidad). Un proceso transparente, validado en la blockchain de eCash, diseñado para asegurar que cada ejemplar llegue a las manos correctas.
+          </p>
+
+          <div class="grid grid-2" style="gap: 2rem;">
+            <article class="card" style="border-left: 4px solid var(--accent-color);">
+              <h3 style="margin-top: 0;">1. El Principio Base</h3>
+              <p>
+                <strong>No es una subasta. No es una rifa.</strong> Aquí el mayor postor no compra al cachorro. El objetivo es eliminar la adopción por impulso y requerir una demostración de compromiso real, medible y avalado por tu entorno.
+              </p>
+            </article>
+
+            <article class="card" style="border-left: 4px solid var(--accent-color);">
+              <h3 style="margin-top: 0;">2. Postulación y Garantía</h3>
+              <p>
+                Los aspirantes serios llenan un formulario detallado. Si el perfil inicial es idóneo, Xolos Ramírez lo aprueba. Para oficializar su candidatura, el aspirante realiza un depósito de garantía (e.g., <strong>50M XEC</strong>) como prueba innegable de seriedad.
+              </p>
+            </article>
+
+            <article class="card" style="border-left: 4px solid var(--accent-color);">
+              <h3 style="margin-top: 0;">3. Respaldo On-Chain</h3>
+              <p>
+                Una vez oficializado, la comunidad del aspirante (familia, amigos, seguidores) envía apoyos en XEC adjuntando un mensaje inmutable (<code>OP_RETURN</code>) en la blockchain, dejando testimonio público de por qué esa persona será un gran guardián.
+              </p>
+            </article>
+
+            <article class="card" style="border-left: 4px solid var(--accent-color);">
+              <h3 style="margin-top: 0;">4. La Consagración</h3>
+              <p>
+                El aspirante con mayor validación comunitaria obtiene prioridad de consideración, pero <strong>la asignación nunca es automática</strong>. Xolos Ramírez realiza una revisión integral final humana y, si todo es correcto, formaliza la guardianía.
+              </p>
+            </article>
+          </div>
+
+          <div style="text-align: center; margin-top: 3.5rem;">
+            <p style="font-family: var(--font-secondary); font-style: italic; color: var(--accent-color); font-size: 1.2rem;">
+              "Teyolia no busca comprador. Busca guardián."
+            </p>
+          </div>
+        </div>
+      </section>
+
       <section data-aos="fade-up" data-aos-duration="1000" style="padding-top: 2rem;">
         <h2>Archivo Histórico</h2>
         <div class="grid grid-2">


### PR DESCRIPTION
### Motivation
- Incluir un tutorial breve en el Hub principal para explicar el concepto de "Teyolia de Guardianía" y su flujo de validación comunitaria on‑chain. 
- Mejorar la comunicación del proceso Proof‑of‑Community para reducir dudas y fricciones antes de la sección de galería histórica. 
- Reutilizar la misma estética y sistema de componentes del sitio para mantener coherencia visual.

### Description
- Se añadió una nueva sección `tutorial-teyolia` en `teyolias-guardiania.html` colocada justo después del bloque de campaña activa y antes del archivo histórico. 
- La sección contiene un título, un párrafo introductorio y cuatro tarjetas numeradas (`article.card`) que describen: `El Principio Base`, `Postulación y Garantía`, `Respaldo On-Chain` y `La Consagración`. 
- Se reutilizan las clases existentes (`container`, `grid`, `card`) y se aplican estilos inline mínimos (p. ej. `border-left: 4px solid var(--accent-color);`) para integrar el contenido con la estética actual. 
- Se añadió un cierre narrativo con el mantra de la campaña para reforzar el mensaje de la sección.

### Testing
- Se validó parsing HTML básico con `python` utilizando `html.parser`, y la comprobación devolvió `HTMLParser OK`. 
- Se intentó validar con `xmllint --html --noout`, pero la herramienta no está instalada en el entorno, por lo que esa validación falló.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e2a6f205b8833287adaa3fb6a4a85e)