### PR TITLE
Añadir Ónix, Luna y Mixa al listado de xolos disponibles

### DIFF
--- a/xolos-disponibles.html
+++ b/xolos-disponibles.html
@@ -368,6 +368,93 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
     </div>
   </article>
 
+
+  <article class="puppy-card" data-aos="fade-up" data-aos-duration="800" data-aos-delay="600">
+    <div class="puppy-card__image-wrapper">
+      <span class="puppy-card__status status-disponible">Disponible</span>
+      <picture>
+        <img
+          src="https://i.imgur.com/d52GgW4.jpeg"
+          alt="Xoloitzcuintle Ónix Ramirez"
+          class="puppy-card__image"
+          loading="lazy"
+          width="600"
+          height="450"
+          style="object-fit: cover;"
+        />
+      </picture>
+    </div>
+    <div class="puppy-card__content">
+      <h3 class="puppy-card__name">Ónix Ramirez</h3>
+      <ul class="puppy-card__details">
+        <li><strong>Edad</strong> Recién nacido</li>
+        <li><strong>Género</strong> Macho</li>
+        <li><strong>Talla</strong> Intermedia</li>
+        <li><strong>Color</strong> Negro</li>
+      </ul>
+      <div class="puppy-card__actions">
+        <a href="mailto:fernando@xolosramirez.com?subject=Interés en Ónix Ramirez&body=Hola, me gustaría recibir información para reservar a Ónix Ramirez." class="btn-small btn-primary-small" onclick="dataLayer.push({ event: 'click_email', cachorro: 'Ónix Ramirez', source: 'xolos_disponibles_contactar' })">Contactar por Email</a>
+      </div>
+    </div>
+  </article>
+
+  <article class="puppy-card" data-aos="fade-up" data-aos-duration="800" data-aos-delay="700">
+    <div class="puppy-card__image-wrapper">
+      <span class="puppy-card__status status-disponible">Disponible</span>
+      <picture>
+        <img
+          src="https://i.imgur.com/gSpb9C5.jpeg"
+          alt="Xoloitzcuintle Luna Ramirez"
+          class="puppy-card__image"
+          loading="lazy"
+          width="600"
+          height="450"
+          style="object-fit: cover;"
+        />
+      </picture>
+    </div>
+    <div class="puppy-card__content">
+      <h3 class="puppy-card__name">Luna Ramirez</h3>
+      <ul class="puppy-card__details">
+        <li><strong>Edad</strong> Recién nacida</li>
+        <li><strong>Género</strong> Hembra</li>
+        <li><strong>Talla</strong> Intermedia</li>
+        <li><strong>Color</strong> Negro</li>
+      </ul>
+      <div class="puppy-card__actions">
+        <a href="mailto:fernando@xolosramirez.com?subject=Interés en Luna Ramirez&body=Hola, me gustaría recibir información para reservar a Luna Ramirez." class="btn-small btn-primary-small" onclick="dataLayer.push({ event: 'click_email', cachorro: 'Luna Ramirez', source: 'xolos_disponibles_contactar' })">Contactar por Email</a>
+      </div>
+    </div>
+  </article>
+
+  <article class="puppy-card" data-aos="fade-up" data-aos-duration="800" data-aos-delay="800">
+    <div class="puppy-card__image-wrapper">
+      <span class="puppy-card__status status-disponible">Disponible</span>
+      <picture>
+        <img
+          src="https://i.imgur.com/h53ymWM.jpeg"
+          alt="Xoloitzcuintle Mixa Ramirez"
+          class="puppy-card__image"
+          loading="lazy"
+          width="600"
+          height="450"
+          style="object-fit: cover;"
+        />
+      </picture>
+    </div>
+    <div class="puppy-card__content">
+      <h3 class="puppy-card__name">Mixa Ramirez</h3>
+      <ul class="puppy-card__details">
+        <li><strong>Edad</strong> Recién nacida</li>
+        <li><strong>Género</strong> Hembra</li>
+        <li><strong>Talla</strong> Intermedia</li>
+        <li><strong>Color</strong> Mariposa</li>
+      </ul>
+      <div class="puppy-card__actions">
+        <a href="mailto:fernando@xolosramirez.com?subject=Interés en Mixa Ramirez&body=Hola, me gustaría recibir información para reservar a Mixa Ramirez." class="btn-small btn-primary-small" onclick="dataLayer.push({ event: 'click_email', cachorro: 'Mixa Ramirez', source: 'xolos_disponibles_contactar' })">Contactar por Email</a>
+      </div>
+    </div>
+  </article>
 </div>
       </section>
 


### PR DESCRIPTION
### Motivation
- Agregar tres perfiles de cachorros recién nacidos al grid de disponibles para mostrar nueva camada y permitir contacto directo desde la página. 
- Mantener el mismo patrón visual y de seguimiento que el resto de las tarjetas, pero sin el botón de video para estos cachorros recién nacidos.

### Description
- Inserté el bloque HTML proporcionado en `xolos-disponibles.html` dentro de la sección `.puppy-grid`, inmediatamente después de la tarjeta de `Teyolia Ramirez`.
- Añadí tres nuevas `article.puppy-card` para `Ónix Ramirez`, `Luna Ramirez` y `Mixa Ramirez` con imágenes, texto descriptivo (edad/género/talla/color) y el estado `Disponible`.
- Cada tarjeta incluye un enlace `mailto:` personalizado y el evento de seguimiento de Google Tag Manager `dataLayer.push(...)` en el `onclick`, y deliberadamente no incluye el botón de video.

### Testing
- Verifiqué la presencia y ubicación de la sección con `rg -n "puppy-grid|Teyolia Ramirez" xolos-disponibles.html` y la salida fue la esperada.
- Inspeccioné el fragmento insertado con `sed -n '300,430p' xolos-disponibles.html` y con `nl -ba xolos-disponibles.html | sed -n '340,500p'`, confirmando que el bloque HTML quedó correctamente integrado.
- No se ejecutó ningún conjunto de pruebas automatizadas de la aplicación porque el cambio es de contenido HTML estático.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e65e6c107c8332a790e0d8d592c1a0)