### PR TITLE
Add Teyolías Guardianship section and mark Tonatiuh as candidate on English page

### DIFF
--- a/en/available-xolos.html
+++ b/en/available-xolos.html
@@ -81,6 +81,24 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
       </p>
     </section>
 
+
+    <section class="container" data-aos="fade-up" data-aos-duration="1000" data-aos-delay="150" style="margin-top: 40px; margin-bottom: 40px;">
+      <div class="grid grid-2">
+        <article class="card highlight-card" data-aos="zoom-in" data-aos-delay="200" style="border-left: 4px solid #d4af37; background: rgba(212, 175, 55, 0.03); padding: 30px;">
+          <h3 style="color: #d4af37;">Teyolías Guardianship ✨</h3>
+          <p>
+            Some xoloitzcuintles aged 6 months or older have reached the ideal maturity to participate in our special <strong>Teyolías Guardianship</strong> program: a way to connect with selected dogs from a cultural, community, and companionship perspective.
+          </p>
+          <a href="../teyolias-guardiania.html" style="font-weight: 600; color: #d4af37; text-decoration: none;">
+            Learn about the program and how to participate →
+          </a>
+          <p class="callout" style="margin-top: 15px; font-size: 0.9rem; color: #666; font-style: italic;">
+            Candidates will be identified with the <strong>✨ Teyolía Candidate</strong> tag within the available profiles below.
+          </p>
+        </article>
+      </div>
+    </section>
+
     <section class="trust" data-aos="fade-up" data-aos-duration="1000" data-aos-delay="80">
       <h2>Trust & Guarantees</h2>
       <div class="trust-grid">
@@ -141,6 +159,8 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
         <article class="puppy-card" data-aos="fade-up" data-aos-duration="800" data-aos-delay="100">
           <div class="puppy-card__image-wrapper">
             <span class="puppy-card__status status-disponible">Available</span>
+            <span class="puppy-card__status" style="top: 40px; background-color: #d4af37; color: #000; font-weight: bold;">✨ Teyolía Candidate</span>
+
             <picture>
               <img
                 src="https://i.imgur.com/uRMgiE2.png"
@@ -155,14 +175,15 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
           <div class="puppy-card__content">
             <h3 class="puppy-card__name">Tonatiuh Ramirez</h3>
             <ul class="puppy-card__details">
-              <li><strong>Age</strong> 5 months</li>
+              <li><strong>Age</strong> 6 months</li>
               <li><strong>Gender</strong> Male</li>
               <li><strong>Size</strong> Miniature</li>
               <li><strong>Color</strong> Black</li>
+              <li><strong>Teyolía</strong> Candidate by age</li>
             </ul>
             <div class="puppy-card__actions">
-              <a href="https://www.youtube.com/watch?v=mwlofFThWwA" class="btn-small btn-outline-small" target="_blank" rel="noopener">Watch Xolo Personality 🎥</a>
-              <a href="mailto:fernando@xolosramirez.com?subject=Interest in Tonatiuh Ramirez&body=Hello, I would like to receive information on how to reserve Tonatiuh Ramirez." class="btn-small btn-primary-small" onclick="dataLayer.push({ event: 'click_email', cachorro: 'Tonatiuh Ramirez', source: 'available_xolos_contact_en' })">Contact via Email</a>
+              <a href="https://www.youtube.com/watch?v=mwlofFThWwA" class="btn-small btn-outline-small" target="_blank" rel="noopener">Watch video 🎥</a>
+              <a href="../teyolias-guardiania.html" class="btn-small btn-primary-small" style="background-color: #d4af37; border-color: #d4af37; color: #000;">Participate in Teyolías ✨</a>
             </div>
           </div>
         </article>


### PR DESCRIPTION
### Motivation
- Introduce the new Teyolías Guardianship program to English visitors and surface eligible candidates within the existing available profiles. 
- Provide a direct, language-appropriate path from the English listings to the main Teyolías program page using correct relative links. 

### Description
- Inserted a new highlight section for the program into `en/available-xolos.html` immediately after the Responsible Adoption Process content that includes explanatory text, a callout, and a link to `../teyolias-guardiania.html`. 
- Updated the `Tonatiuh Ramirez` profile card in `en/available-xolos.html` to add the `✨ Teyolía Candidate` badge, change age to `6 months`, and add a `Teyolía: Candidate by age` detail row. 
- Replaced the previous email contact CTA for Tonatiuh with a gold-styled CTA linking to `../teyolias-guardiania.html` and adjusted the video CTA copy to `Watch video 🎥`.

### Testing
- Ran `git diff --check` to verify there are no whitespace/format issues and it completed successfully. 
- Verified the modified `en/available-xolos.html` file contains the new section and the updated Tonatiuh card by inspecting the file content. 
- No automated visual/browser tests were available in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ef79db58bc83328e289a3f46203387)