### PR TITLE
Sync Teyolía CTA and SEO tags across ES/EN landing pages

### DIFF
--- a/en/teyolias-guardianship.html
+++ b/en/teyolias-guardianship.html
@@ -4,6 +4,9 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Teyolía Guardianship | Xolos Ramírez</title>
+    <meta name="description" content="Discover the Guardianship Teyolías program by Xolos Ramírez: a curated adoption path uniting community and breeder for the Xoloitzcuintle's well-being.">
+    <link rel="alternate" hreflang="es" href="https://xolosramirez.com/teyolias-guardiania.html">
+    <link rel="alternate" hreflang="en" href="https://xolosramirez.com/en/teyolias-guardianship.html">
     <script src="https://cdn.tailwindcss.com"></script>
     <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
     <style>
@@ -68,7 +71,7 @@
                 <a href="https://www.teyolia.cash" target="_blank" rel="noopener noreferrer" class="bg-amber-500 text-stone-900 px-6 py-3 rounded-full font-bold hover:bg-amber-400 transition-all shadow-lg">
                     🔥 View Open Campaigns
                 </a>
-                <a href="https://cartera.xolosarmy.xyz" class="bg-transparent border border-amber-500 text-amber-500 px-6 py-3 rounded-full font-bold hover:bg-amber-500 hover:text-stone-900 transition-all">
+                <a href="https://cartera.xolosarmy.xyz" target="_blank" rel="noopener noreferrer" class="bg-transparent border border-amber-500 text-amber-500 px-6 py-3 rounded-full font-bold hover:bg-amber-500 hover:text-stone-900 transition-all">
                     👛 Get Tonalli Wallet
                 </a>
             </div>
@@ -226,7 +229,7 @@
                 <a href="https://www.teyolia.cash" target="_blank" rel="noopener noreferrer" class="bg-amber-500 text-stone-900 px-8 py-4 rounded-full font-bold hover:bg-amber-400 transition-all shadow-lg text-lg">
                     🔥 Go to Teyolía Platform
                 </a>
-                <a href="https://cartera.xolosarmy.xyz" class="bg-stone-800 text-stone-100 px-8 py-4 rounded-full font-bold hover:bg-stone-700 transition-all shadow-lg border border-stone-600 text-lg">
+                <a href="https://cartera.xolosarmy.xyz" target="_blank" rel="noopener noreferrer" class="bg-stone-800 text-stone-100 px-8 py-4 rounded-full font-bold hover:bg-stone-700 transition-all shadow-lg border border-stone-600 text-lg">
                     👛 Download Tonalli Wallet
                 </a>
             </div>

--- a/teyolias-guardiania.html
+++ b/teyolias-guardiania.html
@@ -4,6 +4,9 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Teyolia de Guardianía | Xolos Ramírez</title>
+    <meta name="description" content="Descubre el programa Teyolías de Guardianía de Xolos Ramírez: un camino de adopción curada donde la tribu y el criadero se unen por el bienestar del xoloitzcuintle.">
+    <link rel="alternate" hreflang="es" href="https://xolosramirez.com/teyolias-guardiania.html">
+    <link rel="alternate" hreflang="en" href="https://xolosramirez.com/en/teyolias-guardianship.html">
     <script src="https://cdn.tailwindcss.com"></script>
     <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
     <style>
@@ -60,9 +63,18 @@
     <header class="bg-stone-900 text-stone-50 py-16 px-6 text-center border-b-8 border-amber-600">
         <div class="max-w-4xl mx-auto">
             <h1 class="text-4xl md:text-5xl font-serif font-bold mb-4 text-amber-500">Teyolía de Guardianía ✨</h1>
-            <p class="text-lg text-stone-300 leading-relaxed">
+            <p class="text-lg text-stone-300 leading-relaxed mb-8">
                 Un camino de adopción curada donde la cultura, la tribu y el criadero se unen para asegurar el bienestar del Xoloitzcuintle.
             </p>
+
+            <div class="flex flex-wrap justify-center gap-4">
+                <a href="https://www.teyolia.cash" target="_blank" rel="noopener noreferrer" class="bg-amber-500 text-stone-900 px-6 py-3 rounded-full font-bold hover:bg-amber-400 transition-all shadow-lg">
+                    🔥 Ver campañas activas
+                </a>
+                <a href="https://cartera.xolosarmy.xyz" target="_blank" rel="noopener noreferrer" class="bg-transparent border border-amber-500 text-amber-500 px-6 py-3 rounded-full font-bold hover:bg-amber-500 hover:text-stone-900 transition-all">
+                    👛 Descargar Tonalli Wallet
+                </a>
+            </div>
         </div>
     </header>
 
@@ -249,11 +261,20 @@
     </div>
 </section>
 
-        <section class="text-center border-t pt-10">
-            <a href="xolos-disponibles.html" class="inline-block bg-stone-900 text-amber-500 px-8 py-4 rounded-full font-bold hover:bg-amber-600 hover:text-stone-900 transition-all">
+        <section class="text-center border-t border-stone-300 pt-16">
+            <h3 class="text-2xl font-serif font-bold mb-6 text-stone-800">¿Listo para dar el siguiente paso?</h3>
+            <div class="flex flex-col sm:flex-row justify-center gap-4 mb-10">
+                <a href="https://www.teyolia.cash" target="_blank" rel="noopener noreferrer" class="bg-amber-500 text-stone-900 px-8 py-4 rounded-full font-bold hover:bg-amber-400 transition-all shadow-lg text-lg">
+                    🔥 Ir a la Plataforma Teyolía
+                </a>
+                <a href="https://cartera.xolosarmy.xyz" target="_blank" rel="noopener noreferrer" class="bg-stone-800 text-stone-100 px-8 py-4 rounded-full font-bold hover:bg-stone-700 transition-all shadow-lg border border-stone-600 text-lg">
+                    👛 Descargar Tonalli Wallet
+                </a>
+            </div>
+            <a href="xolos-disponibles.html" class="inline-block text-stone-500 font-semibold hover:text-amber-600 transition-colors">
                 ⬅ Volver a Xolos Disponibles
             </a>
-            <div class="flex justify-center gap-6 mt-8 opacity-60 text-xs">
+            <div class="flex justify-center gap-6 mt-12 opacity-60 text-xs">
                 <a href="https://github.com/xolosArmy" class="hover:underline">GitHub xolosArmy</a>
                 <a href="blog/teyolia-guardiania-xoloitzcuintle-tutorial.html" class="hover:underline">Tutorial Completo</a>
             </div>


### PR DESCRIPTION
### Motivation
- Ensure both Spanish and English Teyolía landing pages share consistent SEO metadata and reciprocal `hreflang` links to improve multilingual indexing. 
- Align CTAs between languages and make wallet links open safely in a new tab with `target="_blank" rel="noopener noreferrer"` to improve conversion and security. 

### Description
- Added localized `meta` `description` tags and reciprocal `<link rel="alternate" hreflang=...>` entries to `teyolias-guardiania.html` and `en/teyolias-guardianship.html`. 
- Inserted the missing CTA button group into the Spanish header to match the English header (links to Teyolía platform and Tonalli Wallet). 
- Replaced the Spanish final CTA/footer section with the richer conversion block (headline, two CTAs, back link and support links) to match the English experience. 
- Standardized Tonalli Wallet links in the English page to include `target="_blank" rel="noopener noreferrer"` and added the same attributes to newly added Spanish CTAs. 

### Testing
- Ran `git diff -- teyolias-guardiania.html en/teyolias-guardianship.html` and reviewed the output to confirm only the intended CTA/SEO changes were applied (succeeded). 
- Ran `git status --short` to verify modified files appear as expected (succeeded). 
- Attempted a visual validation with Playwright screenshots but the browser launch failed due to a missing system library (`libatk-1.0.so.0`), and the screenshot step did not complete; Playwright browser download was executed during the run.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69efeeb742848332a5a82677e7d1654f)