### PR TITLE
Auto-scroll suave a 'Perfiles destacados' al cargar la página

### DIFF
--- a/xolos-disponibles.html
+++ b/xolos-disponibles.html
@@ -205,7 +205,7 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
         </div>
       </section>
 
-      <section data-aos="fade-up" data-aos-duration="1000" data-aos-delay="100">
+      <section id="perfiles-destacados" data-aos="fade-up" data-aos-duration="1000" data-aos-delay="100">
         <h2>Perfiles destacados</h2>
         <div class="puppy-grid">
 
@@ -651,6 +651,19 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
     <script src="https://unpkg.com/aos@2.3.1/dist/aos.js"></script>
     <script>
       AOS.init({ once: true, duration: 700, offset: 60, easing: 'ease-out' });
+    </script>
+    <script>
+      document.addEventListener("DOMContentLoaded", function() {
+        setTimeout(function() {
+          const seccionDestacados = document.getElementById("perfiles-destacados");
+          if (seccionDestacados) {
+            seccionDestacados.scrollIntoView({
+              behavior: "smooth",
+              block: "start"
+            });
+          }
+        }, 800);
+      });
     </script>
   </body>
 </html>


### PR DESCRIPTION
### Motivation
- Mejorar la experiencia de entrada haciendo que la página se desplace automáticamente y de forma suave a la sección "Perfiles destacados" una vez que el hero y las animaciones se han acomodado.

### Description
- Añadido `id="perfiles-destacados"` a la sección de perfiles en `xolos-disponibles.html` y añadido un script al final del archivo que, en `DOMContentLoaded`, espera `800` ms y llama a `scrollIntoView({ behavior: "smooth", block: "start" })`.

### Testing
- Verifiqué la presencia del `id` y del script con `rg -n "perfiles-destacados|scrollIntoView|DOMContentLoaded" xolos-disponibles.html` y confirmé los cambios y el commit (`git commit`) exitosamente.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e6cdd6518083328a658304826a5ee2)