### PR TITLE
Add WhatsApp floating button and fix HTML structure in contacto.html

### DIFF
--- a/contacto.html
+++ b/contacto.html
@@ -177,7 +177,7 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
             Visitar Blog <span class="btn-icon">→</span>
           </a>
         </div>
-      
+      </section>
     </main>
 
     <footer>
@@ -207,5 +207,16 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
     <script>
       AOS.init({ once: true, duration: 700, offset: 60, easing: 'ease-out' });
     </script>
+
+    <a
+      class="wa-float"
+      href="https://wa.me/qr/LNO2OMMH2ZKWF1"
+      target="_blank"
+      rel="noopener noreferrer"
+      data-gtm="whatsapp-floating"
+      onclick="dataLayer.push({ event: 'click_whatsapp', source: 'floating_button' })"
+    >
+      <span>📲 WhatsApp</span>
+    </a>
   </body>
 </html>


### PR DESCRIPTION
### Motivation
- Add the same floating WhatsApp CTA used on other pages and correct a missing closing tag that broke the HTML structure.

### Description
- Inserted the WhatsApp floating anchor (`class="wa-float"`, `href="https://wa.me/qr/LNO2OMMH2ZKWF1"`, `data-gtm` and `onclick` pushing to `dataLayer`) immediately before `</body>` and closed the previously unclosed `cta-blog-wrapper` `</section>` before `</main>` in `contacto.html`.

### Testing
- No automated tests were run because this is a static HTML-only change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e6c1ba8c348332a60db2c768fe9890)