### PR TITLE
Update Teyolía links to official teyolia.cash and Tonatiuh campaign

### DIFF
--- a/en/teyolias-guardianship.html
+++ b/en/teyolias-guardianship.html
@@ -65,7 +65,7 @@
             </p>
 
             <div class="flex flex-wrap justify-center gap-4">
-                <a href="https://teyolia.xolosramirez.com" target="_blank" rel="noopener noreferrer" class="bg-amber-500 text-stone-900 px-6 py-3 rounded-full font-bold hover:bg-amber-400 transition-all shadow-lg">
+                <a href="https://www.teyolia.cash" target="_blank" rel="noopener noreferrer" class="bg-amber-500 text-stone-900 px-6 py-3 rounded-full font-bold hover:bg-amber-400 transition-all shadow-lg">
                     🔥 View Open Campaigns
                 </a>
                 <a href="../blog/tutorial-tonalli-wallet.html" class="bg-transparent border border-amber-500 text-amber-500 px-6 py-3 rounded-full font-bold hover:bg-amber-500 hover:text-stone-900 transition-all">
@@ -179,7 +179,11 @@
                             <p class="text-stone-700 text-sm leading-relaxed mb-5">
                                 Tonatiuh has been selected as a candidate due to his stage of maturity. During this campaign, interested families can apply as guardians.
                             </p>
-                            <a href="#" class="inline-block bg-stone-900 text-amber-500 px-5 py-3 rounded-full font-bold hover:bg-amber-600 hover:text-stone-900 transition-all">
+                            <a 
+                                href="https://www.teyolia.cash/campaigns/campaign-1777329953138" 
+                                target="_blank"
+                                rel="noopener noreferrer"
+                                class="inline-block bg-stone-900 text-amber-500 px-5 py-3 rounded-full font-bold hover:bg-amber-600 hover:text-stone-900 transition-all">
                                 View Tonatiuh's Teyolía ✨
                             </a>
                         </div>
@@ -219,7 +223,7 @@
         <section class="text-center border-t border-stone-300 pt-16">
             <h3 class="text-2xl font-serif font-bold mb-6 text-stone-800">Ready to take the next step?</h3>
             <div class="flex flex-col sm:flex-row justify-center gap-4 mb-10">
-                <a href="https://teyolia.xolosramirez.com" target="_blank" rel="noopener noreferrer" class="bg-amber-500 text-stone-900 px-8 py-4 rounded-full font-bold hover:bg-amber-400 transition-all shadow-lg text-lg">
+                <a href="https://www.teyolia.cash" target="_blank" rel="noopener noreferrer" class="bg-amber-500 text-stone-900 px-8 py-4 rounded-full font-bold hover:bg-amber-400 transition-all shadow-lg text-lg">
                     🔥 Go to Teyolía Platform
                 </a>
                 <a href="../blog/tutorial-tonalli-wallet.html" class="bg-stone-800 text-stone-100 px-8 py-4 rounded-full font-bold hover:bg-stone-700 transition-all shadow-lg border border-stone-600 text-lg">

--- a/teyolias-guardiania.html
+++ b/teyolias-guardiania.html
@@ -191,7 +191,9 @@
                     </p>
 
                     <a 
-                        href="#"
+                        href="https://www.teyolia.cash/campaigns/campaign-1777329953138"
+                        target="_blank"
+                        rel="noopener noreferrer"
                         class="inline-block bg-stone-900 text-amber-500 px-5 py-3 rounded-full font-bold hover:bg-amber-600 hover:text-stone-900 transition-all"
                     >
                         Ver Teyolía de Tonatiuh ✨


### PR DESCRIPTION
### Motivation
- Ensure the Tonatiuh CTA buttons point to the real Flipstarter/Flipstarter-like campaign and open in a new secure tab. 
- Replace temporary/internal platform links with the official `https://www.teyolia.cash` domain where the header/footer CTAs point to the live platform.

### Description
- In `teyolias-guardiania.html` replaced the Tonatiuh button `href="#"` with `https://www.teyolia.cash/campaigns/campaign-1777329953138` and added `target="_blank"` and `rel="noopener noreferrer"` to open securely in a new tab. 
- In `en/teyolias-guardianship.html` updated the Tonatiuh button to the same campaign URL with `target` and `rel` attributes. 
- In `en/teyolias-guardianship.html` replaced header and footer CTAs that used `https://teyolia.xolosramirez.com` to `https://www.teyolia.cash`. 
- Changes were saved and committed to the repository.

### Testing
- Searched both files to verify replacements with `rg -n "teyolia\.xolosramirez\.com|campaign-1777329953138|href=\"#\"" teyolias-guardiania.html en/teyolias-guardianship.html` and confirmed expected matches were updated, test succeeded. 
- Reviewed the diff with `git diff -- teyolias-guardiania.html en/teyolias-guardianship.html` to confirm the exact edits, test succeeded. 
- Committed the changes with `git commit -m "Update Teyolía links to official platform and Tonatiuh campaign"` and the commit completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69efe7f1a2d0833295adbe532952672b)