### PR TITLE
Agregar sección "El primer día en la playa" y video al post de Tejocote

### DIFF
--- a/blog/2026-04-16-entrega-tejocote-ramirez.html
+++ b/blog/2026-04-16-entrega-tejocote-ramirez.html
@@ -445,6 +445,40 @@
           </p>
         </div>
 
+        <h2>El primer día en la playa: ¡Misión cumplida!</h2>
+        <p>
+          Todo el esfuerzo, el viaje y la espera de madrugada valieron la pena al cien por ciento. Poco después de la entrega, Lola y su esposo nos compartieron un hermoso video de <strong>Tejocote</strong> disfrutando de su nueva vida caribeña. Un tierno y alegre montaje que documenta su transición descubriendo la arena, sintiendo el océano por primera vez y empezando a socializar con otros perritos locales. Es el retrato de un cachorro feliz y muy consentido.
+        </p>
+
+        <p>En este primer acercamiento al mar, pudimos observar detalles hermosos de su adaptación:</p>
+
+        <ul>
+          <li style="margin-bottom: 10px;"><strong>El orgulloso nuevo papá:</strong> El esposo de Lola lo carga tiernamente en la entrada de la playa. Tejocote lleva sus pequeñas cintas en las orejas, un cuidado común en los cachorros de la raza para ayudar a que el cartílago se fortalezca y se mantengan firmes.</li>
+          <li style="margin-bottom: 10px;"><strong>La hora dorada:</strong> Caminando con su correa y sentadito en la arena con un espectacular amanecer de fondo, con el sol reflejándose sobre el mar en tonos dorados.</li>
+          <li style="margin-bottom: 10px;"><strong>¡Nariz empanizada!</strong> El momento más tierno: Tejocote sentado mirando a la cámara con toda la nariz y la boquita completamente llenas de arena por andar de curioso olfateando la playa.</li>
+          <li style="margin-bottom: 10px;"><strong>Sintiendo el mar:</strong> Su nueva familia lo acerca a la orilla, permitiendo que las olas le mojen suavemente las patitas cerca del sargazo.</li>
+          <li style="margin-bottom: 10px;"><strong>Nuevos amigos:</strong> Tejocote ya se está integrando a la manada local, sentadito tranquilo junto a un perro más grande y saludando con curiosidad a otros perritos en la calle.</li>
+        </ul>
+
+        <div class="media-block">
+          <h2 style="margin-top: 6px;">Tejocote descubre el mar</h2>
+          <div class="video-wrap">
+            <iframe
+              src="https://www.youtube.com/embed/trvLgI_FWRQ"
+              title="El primer día de Tejocote en la playa"
+              allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share"
+              allowfullscreen>
+            </iframe>
+          </div>
+          <p class="caption">
+            Mira a <strong>Tejocote</strong> descubriendo la arena, sintiendo el océano y haciendo nuevos amigos.
+            También puedes verlo directamente en YouTube:
+            <a href="https://youtube.com/shorts/trvLgI_FWRQ?si=TI5mqXH0ep0kaA3J" target="_blank" rel="noopener noreferrer">
+              ver Short
+            </a>.
+          </p>
+        </div>
+
         <h2>Un nuevo capítulo para Tejocote Ramírez</h2>
         <p>
           La entrega de Tejocote en Cancún representa mucho más que un traslado exitoso. Representa la continuidad


### PR DESCRIPTION
### Motivation
- Integrar el relato y el video del primer día en la playa dentro del artículo existente para mantener el flujo narrativo y reutilizar las clases CSS ya presentes (`media-block`, `video-wrap`, etc.).

### Description
- Se insertó el bloque HTML proporcionado en `blog/2026-04-16-entrega-tejocote-ramirez.html` inmediatamente después del primer `media-block` y antes del encabezado `<h2>Un nuevo capítulo para Tejocote Ramírez</h2>`.
- El bloque incluye un nuevo encabezado `El primer día en la playa: ¡Misión cumplida!`, párrafos narrativos, una lista descriptiva y una segunda `media-block` con `video-wrap` que incrusta el YouTube short `trvLgI_FWRQ` y su leyenda.
- El marcado utiliza las clases y estilos existentes para asegurar que la nueva sección se integre visualmente con el resto del artículo.

### Testing
- No se ejecutaron pruebas automatizadas para este cambio de contenido HTML estático.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e78fa2ebe0833285788a1b811d509f)