### PR TITLE
Agregar sección "Historia Viva" con video en la página principal

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -1379,6 +1379,10 @@ form textarea:focus {
   box-shadow: var(--sombra-suave);
 }
 
+.live-show--about .live-show__container{
+  grid-template-columns: minmax(0, 1.1fr) minmax(0, 0.9fr);
+}
+
 .live-show__content h2{
   margin: 0.4rem 0 1rem;
 }
@@ -1386,6 +1390,32 @@ form textarea:focus {
 .live-show__content p{
   margin: 0;
   max-width: 54ch;
+  color: var(--color-texto-suave);
+}
+
+.live-show__details{
+  display:grid;
+  gap:1rem;
+  margin-top:1.5rem;
+}
+
+.live-show__callout{
+  padding:1rem;
+  background: rgba(212, 175, 55, 0.05);
+  border-left: 3px solid var(--color-dorado);
+}
+
+.live-show__callout h4{
+  margin:0 0 0.5rem;
+  font-size:0.9rem;
+}
+
+.live-show__callout p,
+.live-show__mission{
+  font-size:0.85rem;
+}
+
+.live-show__mission{
   color: var(--color-texto-suave);
 }
 
@@ -1468,10 +1498,28 @@ form textarea:focus {
 @media (max-width: 900px){
   .live-show__container{
     grid-template-columns: 1fr;
+    text-align: center;
+    padding: 1.5rem;
+  }
+
+  .live-show--about .live-show__container{
+    grid-template-columns: 1fr;
   }
 
   .live-show__content p{
     max-width: none;
+  }
+
+  .live-show__eyebrow{
+    justify-content: center;
+  }
+
+  .live-show__eyebrow::before{
+    display:none;
+  }
+
+  .live-show__callout{
+    text-align: left;
   }
 }
 

--- a/index.html
+++ b/index.html
@@ -123,22 +123,48 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
         </div>
       </section>
 
-      <section class="trust-mobile" data-aos="fade-up" data-aos-duration="900">
-        <p>✔️ Criadero documentado · ✔️ Acompañamiento real · ✔️ Entregas nacionales e internacionales</p>
+      <section class="live-show live-show--about" data-aos="fade-up" data-aos-duration="1000">
+        <div class="container">
+          <div class="live-show__container">
+            <div class="live-show__frame">
+              <div class="live-show__badge">
+                <span class="live-show__dot" aria-hidden="true"></span>
+                Historia Viva
+              </div>
+              <div class="live-show__video">
+                <iframe
+                  src="https://www.youtube.com/embed/0Z6luzI6TpY"
+                  title="Xolos Ramírez: Historia y Propósito"
+                  allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
+                  allowfullscreen
+                ></iframe>
+              </div>
+            </div>
+
+            <div class="live-show__content">
+              <span class="live-show__eyebrow">Nuestro Origen</span>
+              <h2>Xolos Ramírez: Guardianes de la Pirámide Viviente</h2>
+              <p>
+                Fundado por Fernando Ramírez y su familia, nuestro criadero es el resultado de más de 6 años de dedicación a la preservación del <strong>Xoloitzcuintle</strong>. Para nosotros, cada ejemplar es una "pirámide viviente" y un guardián del tiempo con más de 3,000 años de historia.
+              </p>
+              <div class="live-show__details">
+                <div class="callout live-show__callout">
+                  <h4>Linaje y Pedigrí Internacional</h4>
+                  <p>
+                    Construimos nuestra genealogía desde cero. Hoy, el apellido <strong>Ramírez</strong> es un sello de calidad en pedigríes azules internacionales avalados por la Federación Canófila Mexicana, garantizando trazabilidad total mediante microchip y tatuaje.
+                  </p>
+                </div>
+                <p class="live-show__mission">
+                  Nuestra misión trasciende fronteras: exportamos la cultura y el legado espiritual de México a familias en Europa, Asia y toda América.
+                </p>
+              </div>
+            </div>
+          </div>
+        </div>
       </section>
 
-      <section data-aos="fade-up" data-aos-duration="1000">
-        <h2>¿Quiénes somos?</h2>
-        <p>
-          Xolos Ramírez — Guardianes del linaje, criadores de historia viva.
-        </p>
-        <p> <strong>Nuestra Misión</strong>
-
-Conservación de la Raza: Creemos firmemente en la importancia de la conservación del Xoloitzcuintle, por lo que solo agregamos Xoloitzcuintles puros y registrados a nuestro programa de cría. Seleccionamos cuidadosamente parejas compatibles para asegurar la salud genética y el bienestar general de los cachorros.
-
-Crianza con Amor y Cuidado: Nuestro criadero es un hogar dedicado al amor y cuidado de los Xoloitzcuintles. Valoramos la autenticidad de la raza y nos esforzamos por contribuir a su legado ancestral.
-
-Selección de Ejemplares de Calidad: Seleccionamos cuidadosamente a los perros que forman parte de nuestro programa de cría, buscando preservar las características únicas y deseables del Xoloitzcuintle. </p>
+      <section class="trust-mobile" data-aos="fade-up" data-aos-duration="900">
+        <p>✔️ Criadero documentado · ✔️ Acompañamiento real · ✔️ Entregas nacionales e internacionales</p>
       </section>
 
       <section class="trust" data-aos="fade-up" data-aos-duration="1000" data-aos-delay="80">


### PR DESCRIPTION
### Motivation
- Integrar la sección “Sobre Nosotros” con un video de YouTube y una narrativa histórica para dar contexto al linaje y misión del criadero. 
- Mantener la coherencia visual con las variables y tipografías existentes (dorados, Cinzel/Poppins y efectos de profundidad). 
- Asegurar que el bloque sea responsivo y se comporte bien en escritorio y en móviles.

### Description
- Añadido un nuevo bloque HTML `section.live-show.live-show--about` con badge, `iframe` de YouTube y texto narrativo (mención de Fernando Ramírez, "pirámide viviente", pedigrí, microchip y misión internacional) en `index.html`. 
- Reemplazado el bloque de texto anterior por la nueva sección y reubicada la sección `trust-mobile` después del nuevo bloque para conservar el flujo de la página. 
- Agregadas reglas CSS en `css/styles.css` para soportar el layout específico del bloque mediante el modificador `.live-show--about`, además de estilos nuevos para `.live-show__details`, `.live-show__callout` y `.live-show__mission` para eliminar estilos inline y mejorar la accesibilidad visual. 
- Ajustes responsivos para móviles que centran la eyebrow, ocultan la decoración en móvil y mantienen el apilamiento de columnas a una única columna en pantallas pequeñas.

### Testing
- Ejecutado `git diff --check` para validar diferencias y verificar que no haya errores de espacio en blanco (resultado OK). 
- Parseado `index.html` con un pequeño script `python3` usando `html.parser.HTMLParser` para validar que el HTML sea sintácticamente parseable (resultado OK). 
- Verificado si hay tooling de navegador/headless con `which chromium || which chromium-browser || which google-chrome || which playwright` y comprobado que no había navegador/headless disponible en el entorno, por lo que no se generaron capturas automáticas de pantalla. 
- Revisado el estado del árbol de trabajo con `git status --short` y confirmado que los archivos modificados son `index.html` y `css/styles.css`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a00e702fe0c8332a8b4ffe386cc809c)