### PR TITLE
Add elegant language switcher to xolos disponibles navigation

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -289,6 +289,26 @@ a:hover {
 .nav-menu a{ color:var(--text); padding:.5rem .75rem; border-radius:.5rem; }
 .nav-menu a:hover{ background:var(--card); }
 
+.lang-switch {
+  font-family: 'Cinzel', serif;
+  font-size: .8rem;
+  text-transform: uppercase;
+  letter-spacing: 1px;
+  color: var(--accent) !important;
+  border: 1px solid rgba(203, 161, 53, .3);
+  padding: 4px 10px !important;
+  border-radius: 4px;
+  transition: all .3s ease;
+  display: inline-block;
+}
+
+.lang-switch:hover {
+  background-color: var(--accent);
+  color: #000 !important;
+  border-color: var(--accent);
+  text-decoration: none !important;
+}
+
 .hamburger{ display:none; background:transparent; border:0; color:var(--text); padding:.35rem .6rem; border-radius:.5rem; font-size:2rem; }
 
 @media (max-width: 768px){
@@ -329,6 +349,11 @@ a:hover {
     position: static;
     padding: 0;
     box-shadow: none;
+  }
+
+  .lang-switch {
+    margin-bottom: 1rem;
+    width: fit-content;
   }
 }
 

--- a/xolos-disponibles.html
+++ b/xolos-disponibles.html
@@ -98,6 +98,7 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
 
         <nav id="menu" class="nav-menu" data-visible="false">
           <ul>
+            <li><a href="en/available-xolos.html" class="lang-switch">English</a></li>
             <li><a href="index.html">Inicio</a></li>
             <li><a href="xolos-disponibles.html">Xolos disponibles</a></li>
             <li><a href="galeria.html">Galería</a></li>


### PR DESCRIPTION
### Motivation
- Add a discreet, brand‑consistent language switch in the header so English visitors can reach the translated listing without changing the existing layout or visual identity.

### Description
- Inserted an `English` link as the first `<li>` in the navigation of `xolos-disponibles.html` pointing to `en/available-xolos.html` with class `lang-switch`, and added a `.lang-switch` rule to `css/styles.css` using the `Cinzel` font, `--accent` color, a subtle gold border and hover state, plus a mobile adjustment under `@media (max-width: 768px)` to preserve menu spacing.

### Testing
- Ran `git diff --check` which returned no issues and committed the changes successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e67aa6fe6c833288fc70f429dae5bf)