### PR TITLE
Actualiza entrada de Humo con seguimiento de abril 2026

### DIFF
--- a/blog/2026-03-28-entrega-humo-ramirez.html
+++ b/blog/2026-03-28-entrega-humo-ramirez.html
@@ -536,6 +536,25 @@
           </ul>
         </div>
 
+        <h2 id="actualizacion-abril-2026">Actualización: Abril 2026</h2>
+        <p>
+          A casi un mes de su llegada al nuevo hogar, <strong>Luciana</strong> nos comparte su alegría y una hermosa
+          actualización de <strong>Humo Ramírez</strong>. Nos comenta que se siente sumamente contenta con la
+          adaptación del ejemplar y ya estamos coordinando una reunión para la <strong>primera semana de mayo</strong>
+          para compartir a detalle esta maravillosa experiencia.
+        </p>
+
+        <div style="margin: 34px 0; text-align: center;">
+          <img
+            src="https://i.imgur.com/v8KwRYG.jpeg"
+            alt="Xoloitzcuintle Humo Ramírez con Luciana"
+            style="width: 100%; max-width: 500px; border-radius: 22px; box-shadow: var(--shadow-soft); border: 1px solid var(--border);"
+          >
+          <p style="font-size: 0.9rem; color: var(--muted); margin-top: 12px; font-style: italic;">
+            Humo Ramírez disfrutando de un día con su nueva familia.
+          </p>
+        </div>
+
         <div class="cta-box">
           <h3>Conoce más ejemplares disponibles</h3>
           <p>


### PR DESCRIPTION
### Motivation
- Añadir una actualización al artículo de la entrega de Humo para reflejar la información reciente que comparte Luciana y mostrar la foto provista, colocándola como continuidad de la historia antes del llamado a la acción.

### Description
- Se insertó una sección `h2` con `id="actualizacion-abril-2026"`, un párrafo descriptivo y un bloque centrado con la imagen `https://i.imgur.com/v8KwRYG.jpeg` y pie de foto en `blog/2026-03-28-entrega-humo-ramirez.html` justo antes de `<div class="cta-box">`.
- El archivo modificado fue guardado y registrado con el mensaje de commit `Actualiza entrada de Humo con seguimiento de abril 2026`.

### Testing
- Se verificó la ubicación del bloque y el contenido con `rg -n "<div class=\"cta-box\">" blog/2026-03-28-entrega-humo-ramirez.html && sed -n '1,260p' blog/2026-03-28-entrega-humo-ramirez.html`, que se ejecutó con éxito.
- Se inspeccionaron las líneas modificadas con `nl -ba blog/2026-03-28-entrega-humo-ramirez.html | sed -n '520,590p' && git status --short`, que se ejecutó con éxito.
- Se añadió y confirmó el cambio al historial con `git add blog/2026-03-28-entrega-humo-ramirez.html && git commit -m "Actualiza entrada de Humo con seguimiento de abril 2026"` y `git log -1 --oneline`, los cuales se ejecutaron con éxito.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ebb8eb3ecc8332bd76611164fb6e25)