### PR TITLE
Add canonical/hreflang + English SEO copy and lazy-load noscript iframe

### DIFF
--- a/en/available-xolos.html
+++ b/en/available-xolos.html
@@ -8,7 +8,13 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
 })(window,document,'script','dataLayer','GTM-MGTMWN7T');</script>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Available Xolos - Xolos Ramírez</title>
+  <title>Available Xoloitzcuintli Puppies for Sale | Xolos Ramírez</title>
+  <meta name="description" content="Meet our available Xoloitzcuintli puppies. Standard, intermediate, and miniature sizes available. Health certified, NFT lineage, and safe shipping to the US & Canada.">
+
+  <link rel="canonical" href="https://xolosramirez.com/en/available-xolos.html">
+  <link rel="alternate" hreflang="en" href="https://xolosramirez.com/en/available-xolos.html">
+  <link rel="alternate" hreflang="es" href="https://xolosramirez.com/xolos-disponibles.html">
+  <link rel="alternate" hreflang="x-default" href="https://xolosramirez.com/xolos-disponibles.html">
   <link rel="stylesheet" href="../css/styles.css">
   <link href="https://unpkg.com/aos@2.3.1/dist/aos.css" rel="stylesheet">
 </head>

--- a/en/index.html
+++ b/en/index.html
@@ -10,11 +10,8 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
     <!-- End Google Tag Manager -->
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>Xolos Ramirez | Community dedicated to the Xoloitzcuintle</title>
-    <meta
-      name="description"
-      content="Discover the Xolos Ramirez community: history, responsible adoptions, a gallery, and stories about the xoloitzcuintle in Mexico."
-    />
+    <title>Premium Xoloitzcuintli Breeder | Xolos Ramírez Mexico</title>
+    <meta name="description" content="Discover Xolos Ramírez, a premier Xoloitzcuintli breeder in Mexico. We preserve the miniature, intermediate, and standard hairless dog. Safe shipping to USA and Canada.">
     <meta
       name="keywords"
       content="xoloitzcuintle, xolo, responsible adoption, Mexican hairless dog, xolo community, Mexican culture"
@@ -33,9 +30,10 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
       content="Discover the Xolos Ramirez community: history, responsible adoptions, a gallery, and stories about the xoloitzcuintle in Mexico."
     />
     <meta name="twitter:image" content="https://www.xolosramirez.com/img/hero/site-hero.jpg" />
-    <link rel="alternate" hreflang="es" href="https://www.xolosramirez.com/index.html" />
-    <link rel="alternate" hreflang="en" href="https://www.xolosramirez.com/en/index.html" />
-    <link rel="alternate" hreflang="x-default" href="https://www.xolosramirez.com/index.html" />
+    <link rel="canonical" href="https://xolosramirez.com/en/index.html">
+    <link rel="alternate" hreflang="en" href="https://xolosramirez.com/en/index.html">
+    <link rel="alternate" hreflang="es" href="https://xolosramirez.com/index.html">
+    <link rel="alternate" hreflang="x-default" href="https://xolosramirez.com/index.html">
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
     <link
@@ -51,6 +49,7 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
     <noscript>
       <iframe
         src="https://www.googletagmanager.com/ns.html?id=GTM-MGTMWN7T"
+        loading="lazy"
         height="0"
         width="0"
         style="display: none; visibility: hidden"


### PR DESCRIPTION
### Motivation
- Ensure Google understands the relationship between English and Spanish pages and surface the correct language version for US/Canada searchers.
- Improve English landing snippet copy to increase ad and organic CTR for the sales page.
- Reduce non-critical iframe load on mobile by deferring the noscript iframe.

### Description
- Updated `en/index.html` to set a conversion-focused `<title>` and `<meta name="description">`, added a `<link rel="canonical">` and `hreflang` alternates for `en`, `es`, and `x-default`. 
- Updated `en/available-xolos.html` to set a sales-focused `<title>` and `<meta name="description">`, and added a `<link rel="canonical">` plus `hreflang` alternates pointing to the English and Spanish landing URLs.
- Added `loading="lazy"` to the noscript Google Tag Manager `<iframe>` in the English homepage to defer a non-critical iframe.
- Changes applied only to `en/index.html` and `en/available-xolos.html` to preserve existing Spanish URLs and hero iframe behavior.

### Testing
- Ran an HTMLParser smoke test that successfully parsed `en/index.html` and `en/available-xolos.html` with no errors. 
- Ran a string-validation script that confirmed the presence of the new `<title>`, `<meta name="description">`, `<link rel="canonical">`, and `hreflang` entries in both files and confirmed `loading="lazy"` was added where expected, and all checks passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fe1311b2fc8332917b925f27813205)