### PR TITLE
Actualizar sección de adopciones en index con tarjeta destacada

### DIFF
--- a/index.html
+++ b/index.html
@@ -170,42 +170,29 @@ Selección de Ejemplares de Calidad: Seleccionamos cuidadosamente a los perros q
         </div>
       </section>
 
-      <section id="adopciones" class="grid grid-2" data-aos="fade-up" data-aos-duration="1000" data-aos-delay="100">
-        <article class="card" data-aos="zoom-in" data-aos-delay="150">
-          <picture class="card__media">
+      <section id="adopciones" data-aos="fade-up" data-aos-duration="1000" data-aos-delay="100" style="max-width: 900px; margin: 40px auto; padding: 0 20px;">
+        <article class="card highlight-card" data-aos="zoom-in" data-aos-delay="150" style="border: 2px solid #d4af37; border-radius: 8px; box-shadow: 0 15px 35px rgba(0,0,0,0.15); text-align: center; overflow: hidden; padding-bottom: 30px;">
+          <picture class="card__media" style="display: block; border-bottom: 3px solid #d4af37;">
            <img
              src="img/xolos/ConoceXolos.jpg"
-             width="600"
-             height="400"
+             width="900"
+             height="500"
              loading="lazy"
              decoding="async"
              alt="Xoloitzcuintle con textura de piel detallada"
+             style="width: 100%; height: auto; object-fit: cover;"
           />
           </picture>
-          <h3>Conoce a los xolos disponibles</h3>
-          <p>
-            Perfiles detallados con información de salud, temperamento y
-            requisitos de adopción.
-          </p>
-          <a href="xolos-disponibles.html">Explorar ejemplares</a>
-        </article>
-        <article class="card" data-aos="zoom-in" data-aos-delay="250">
-          <picture class="card__media">
-        <img
-         src="img/xolos/XochimaniRamirez.JPG"
-         width="600"
-         height="400"
-         loading="lazy"
-         decoding="async"
-         alt="Xoloitzcuintle Xochimani Ramirez"
-         />
-        </picture>
-          <h3>Aprende sobre su historia</h3>
-          <p>
-            Recopilamos relatos, investigaciones y datos arqueológicos que
-            muestran el papel del xoloitzcuintle en la cosmovisión mesoamericana.
-          </p>
-          <a href="blog/historia-xoloitzcuintle.html">Leer más</a>
+          <div style="padding: 30px 20px 10px;">
+            <h3 style="font-size: 2rem; margin-bottom: 15px; color: #2c2c2c;">Conoce a los xolos disponibles</h3>
+            <p style="font-size: 1.1rem; margin-bottom: 30px; color: #555; line-height: 1.6;">
+              Explora nuestros perfiles detallados con información de salud, temperamento y
+              los requisitos para una adopción responsable. Encuentra a tu compañero ancestral.
+            </p>
+            <a href="xolos-disponibles.html" class="btn" style="display: inline-flex; align-items: center; justify-content: center; padding: 15px 45px; font-size: 1.1rem; text-transform: uppercase; letter-spacing: 2px; font-weight: 700; background-color: #d4af37; color: #fff; border: none; text-decoration: none; transition: all 0.3s ease;">
+              Ver Xolos Disponibles <span style="margin-left: 12px; font-size: 1.4rem;">→</span>
+            </a>
+          </div>
         </article>
       </section>
 


### PR DESCRIPTION
### Motivation

- Modernizar y enfatizar la sección de adopciones para convertirla en un bloque visual principal y mejorar la conversión hacia la lista de ejemplares disponibles.
- Quitar la distribución en dos columnas para que la tarjeta ocupe el ancho central y se vea más prominente en pantallas medias y grandes.
- Eliminar la tarjeta secundaria sobre historia para simplificar el foco en adopciones.

### Description

- Reemplacé por completo la sección `<section id="adopciones">` en `index.html` por una única tarjeta centrada con `style="max-width: 900px; margin: 40px auto; padding: 0 20px;"`.
- Eliminé la clase `grid grid-2` y el segundo `<article>` correspondiente a “Aprende sobre su historia”.
- Añadí estilos inline para apariencia premium (borde dorado `#d4af37`, `box-shadow`, borde inferior en la imagen, `border-radius`) y ajusté el `img` a `width: 100%; height: auto; object-fit: cover;` con tamaños mayores.
- Convertí el enlace en un CTA visual con la clase `btn` y estilos inline grandes y dorados para destacar la acción `Ver Xolos Disponibles`.

### Testing

- Ejecuté `git diff --check` y no se reportaron problemas de espacio/formatos, por lo que el cambio pasó la verificación rápida de diff.
- Inspeccioné el bloque modificado con `nl -ba index.html | sed -n '165,230p'` para confirmar que la nueva sección y sus atributos se insertaron correctamente.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e6c34b19d88332a20c258ea557e084)