### PR TITLE
Add swipe indicator overlay to gallery cards

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -1543,3 +1543,47 @@ form textarea:focus {
   font-size: 1.5rem;
   margin-bottom: 10px;
 }
+/* =========================================
+   INDICADOR DE SWIPE PARA GALERÍAS
+   ========================================= */
+.swipe-indicator {
+  position: absolute;
+  bottom: 15px;
+  right: 15px;
+  background: rgba(17, 17, 17, 0.75);
+  color: #d4af37; /* Dorado Xolo */
+  padding: 6px 12px;
+  border-radius: 20px;
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  font-size: 0.7rem;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.5px;
+  z-index: 10;
+  pointer-events: none; /* Evita que bloquee el deslizamiento con el dedo */
+  border: 1px solid rgba(212, 175, 55, 0.3);
+  backdrop-filter: blur(4px);
+  animation: swipe-bounce 2s infinite;
+}
+
+.swipe-indicator svg {
+  width: 14px;
+  height: 14px;
+}
+
+/* Animación sutil de rebote hacia la derecha */
+@keyframes swipe-bounce {
+  0%, 20%, 50%, 80%, 100% { transform: translateX(0); }
+  40% { transform: translateX(6px); }
+  60% { transform: translateX(3px); }
+}
+
+/* Ocultar en pantallas muy grandes si prefieres que solo se vea en móviles
+(Opcional: borra esto si quieres que se vea también en PC) */
+@media (min-width: 1024px) {
+  .swipe-indicator {
+    display: none;
+  }
+}

--- a/xolos-disponibles.html
+++ b/xolos-disponibles.html
@@ -247,6 +247,11 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
     <div class="puppy-card__image-wrapper">
       <span class="puppy-card__status status-disponible">Disponible</span>
 
+      <div class="swipe-indicator" aria-hidden="true">
+        <span>Desliza</span>
+        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M5 12h14M12 5l7 7-7 7"/></svg>
+      </div>
+
       <div style="display: flex; overflow-x: auto; scroll-snap-type: x mandatory; scrollbar-width: none; -ms-overflow-style: none;">
         <style>
           /* Ocultar barra de scroll para mantener la estética limpia */
@@ -291,6 +296,11 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
        <!--
       <span class="puppy-card__status" style="top: 40px; background-color: #ff4d4d; color: #fff;">🔥 1 personas preguntando</span>
       -->
+
+      <div class="swipe-indicator" aria-hidden="true">
+        <span>Desliza</span>
+        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M5 12h14M12 5l7 7-7 7"/></svg>
+      </div>
 
       <div style="display: flex; overflow-x: auto; scroll-snap-type: x mandatory; scrollbar-width: none; -ms-overflow-style: none;">
         <style>
@@ -381,6 +391,11 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
       <span class="puppy-card__status" style="top: 40px; background-color: #ff4d4d; color: #fff;">🔥 3 personas preguntando</span>
       -->
 
+      <div class="swipe-indicator" aria-hidden="true">
+        <span>Desliza</span>
+        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M5 12h14M12 5l7 7-7 7"/></svg>
+      </div>
+
       <div style="display: flex; overflow-x: auto; scroll-snap-type: x mandatory; scrollbar-width: none; -ms-overflow-style: none;">
         <style>
           /* Ocultar barra de scroll en navegadores webkit para que luzca limpio */
@@ -456,6 +471,11 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
       <span class="puppy-card__status status-disponible">Reservada</span>
       <span class="puppy-card__status" style="top: 40px; background-color: #555; color: #fff;">🍼 Reserva abierta</span>
 <span class="puppy-card__status" style="top: 40px; background-color: #ff4d4d; color: #fff;">por Eduardo Téllez</span>
+
+      <div class="swipe-indicator" aria-hidden="true">
+        <span>Desliza</span>
+        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M5 12h14M12 5l7 7-7 7"/></svg>
+      </div>
 
       <div style="display: flex; overflow-x: auto; scroll-snap-type: x mandatory; scrollbar-width: none; -ms-overflow-style: none;">
         <style>


### PR DESCRIPTION
### Motivation
- Mejorar la usabilidad de las galerías móviles indicando que las fotos son deslizable sin romper la estética premium del sitio.
- Mantener un indicador discreto y consistente con la paleta dorada y fondo oscuro del diseño existente.

### Description
- Añadido un bloque de estilos `swipe-indicator` en `css/styles.css` que define la píldora oscura semitransparente, texto dorado, `backdrop-filter`, `pointer-events: none` y la animación `@keyframes swipe-bounce`.
- Insertado el bloque HTML del indicador (`<div class="swipe-indicator" aria-hidden="true">…</div>`) dentro de `xolos-disponibles.html` justo después de las etiquetas de estado y antes del contenedor desplazable en los perfiles con carrusel: `Ozomatli Ramirez`, `Nox Ramirez`, `Ónix Ramirez` y `Luna Ramirez`.
- El CSS incluye una media query para ocultar el indicador en pantallas anchas (`@media (min-width: 1024px)`), manteniendo la visibilidad en móviles.

### Testing
- Ejecutado `git diff --check`, que no reportó errores y pasó correctamente.
- Ejecutado un script de validación en `python3` que verificó que existen exactamente 4 instancias de `class="swipe-indicator"` y que el CSS contiene `.swipe-indicator` y `@keyframes swipe-bounce`, y la validación pasó.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ff4949b91c833282fc77313ca03de8)