### PR TITLE
Scroll automático al Show en Vivo

### DIFF
--- a/xolos-disponibles.html
+++ b/xolos-disponibles.html
@@ -172,7 +172,7 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
         </div>
       </section>
 
-      <section class="live-show section" data-aos="fade-up" data-aos-duration="1000" data-aos-delay="90">
+      <section class="live-show section section-live-show" data-aos="fade-up" data-aos-duration="1000" data-aos-delay="90">
         <div class="container live-show__container">
           <div class="live-show__content">
             <span class="live-show__eyebrow">En vivo</span>
@@ -718,16 +718,16 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
       AOS.init({ once: true, duration: 700, offset: 60, easing: 'ease-out' });
     </script>
     <script>
+      // Scroll automático hacia la sección del Show en Vivo
       document.addEventListener("DOMContentLoaded", function() {
         setTimeout(function() {
-          const seccionDestacados = document.getElementById("perfiles-destacados");
-          if (seccionDestacados) {
-            seccionDestacados.scrollIntoView({
-              behavior: "smooth",
-              block: "start"
-            });
+          // Buscamos directamente la clase de la sección del show
+          const showSection = document.querySelector('.section-live-show');
+          if (showSection) {
+            // Hacemos el scroll suave hacia esa sección
+            showSection.scrollIntoView({ behavior: 'smooth', block: 'start' });
           }
-        }, 800);
+        }, 3500); // Se activa a los 3.5 segundos (puedes ajustar este número)
       });
     </script>
   </body>


### PR DESCRIPTION
### Motivación
- Evitar que la página haga scroll hacia la sección de perfiles destacados y en su lugar aterrizar directamente en el reproductor del Show para mejorar la experiencia de usuario.

### Descripción
- Se añadió la clase `section-live-show` al elemento de la sección del Show en Vivo para poder identificarla con un selector CSS.
- Se reemplazó el script de auto-scroll para buscar `document.querySelector('.section-live-show')` y ejecutar `scrollIntoView({ behavior: 'smooth', block: 'start' })` después de `3500` milisegundos.
- Se eliminó la lógica anterior que hacía scroll hacia el elemento con `id="perfiles-destacados"` para evitar scrolls conflictivos.

### Testing
- Se ejecutaron aserciones estáticas con un script de `python3` que verificó la presencia de la clase `section-live-show`, el selector usado, el retardo de `3500` ms y la ausencia del antiguo `getElementById("perfiles-destacados")`, y todas pasaron.
- Se ejecutó `git diff --check` para validar el diff y no se reportaron errores.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fe410d24708332b7a3dd68588eb568)