### PR TITLE
Actualizar sección a “Registro de Aspirantes” en teyolias-guardiania.html

### DIFF
--- a/teyolias-guardiania.html
+++ b/teyolias-guardiania.html
@@ -158,13 +158,11 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
       </section>
 
       <section data-aos="fade-up" data-aos-duration="1000" data-aos-offset="120">
-        <h2>Eventos y talleres</h2>
+        <h2>Registro de Aspirantes</h2>
         <p>
-          Compartimos momentos de nuestras actividades mensuales: talleres de
-          cuidado dermatológico, caminatas históricas y convivencias familiares.
-          Cada evento fomenta la educación y el respeto por la raza.
+          Inicia tu proceso para convertirte en el guardián de un Xoloitzcuintle. Regístrate como aspirante y da el primer paso para participar en nuestra próxima Teyolia de Guardianía, demostrando tu compromiso real con la preservación de nuestro linaje.
         </p>
-        <a href="contacto.html">Solicitar calendario de eventos</a>
+        <a href="contacto.html" class="btn btn-primary">Registrarse como candidato</a>
       </section>
     </main>
 


### PR DESCRIPTION
### Motivation
- Cambiar el bloque informativo y el llamado a la acción para convertir la sección de "Eventos y talleres" en un invitación clara a registrarse como aspirante a guardián, orientando tráfico hacia la página de contacto.

### Description
- Reemplazado el contenido de la sección en `teyolias-guardiania.html`: nuevo encabezado `Registro de Aspirantes`, párrafo descriptivo y enlace a `contacto.html` con `class="btn btn-primary"` y texto `Registrarse como candidato`.

### Testing
- Se localizó el archivo con `rg`, se aplicó el parche con éxito y se confirmó el cambio con `git commit` y `git status --short`, mostrando árbol limpio después del commit.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e2a9b4a32c83328759f7112800026b)