### PR TITLE
Actualizar imagen de la sección #adopciones en index.html

### DIFF
--- a/index.html
+++ b/index.html
@@ -174,12 +174,12 @@ Selección de Ejemplares de Calidad: Seleccionamos cuidadosamente a los perros q
         <article class="card highlight-card" data-aos="zoom-in" data-aos-delay="150" style="border: 2px solid #d4af37; border-radius: 8px; box-shadow: 0 15px 35px rgba(0,0,0,0.15); text-align: center; overflow: hidden; padding-bottom: 30px;">
           <picture class="card__media" style="display: block; border-bottom: 3px solid #d4af37;">
            <img
-             src="img/xolos/ConoceXolos.jpg"
+             src="https://i.imgur.com/xnwFe3z.jpeg"
              width="900"
              height="500"
              loading="lazy"
              decoding="async"
-             alt="Xoloitzcuintle con textura de piel detallada"
+             alt="Xoloitzcuintle disponible para adopción responsable"
              style="width: 100%; height: auto; object-fit: cover;"
           />
           </picture>


### PR DESCRIPTION
### Motivation
- Actualizar la tarjeta de adopciones para mostrar la nueva imagen remota y proporcionar un texto alternativo que describa la adopción responsable.

### Description
- Se reemplazó el `src` de la etiqueta `<img>` dentro de la sección `#adopciones` en `index.html` de `img/xolos/ConoceXolos.jpg` a `https://i.imgur.com/xnwFe3z.jpeg` y se actualizó el `alt` a `Xoloitzcuintle disponible para adopción responsable`.

### Testing
- Se verificó el cambio y la integridad del repositorio ejecutando `git diff --check`, `git diff -- index.html | sed -n '1,120p'` y `git status --short`, y todos los comandos completaron sin errores.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e6c527ed908332aaf4f363323fb443)