### PR TITLE
Add homepage E‑E‑A‑T authority cluster and 'Miniatura' badge on puppy card

### DIFF
--- a/index.html
+++ b/index.html
@@ -314,6 +314,33 @@ NFTs de Linaje Xoloitzcuintle</a></li>
         </div>
       </section>
 
+      <section class="section" style="background-color: var(--color-fondo-alt, #1e1917); padding: 5rem 0; border-top: 1px solid rgba(212, 175, 55, 0.1);">
+        <div class="container">
+          <div style="text-align: center; max-width: 800px; margin: 0 auto 3rem;">
+            <span style="color: var(--color-dorado, #d4af37); font-weight: bold; letter-spacing: 2px; text-transform: uppercase; font-size: 0.85rem;">Guía Definitiva y Cuidados</span>
+            <h2 style="font-family: 'Cinzel', serif; font-size: 2.5rem; margin-top: 0.5rem;">Crianza Ética y Conocimiento Experto</h2>
+            <p style="color: var(--color-texto-suave, #a89f91); font-size: 1.1rem; line-height: 1.6;">Como criadores especializados, nuestro deber es educar. Antes de integrar a un Xoloitzcuintle a tu familia, domina sus necesidades, su genética y su temperamento milenario.</p>
+          </div>
+
+          <div style="display: grid; grid-template-columns: repeat(auto-fit, minmax(300px, 1fr)); gap: 2rem;">
+            <a href="blog/cuidados-basicos.html" style="text-decoration: none; background: #1a1512; padding: 2rem; border-radius: 12px; border: 1px solid rgba(255,255,255,0.05); transition: transform 0.3s ease;">
+              <h3 style="color: var(--color-dorado, #d4af37); font-size: 1.3rem; margin-bottom: 1rem;">🛡️ Cuidados de la Piel y Alimentación</h3>
+              <p style="color: #e0d5c1; font-size: 0.95rem; line-height: 1.5; margin: 0;">Descubre las rutinas dermatológicas exactas y la dieta premium que requiere la variedad sin pelo para mantener su salud óptima.</p>
+            </a>
+
+            <a href="blog/guia-tallas-xoloitzcuintle.html" style="text-decoration: none; background: #1a1512; padding: 2rem; border-radius: 12px; border: 1px solid rgba(255,255,255,0.05); transition: transform 0.3s ease;">
+              <h3 style="color: var(--color-dorado, #d4af37); font-size: 1.3rem; margin-bottom: 1rem;">📏 Guía de Tallas: Estándar a Miniatura</h3>
+              <p style="color: #e0d5c1; font-size: 0.95rem; line-height: 1.5; margin: 0;">Comprende las diferencias morfológicas, de espacio y genética entre el Xoloitzcuintle Miniatura, Intermedio y Estándar.</p>
+            </a>
+
+            <a href="blog/xoloitzcuintle-temperamento.html" style="text-decoration: none; background: #1a1512; padding: 2rem; border-radius: 12px; border: 1px solid rgba(255,255,255,0.05); transition: transform 0.3s ease;">
+              <h3 style="color: var(--color-dorado, #d4af37); font-size: 1.3rem; margin-bottom: 1rem;">🧠 Temperamento y Socialización</h3>
+              <p style="color: #e0d5c1; font-size: 0.95rem; line-height: 1.5; margin: 0;">Conoce la psicología del perro guardián prehispánico. Inteligencia, apego a la familia y cómo socializarlos correctamente.</p>
+            </a>
+          </div>
+        </div>
+      </section>
+
       <section class="cta-section">
         <div class="container">
           <h2>¿Listo para recibir a un compañero ancestral?</h2>

--- a/xolos-disponibles.html
+++ b/xolos-disponibles.html
@@ -352,6 +352,11 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
     </div>
     <div class="puppy-card__content">
       <h3 class="puppy-card__name">Teyolia Ramirez</h3>
+      <div style="margin-bottom: 1rem;">
+        <span style="background: linear-gradient(145deg, var(--color-dorado, #d4af37), #f5d061); color: #111; font-weight: 800; font-size: 0.75rem; text-transform: uppercase; padding: 0.3rem 0.8rem; border-radius: 999px; display: inline-flex; align-items: center; gap: 0.4rem; box-shadow: 0 2px 10px rgba(212, 175, 55, 0.4);">
+          ✨ Tamaño Miniatura Exclusivo
+        </span>
+      </div>
       <ul class="puppy-card__details">
         <li><strong>Edad</strong> 2 meses</li>
         <li><strong>Género</strong> Hembra</li>


### PR DESCRIPTION
### Motivation
- Improve on‑page E‑E‑A‑T signals and distribute homepage authority to existing long‑tail articles about care, sizes and temperament. 
- Make the “Miniatura” size immediately visible in the puppy catalogue so users and search engines can detect that keyword quickly.

### Description
- Injected an authority “Guía Definitiva y Cuidados” section into `index.html` linking to `blog/cuidados-basicos.html`, `blog/guia-tallas-xoloitzcuintle.html` and `blog/xoloitzcuintle-temperamento.html` with inline styling to match the site aesthetic.  
- Added an inline visual badge block above the `Teyolia Ramirez` card name in `xolos-disponibles.html` that reads “✨ Tamaño Miniatura Exclusivo”.
- Changes are localized to `index.html` and `xolos-disponibles.html` and use inline styles to ensure immediate visual impact without altering global CSS.

### Testing
- Verified both HTML files parse with `python3` using `html.parser` which completed without errors.  
- Served the site locally with `python3 -m http.server 4173` and captured full‑page screenshots using Playwright after running `npx --yes playwright install` and `npx --yes playwright install-deps chromium`.  
- Playwright screenshot commands completed and produced `/tmp/xolosramirez-index.png` and `/tmp/xolosramirez-disponibles.png`, indicating the injected section and badge render successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fcdbeb903083329bcc2cb5dfff5383)