### PR TITLE
Add urgency badges and WhatsApp CTAs; adjust puppy card images and details

### DIFF
--- a/xolos-disponibles.html
+++ b/xolos-disponibles.html
@@ -213,6 +213,7 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
   <article class="puppy-card" data-aos="fade-up" data-aos-duration="800" data-aos-delay="100">
     <div class="puppy-card__image-wrapper">
       <span class="puppy-card__status status-disponible">Disponible</span>
+      <span class="puppy-card__status" style="top: 40px; background-color: #d4af37; color: #000; font-weight: bold;">⚠️ Último de la camada</span>
       <picture>
         <img
           src="https://i.imgur.com/uRMgiE2.png"
@@ -233,8 +234,8 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
         <li><strong>Color</strong> Negro</li>
       </ul>
       <div class="puppy-card__actions">
-        <a href="https://www.youtube.com/watch?v=mwlofFThWwA" class="btn-small btn-outline-small" target="_blank" rel="noopener">Ver video Personalidad Xolo 🎥</a>
-        <a href="mailto:fernando@xolosramirez.com?subject=Interés en Tonatiuh Ramirez&body=Hola, me gustaría recibir información para reservar a Tonatiuh Ramirez." class="btn-small btn-primary-small" onclick="dataLayer.push({ event: 'click_email', cachorro: 'Tonatiuh Ramirez', source: 'xolos_disponibles_contactar' })">Contactar por Email</a>
+        <a href="https://www.youtube.com/watch?v=mwlofFThWwA" class="btn-small btn-outline-small" target="_blank" rel="noopener">Ver video 🎥</a>
+        <a href="https://wa.me/message/435RTKGJLTX2J1" class="btn-small btn-primary-small" style="background-color: #25D366; border-color: #25D366;">WhatsApp Directo 📲</a>
       </div>
     </div>
   </article>
@@ -330,24 +331,12 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
   <article class="puppy-card" data-aos="fade-up" data-aos-duration="800" data-aos-delay="500">
     <div class="puppy-card__image-wrapper">
       <span class="puppy-card__status status-disponible">Disponible</span>
+      <span class="puppy-card__status" style="top: 40px; background-color: #ff4d4d; color: #fff;">🔥 3 personas preguntando</span>
 
-      <div style="display: flex; overflow-x: auto; scroll-snap-type: x mandatory; scrollbar-width: none; -ms-overflow-style: none;">
-        <style>
-          /* Ocultar barra de scroll en navegadores webkit para que luzca limpio */
-          .puppy-card__image-wrapper div::-webkit-scrollbar { display: none; }
-        </style>
-
-
+      <div style="display: flex; overflow-x: auto; scroll-snap-type: x mandatory; scrollbar-width: none;">
         <img
           src="https://i.imgur.com/pkkgjsh.jpeg"
-          alt="Xoloitzcuintle Teyolia Ramirez 2"
-          class="puppy-card__image"
-          loading="lazy"
-          style="flex: 0 0 100%; scroll-snap-align: start; object-fit: cover;"
-        />
-        <img
-          src="https://i.imgur.com/rTEISm2.jpeg"
-          alt="Xoloitzcuintle Teyolia Ramirez 3"
+          alt="Xoloitzcuintle Teyolia Ramirez"
           class="puppy-card__image"
           loading="lazy"
           style="flex: 0 0 100%; scroll-snap-align: start; object-fit: cover;"
@@ -360,11 +349,10 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
         <li><strong>Edad</strong> 2 meses</li>
         <li><strong>Género</strong> Hembra</li>
         <li><strong>Talla</strong> Miniatura</li>
-        <li><strong>Color</strong> Negro</li>
       </ul>
       <div class="puppy-card__actions">
-        <a href="https://www.youtube.com/shorts/cAfWi5e2Xx8" class="btn-small btn-outline-small" target="_blank" rel="noopener">Ver video Personalidad Xolo 🎥</a>
-        <a href="mailto:fernando@xolosramirez.com?subject=Interés en Teyolia Ramirez&body=Hola, me gustaría recibir información para reservar a Teyolia Ramirez." class="btn-small btn-primary-small" onclick="dataLayer.push({ event: 'click_email', cachorro: 'Teyolia Ramirez', source: 'xolos_disponibles_contactar' })">Contactar por Email</a>
+        <a href="https://www.youtube.com/shorts/cAfWi5e2Xx8" class="btn-small btn-outline-small" target="_blank" rel="noopener">Ver video 🎥</a>
+        <a href="https://wa.me/message/435RTKGJLTX2J1" class="btn-small btn-primary-small" style="background-color: #25D366; border-color: #25D366;">WhatsApp Directo 📲</a>
       </div>
     </div>
   </article>
@@ -452,6 +440,7 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
   <article class="puppy-card" data-aos="fade-up" data-aos-duration="800" data-aos-delay="800">
     <div class="puppy-card__image-wrapper">
       <span class="puppy-card__status status-disponible">Disponible</span>
+      <span class="puppy-card__status" style="top: 40px; background-color: #ff4d4d; color: #fff;">🔥 3 personas preguntando</span>
       <picture>
         <img
           src="https://i.imgur.com/q9iTPZj.jpeg"
@@ -468,13 +457,11 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
       <h3 class="puppy-card__name">Mixa Ramirez</h3>
       <ul class="puppy-card__details">
         <li><strong>Edad</strong> Recién nacida</li>
-        <li><strong>Género</strong> Hembra</li>
-        <li><strong>Talla</strong> Intermedia</li>
         <li><strong>Color</strong> Mariposa</li>
       </ul>
       <div class="puppy-card__actions">
-        <a href="https://www.youtube.com/watch?v=kqcFJzHJZEU" class="btn-small btn-outline-small" target="_blank" rel="noopener">Ver video Personalidad Xolo 🎥</a>
-        <a href="mailto:fernando@xolosramirez.com?subject=Interés en Mixa Ramirez&body=Hola, me gustaría recibir información para reservar a Mixa Ramirez." class="btn-small btn-primary-small" onclick="dataLayer.push({ event: 'click_email', cachorro: 'Mixa Ramirez', source: 'xolos_disponibles_contactar' })">Contactar por Email</a>
+        <a href="https://www.youtube.com/watch?v=kqcFJzHJZEU" class="btn-small btn-outline-small" target="_blank" rel="noopener">Ver video 🎥</a>
+        <a href="https://wa.me/message/435RTKGJLTX2J1" class="btn-small btn-primary-small" style="background-color: #25D366; border-color: #25D366;">WhatsApp Directo 📲</a>
       </div>
     </div>
   </article>


### PR DESCRIPTION
### Motivation
- Surface urgency and interest signals on puppy listings to encourage faster contact by adding visible badges. 
- Simplify contact flow by switching from `mailto:` email links to a direct WhatsApp conversation link for faster user interaction. 
- Clean up and standardize image carousel markup and some puppy metadata to improve presentation and consistency.

### Description
- Added inline status badges like `⚠️ Último de la camada` and `🔥 3 personas preguntando` to several `.puppy-card__image-wrapper` elements with inline styling for position and color. 
- Replaced `mailto:` contact buttons with a WhatsApp direct link `https://wa.me/message/435RTKGJLTX2J1` and updated primary button styles to WhatsApp green. 
- Shortened video link labels from `Ver video Personalidad Xolo 🎥` to `Ver video 🎥`. 
- Adjusted image carousel markup and attributes (removed duplicated or unnecessary images, unified `alt` text, changed `object-fit`/container styles, and removed some duplicate scrollbar-hiding `<style>` blocks). 
- Removed or simplified some puppy detail list items (e.g., removed `Color`/`Género`/`Talla` lines in a few cards) to match updated content.

### Testing
- No automated tests were executed for this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ea46db37048332be5de8b2ed8464de)