### PR TITLE
Improve commercial SEO snippets and price guide links

### DIFF
--- a/contacto.html
+++ b/contacto.html
@@ -10,10 +10,10 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
     <!-- End Google Tag Manager -->
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>Contacto y asesoría sobre xoloitzcuintles | Xolos Ramirez</title>
+    <title>Contacto: Criadero y Venta de Xoloitzcuintles | Xolos Ramírez</title>
     <meta
       name="description"
-      content="Solicita información de adopciones, colaboraciones y eventos del xoloitzcuintle con el equipo especializado de Xolos Ramirez."
+      content="Contáctanos para la compra de tu cachorro xoloitzcuintle. Asesoría sobre precios, tallas (miniatura, estándar) y detalles de envíos desde nuestro criadero."
     />
     <meta
       name="keywords"

--- a/index.html
+++ b/index.html
@@ -10,10 +10,10 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
     <!-- End Google Tag Manager -->
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>Xolos Ramirez | Comunidad dedicada al xoloitzcuintle</title>
+    <title>Criadero de Xoloitzcuintles: Venta y Adopción | Xolos Ramírez CDMX</title>
     <meta
       name="description"
-      content="Descubre la comunidad Xolos Ramirez: historia, adopciones responsables, galería y testimonios sobre el xoloitzcuintle en México."
+      content="Bienvenido al criadero de xoloitzcuintles Xolos Ramírez. Preservamos la raza miniatura, intermedia y estándar. Conoce el precio, salud y ejemplares en venta."
     />
     <meta
       name="keywords"
@@ -320,6 +320,14 @@ NFTs de Linaje Xoloitzcuintle</a></li>
           <a href="http://xolosramirez.com/xolos-disponibles.html" class="btn">Adopta un Xolo</a>
         </div>
       </section>
+
+      <div class="container" style="margin-top: 4rem; margin-bottom: 4rem;">
+        <div style="background: linear-gradient(145deg, #1a1512, #2a201c); padding: 3rem 2rem; text-align: center; border-radius: 12px; border: 1px solid rgba(212, 175, 55, 0.2); box-shadow: 0 10px 30px rgba(0,0,0,0.5);">
+          <h3 style="color: var(--color-dorado, #d4af37); margin-bottom: 1rem; font-family: 'Cinzel', serif; font-size: 1.8rem;">¿Dudas sobre la inversión en un Xoloitzcuintle?</h3>
+          <p style="color: #e0d5c1; margin-bottom: 2rem; max-width: 600px; margin-left: auto; margin-right: auto; line-height: 1.6;">Descubre qué influye en el valor de esta raza milenaria, el impacto de su linaje y todo lo que incluye nuestro exclusivo programa de crianza y entregas.</p>
+          <a href="blog/precio-xoloitzcuintle.html" class="btn" style="background-color: var(--color-dorado, #d4af37); color: #111; font-weight: 800; padding: 1rem 2rem; border-radius: 999px; text-decoration: none; display: inline-block;">Ver guía de Precios y Qué Incluye</a>
+        </div>
+      </div>
     </main>
 
     <footer>

--- a/testimonios.html
+++ b/testimonios.html
@@ -10,10 +10,10 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
     <!-- End Google Tag Manager -->
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>Testimonios de familias y expertos | Xolos Ramirez</title>
+    <title>Testimonios de Familias con Xoloitzcuintles | Xolos Ramírez</title>
     <meta
       name="description"
-      content="Lee testimonios auténticos de adoptantes, especialistas y aliados que respaldan la misión de Xolos Ramirez."
+      content="Lee las opiniones y testimonios reales de familias que han adquirido un xoloitzcuintle con nosotros. Envíos nacionales e internacionales seguros."
     />
     <meta
       name="keywords"

--- a/xolos-disponibles.html
+++ b/xolos-disponibles.html
@@ -200,6 +200,12 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
 
       <section id="perfiles-destacados" data-aos="fade-up" data-aos-duration="1000" data-aos-delay="100">
         <h2>Perfiles destacados</h2>
+        <div style="background-color: rgba(212, 175, 55, 0.05); border-left: 4px solid var(--color-dorado, #d4af37); padding: 1.5rem; margin-bottom: 3rem; border-radius: 0 8px 8px 0;">
+          <h3 style="color: var(--color-dorado, #d4af37); margin-top: 0; font-size: 1.2rem; font-family: 'Cinzel', serif;">Transparencia y Valor Premium</h3>
+          <p style="color: var(--color-texto, #f1e6d6); margin-bottom: 0.8rem; font-size: 0.95rem;">Antes de reservar a tu cachorro, conoce qué respalda nuestra crianza ética, las garantías de salud, el registro NFT y <strong>¿cuál es el precio de un xoloitzcuintle?</strong></p>
+          <a href="blog/precio-xoloitzcuintle.html" style="color: var(--color-dorado, #d4af37); font-weight: bold; text-decoration: underline; font-size: 0.95rem;">Leer nuestra guía de valor y precios &rarr;</a>
+        </div>
+
          <div class="puppy-grid">
 
   <!--


### PR DESCRIPTION
### Motivation
- Aumentar el CTR comercial y la relevancia para la búsqueda "xoloitzcuintle precio" al usar títulos y descripciones orientadas a compra y enlazar el artículo principal de precios desde las páginas de mayor tráfico.

### Description
- Actualicé el `<title>` y la `meta name="description"` en `index.html` para enfatizar venta, adopción, tallas y precio. 
- Actualicé el `<title>` y la `meta name="description"` en `testimonios.html` para resaltar testimonios reales y opciones de envío. 
- Actualicé el `<title>` y la `meta name="description"` en `contacto.html` para reforzar intención comercial sobre compra, precios y envíos. 
- Añadí un CTA en `index.html` y un bloque “Transparencia y Valor Premium” justo antes de la cuadrícula de cachorros en `xolos-disponibles.html`, ambos enlazando a `blog/precio-xoloitzcuintle.html`.

### Testing
- Ejecuté un chequeo de humo de parsing con `python3` (`HTMLParser().feed`) sobre los archivos modificados y pasó correctamente. 
- Verifiqué la presencia de los snippets y los enlaces con `rg` y se encontraron las cadenas esperadas en los archivos modificados. 
- Intenté comprobar un navegador/headless (`command -v chromium|google-chrome|firefox`) y no había un navegador instalado, por lo que las pruebas visuales basadas en navegador fallaron.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fcd9086b5c8332a37890b782376304)