### PR TITLE
Estandariza CTAs a WhatsApp en perfiles de cachorros (Ozomatli, Nox, Ónix, Luna)

### DIFF
--- a/xolos-disponibles.html
+++ b/xolos-disponibles.html
@@ -277,7 +277,7 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
       </ul>
       <div class="puppy-card__actions">
         <a href="https://youtube.com/shorts/V0Z_qj4GMsY" class="btn-small btn-outline-small" target="_blank" rel="noopener">Ver video Personalidad Xolo 🎥</a>
-        <a href="mailto:fernando@xolosramirez.com?subject=Interés en Ozomatli Ramirez&body=Hola, me gustaría recibir información para reservar a Ozomatli Ramirez." class="btn-small btn-primary-small" onclick="dataLayer.push({ event: 'click_email', cachorro: 'Ozomatli Ramirez', source: 'xolos_disponibles_contactar' })">Contactar por Email</a>
+        <a href="https://wa.me/message/435RTKGJLTX2J1?text=Hola,%20estoy%20interesado%20en%20recibir%20informaci%C3%B3n%20para%20reservar%20a%20Ozomatli%20Ramirez" class="btn-small btn-primary-small" style="background-color: #25D366; border-color: #25D366;">WhatsApp Directo 📲</a>
       </div>
     </div>
   </article>
@@ -321,7 +321,7 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
       </ul>
       <div class="puppy-card__actions">
         <a href="https://youtube.com/embed/Fa1DlRRWvOU" class="btn-small btn-outline-small" target="_blank" rel="noopener">Ver video Personalidad Xolo 🎥</a>
-        <a href="mailto:fernando@xolosramirez.com?subject=Interés en Nox Ramirez&body=Hola, me gustaría recibir información para reservar a Nox Ramirez." class="btn-small btn-primary-small" onclick="dataLayer.push({ event: 'click_email', cachorro: 'Nox Ramirez', source: 'xolos_disponibles_contactar' })">Contactar por Email</a>
+        <a href="https://wa.me/message/435RTKGJLTX2J1?text=Hola,%20me%20gustar%C3%ADa%20reservar%20a%20Nox%20Ramirez" class="btn-small btn-primary-small" style="background-color: #25D366; border-color: #25D366;">WhatsApp Directo 📲</a>
       </div>
     </div>
   </article>
@@ -361,6 +361,7 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
   <article class="puppy-card" data-aos="fade-up" data-aos-duration="800" data-aos-delay="600">
     <div class="puppy-card__image-wrapper">
       <span class="puppy-card__status status-disponible">Disponible</span>
+      <span class="puppy-card__status" style="top: 40px; background-color: #555; color: #fff;">🍼 Reserva abierta</span>
 
       <div style="display: flex; overflow-x: auto; scroll-snap-type: x mandatory; scrollbar-width: none; -ms-overflow-style: none;">
         <style>
@@ -393,7 +394,7 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
       </ul>
       <div class="puppy-card__actions">
         <a href="https://www.youtube.com/watch?v=yp0tAIOjBlA" class="btn-small btn-outline-small" target="_blank" rel="noopener">Ver video Personalidad Xolo 🎥</a>
-        <a href="mailto:fernando@xolosramirez.com?subject=Interés en Ónix Ramirez&body=Hola, me gustaría recibir información para reservar a Ónix Ramirez." class="btn-small btn-primary-small" onclick="dataLayer.push({ event: 'click_email', cachorro: 'Ónix Ramirez', source: 'xolos_disponibles_contactar' })">Contactar por Email</a>
+        <a href="https://wa.me/message/435RTKGJLTX2J1?text=Hola,%20quiero%20informaci%C3%B3n%20sobre%20la%20camada%20reci%C3%A9n%20nacida%20de%20%C3%93nix%20Ramirez" class="btn-small btn-primary-small" style="background-color: #25D366; border-color: #25D366;">WhatsApp Directo 📲</a>
       </div>
     </div>
   </article>
@@ -401,6 +402,7 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
   <article class="puppy-card" data-aos="fade-up" data-aos-duration="800" data-aos-delay="700">
     <div class="puppy-card__image-wrapper">
       <span class="puppy-card__status status-disponible">Disponible</span>
+      <span class="puppy-card__status" style="top: 40px; background-color: #555; color: #fff;">🍼 Reserva abierta</span>
 
       <div style="display: flex; overflow-x: auto; scroll-snap-type: x mandatory; scrollbar-width: none; -ms-overflow-style: none;">
         <style>
@@ -432,7 +434,7 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
       </ul>
       <div class="puppy-card__actions">
         <a href="https://www.youtube.com/watch?v=5OvYnLW7aGE" class="btn-small btn-outline-small" target="_blank" rel="noopener">Ver video Personalidad Xolo 🎥</a>
-        <a href="mailto:fernando@xolosramirez.com?subject=Interés en Luna Ramirez&body=Hola, me gustaría recibir información para reservar a Luna Ramirez." class="btn-small btn-primary-small" onclick="dataLayer.push({ event: 'click_email', cachorro: 'Luna Ramirez', source: 'xolos_disponibles_contactar' })">Contactar por Email</a>
+        <a href="https://wa.me/message/435RTKGJLTX2J1?text=Hola,%20quiero%20informaci%C3%B3n%20sobre%20la%20camada%20reci%C3%A9n%20nacida%20de%20Luna%20Ramirez" class="btn-small btn-primary-small" style="background-color: #25D366; border-color: #25D366;">WhatsApp Directo 📲</a>
       </div>
     </div>
   </article>


### PR DESCRIPTION
### Motivation
- Unificar el llamado a la acción para reservas y maximizar conversión cambiando el contacto por correo a WhatsApp en los perfiles de cachorros. 
- Reforzar la urgencia en camadas recién nacidas con una etiqueta visible que invite a reservar tempranamente.

### Description
- Reemplacé los enlaces `mailto:` por enlaces de WhatsApp (`https://wa.me/message/435RTKGJLTX2J1?text=...`) con mensajes prellenados para `Ozomatli`, `Nox`, `Ónix` y `Luna` en `xolos-disponibles.html`.
- Actualicé el estilo de los botones resultantes para usar el color verde de WhatsApp (`style="background-color: #25D366; border-color: #25D366;"`) manteniendo el botón de video existente.
- Añadí la etiqueta secundaria `🍼 Reserva abierta` en las tarjetas de los recién nacidos `Ónix` y `Luna` para comunicar reserva temprana.
- Se removieron los CTAs de email originales (incluyendo el `onclick` asociado al push de `dataLayer` para email) y se dejó la navegación a video sin cambios.

### Testing
- Ejecuté `git diff --check` y no reportó errores, por lo que no hay advertencias de formato o espacios en blanco en las diferencias.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ea4a4e2bc08332aed2939646fb0d96)