### PR TITLE
Actualizar perfiles de Ónix, Luna y Mixa en xolos-disponibles.html

### DIFF
--- a/xolos-disponibles.html
+++ b/xolos-disponibles.html
@@ -373,17 +373,27 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
   <article class="puppy-card" data-aos="fade-up" data-aos-duration="800" data-aos-delay="600">
     <div class="puppy-card__image-wrapper">
       <span class="puppy-card__status status-disponible">Disponible</span>
-      <picture>
+
+      <div style="display: flex; overflow-x: auto; scroll-snap-type: x mandatory; scrollbar-width: none; -ms-overflow-style: none;">
+        <style>
+          /* Ocultar barra de scroll en navegadores webkit para que luzca limpio */
+          .puppy-card__image-wrapper div::-webkit-scrollbar { display: none; }
+        </style>
         <img
-          src="https://i.imgur.com/d52GgW4.jpeg"
-          alt="Xoloitzcuintle Ónix Ramirez"
+          src="https://i.imgur.com/xYNbvRL.jpeg"
+          alt="Xoloitzcuintle Ónix Ramirez 1"
           class="puppy-card__image"
           loading="lazy"
-          width="600"
-          height="450"
-          style="object-fit: cover;"
+          style="flex: 0 0 100%; scroll-snap-align: start; object-fit: cover;"
         />
-      </picture>
+        <img
+          src="https://i.imgur.com/KG6X2TR.jpeg"
+          alt="Xoloitzcuintle Ónix Ramirez 2"
+          class="puppy-card__image"
+          loading="lazy"
+          style="flex: 0 0 100%; scroll-snap-align: start; object-fit: cover;"
+        />
+      </div>
     </div>
     <div class="puppy-card__content">
       <h3 class="puppy-card__name">Ónix Ramirez</h3>
@@ -394,6 +404,7 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
         <li><strong>Color</strong> Negro</li>
       </ul>
       <div class="puppy-card__actions">
+        <a href="URL_DEL_VIDEO_AQUI" class="btn-small btn-outline-small" target="_blank" rel="noopener">Ver video Personalidad Xolo 🎥</a>
         <a href="mailto:fernando@xolosramirez.com?subject=Interés en Ónix Ramirez&body=Hola, me gustaría recibir información para reservar a Ónix Ramirez." class="btn-small btn-primary-small" onclick="dataLayer.push({ event: 'click_email', cachorro: 'Ónix Ramirez', source: 'xolos_disponibles_contactar' })">Contactar por Email</a>
       </div>
     </div>
@@ -402,17 +413,26 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
   <article class="puppy-card" data-aos="fade-up" data-aos-duration="800" data-aos-delay="700">
     <div class="puppy-card__image-wrapper">
       <span class="puppy-card__status status-disponible">Disponible</span>
-      <picture>
+
+      <div style="display: flex; overflow-x: auto; scroll-snap-type: x mandatory; scrollbar-width: none; -ms-overflow-style: none;">
+        <style>
+          .puppy-card__image-wrapper div::-webkit-scrollbar { display: none; }
+        </style>
         <img
-          src="https://i.imgur.com/gSpb9C5.jpeg"
-          alt="Xoloitzcuintle Luna Ramirez"
+          src="https://i.imgur.com/YVroHIG.jpeg"
+          alt="Xoloitzcuintle Luna Ramirez 1"
           class="puppy-card__image"
           loading="lazy"
-          width="600"
-          height="450"
-          style="object-fit: cover;"
+          style="flex: 0 0 100%; scroll-snap-align: start; object-fit: cover;"
         />
-      </picture>
+        <img
+          src="https://i.imgur.com/JdVncOT.jpeg"
+          alt="Xoloitzcuintle Luna Ramirez 2"
+          class="puppy-card__image"
+          loading="lazy"
+          style="flex: 0 0 100%; scroll-snap-align: start; object-fit: cover;"
+        />
+      </div>
     </div>
     <div class="puppy-card__content">
       <h3 class="puppy-card__name">Luna Ramirez</h3>
@@ -423,6 +443,7 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
         <li><strong>Color</strong> Negro</li>
       </ul>
       <div class="puppy-card__actions">
+        <a href="URL_DEL_VIDEO_AQUI" class="btn-small btn-outline-small" target="_blank" rel="noopener">Ver video Personalidad Xolo 🎥</a>
         <a href="mailto:fernando@xolosramirez.com?subject=Interés en Luna Ramirez&body=Hola, me gustaría recibir información para reservar a Luna Ramirez." class="btn-small btn-primary-small" onclick="dataLayer.push({ event: 'click_email', cachorro: 'Luna Ramirez', source: 'xolos_disponibles_contactar' })">Contactar por Email</a>
       </div>
     </div>
@@ -433,7 +454,7 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
       <span class="puppy-card__status status-disponible">Disponible</span>
       <picture>
         <img
-          src="https://i.imgur.com/h53ymWM.jpeg"
+          src="https://i.imgur.com/q9iTPZj.jpeg"
           alt="Xoloitzcuintle Mixa Ramirez"
           class="puppy-card__image"
           loading="lazy"
@@ -452,6 +473,7 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
         <li><strong>Color</strong> Mariposa</li>
       </ul>
       <div class="puppy-card__actions">
+        <a href="URL_DEL_VIDEO_AQUI" class="btn-small btn-outline-small" target="_blank" rel="noopener">Ver video Personalidad Xolo 🎥</a>
         <a href="mailto:fernando@xolosramirez.com?subject=Interés en Mixa Ramirez&body=Hola, me gustaría recibir información para reservar a Mixa Ramirez." class="btn-small btn-primary-small" onclick="dataLayer.push({ event: 'click_email', cachorro: 'Mixa Ramirez', source: 'xolos_disponibles_contactar' })">Contactar por Email</a>
       </div>
     </div>


### PR DESCRIPTION
### Motivation
- Actualizar los perfiles de tres cachorros en la página de disponibles para mostrar las nuevas imágenes y añadir un botón de video por perfil.
- Soportar dos imágenes por perfil donde corresponde usando la misma experiencia de carrusel horizontal que ya usan otros perfiles.

### Description
- Reemplacé los bloques `<article>` de `Ónix Ramirez`, `Luna Ramirez` y `Mixa Ramirez` dentro de `xolos-disponibles.html` con el HTML proporcionado. 
- Para `Ónix` y `Luna` implementé un carrusel horizontal con `overflow-x: auto` y `scroll-snap-type: x mandatory`, incluyendo estilos inline para ocultar la barra de scroll en WebKit. 
- Para `Mixa` actualicé la imagen a la nueva URL y mantuve la estructura de imagen única. 
- Agregué en los tres perfiles el botón `Ver video Personalidad Xolo 🎥` con el placeholder `href="URL_DEL_VIDEO_AQUI"` y conservé el enlace de contacto por email con `dataLayer.push` para seguimiento.

### Testing
- Busqué los nuevos marcadores y alt-texts con `rg -n "URL_DEL_VIDEO_AQUI|Ónix Ramirez 1|Luna Ramirez 2|q9iTPZj" xolos-disponibles.html` y la búsqueda devolvió las coincidencias esperadas (éxito). 
- Apliqué el reemplazo con un script Python que ejecutó la sustitución del bloque HTML en `xolos-disponibles.html` y el script terminó indicando que la actualización se realizó (éxito). 
- Verifiqué el fragmento resultante inspeccionando líneas con `nl -ba xolos-disponibles.html | sed -n '370,485p'` para confirmar la presencia del carrusel, las dos imágenes por perfil y los tres placeholders `URL_DEL_VIDEO_AQUI` (éxito).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e8f9697460833282418c5129c7d403)