### PR TITLE
Fix English available Xolo card sliders

### DIFF
--- a/en/available-xolos.html
+++ b/en/available-xolos.html
@@ -439,26 +439,25 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
         <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M5 12h14M12 5l7 7-7 7"/></svg>
       </div>
     
-    <picture>
+    <div style="display: flex; overflow-x: auto; scroll-snap-type: x mandatory; scrollbar-width: none; -ms-overflow-style: none;">
+      <style>
+        .puppy-card__image-wrapper div::-webkit-scrollbar { display: none; }
+      </style>
       <img
         src="https://i.imgur.com/QigN5j6.jpeg"
-        alt="Xoloitzcuintli Mixa Ramirez"
+        alt="Xoloitzcuintli Mixa Ramirez 1"
         class="puppy-card__image"
         loading="lazy"
-        width="600"
-        height="450"
         style="flex: 0 0 100%; scroll-snap-align: start; object-fit: cover;"
       />
       <img
         src="https://i.imgur.com/tKlx8OO.jpeg"
-        alt="Xoloitzcuintli Mixa Ramirez"
+        alt="Xoloitzcuintli Mixa Ramirez 2"
         class="puppy-card__image"
         loading="lazy"
-        width="600"
-        height="450"
         style="flex: 0 0 100%; scroll-snap-align: start; object-fit: cover;"
       />
-    </picture>
+    </div>
   </div>
   <div class="puppy-card__content">
     <h3 class="puppy-card__name">Mixa Ramirez</h3>
@@ -469,10 +468,10 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
       <li><strong>Color</strong> Butterfly</li>
     </ul>
    <div class="puppy-video-container" style="margin: 1rem 0; border-radius: 8px; overflow: hidden; aspect-ratio: 16/9;">
-    <iframe width="100%" height="100%" src="https://www.youtube.com/embed/swT_Xkc7Kco" title="Onix Ramirez" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen loading="lazy"></iframe>
+    <iframe width="100%" height="100%" src="https://www.youtube.com/embed/swT_Xkc7Kco" title="Mixa Ramirez" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen loading="lazy"></iframe>
   </div>
   <div class="puppy-card__actions">
-      <a href="mailto:fernando@xolosramirez.com?subject=Interest in Mixa Ramirez&body=Hello, I would like to receive information about reserving Mixa Ramirez." class="btn-small btn-primary-small" onclick="dataLayer.push({ event: 'click_email', cachorro: 'Mixa Ramirez', source: 'xolos_disponibles_contactar' })">Contact by Email</a>
+      <a href="mailto:fernando@xolosramirez.com?subject=Interest in Mixa Ramirez&body=Hello, I would like to receive information about reserving Mixa Ramirez." class="btn-small btn-primary-small" onclick="dataLayer.push({ event: 'click_email', cachorro: 'Mixa Ramirez', source: 'available_xolos_contact_en' })">Contact by Email</a>
     </div>
   </div>
 </article>
@@ -481,30 +480,29 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
   <div class="puppy-card__image-wrapper">
     <span class="puppy-card__status status-disponible">Available</span>
      <div class="swipe-indicator" aria-hidden="true">
-        <span>Swap</span>
+        <span>Swipe</span>
         <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M5 12h14M12 5l7 7-7 7"/></svg>
       </div>
 
-    <picture>
+    <div style="display: flex; overflow-x: auto; scroll-snap-type: x mandatory; scrollbar-width: none; -ms-overflow-style: none;">
+      <style>
+        .puppy-card__image-wrapper div::-webkit-scrollbar { display: none; }
+      </style>
       <img
         src="https://i.imgur.com/ZPCGdKx.jpeg"
-        alt="Xoloitzcuintli Chimalma Ramirez."
+        alt="Xoloitzcuintli Chimalma Ramirez 1"
         class="puppy-card__image"
         loading="lazy"
-        width="600"
-        height="450"
         style="flex: 0 0 100%; scroll-snap-align: start; object-fit: cover;"
       />
       <img
         src="https://i.imgur.com/qtUQqos.jpeg"
-        alt="Xoloitzcuintli Chimalma Ramirez"
+        alt="Xoloitzcuintli Chimalma Ramirez 2"
         class="puppy-card__image"
         loading="lazy"
-        width="600"
-        height="450"
         style="flex: 0 0 100%; scroll-snap-align: start; object-fit: cover;"
       />
-    </picture>
+    </div>
   </div>
   <div class="puppy-card__content">
     <h3 class="puppy-card__name">Chimalma Ramirez</h3>
@@ -518,7 +516,7 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
     <iframe width="100%" height="100%" src="https://www.youtube.com/embed/7mRvkDOoHXk" title="Chimalma Ramirez" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen loading="lazy"></iframe>
   </div>
   <div class="puppy-card__actions">
-      <a href="mailto:fernando@xolosramirez.com?subject=Interest in Mixa Ramirez&body=Hello, I would like to receive information about reserving Mixa Ramirez." class="btn-small btn-primary-small" onclick="dataLayer.push({ event: 'click_email', cachorro: 'Mixa Ramirez', source: 'xolos_disponibles_contactar' })">Contact by Email</a>
+      <a href="mailto:fernando@xolosramirez.com?subject=Interest in Chimalma Ramirez&body=Hello, I would like to receive information about reserving Chimalma Ramirez." class="btn-small btn-primary-small" onclick="dataLayer.push({ event: 'click_email', cachorro: 'Chimalma Ramirez', source: 'available_xolos_contact_en' })">Contact by Email</a>
     </div>
   </div>
 </article>


### PR DESCRIPTION
### Motivation
- Restore consistent horizontal swipe behavior on the English listing cards for Mixa Ramirez and Chimalma Ramirez by removing the `<picture>` wrapper that prevented scrolling and align their markup and analytics with the rest of the cards.

### Description
- Updated `en/available-xolos.html` to replace the `<picture>` wrappers for Mixa and Chimalma with a horizontally scrollable flex container using `display: flex; overflow-x: auto; scroll-snap-type: x mandatory;` and a small rule to hide the scrollbar.
- Adjusted image `alt` texts to include `1`/`2`, preserved `loading="lazy"` and `scroll-snap-align` styles on images, and kept `object-fit: cover` behavior.
- Fixed the Mixa iframe `title` to `Mixa Ramirez`, corrected Chimalma’s swipe indicator text from `Swap` to `Swipe`, and updated both email action links to use the English analytics payload `source: 'available_xolos_contact_en'` with the correct `cachorro` names.

### Testing
- A Python assertion script verified that both cards no longer contain `<picture>`, include the `overflow-x: auto` container, include `<span>Swipe</span>`, and show the corrected analytics strings, and the checks passed.
- `rg` was used to inspect the file for the changed tokens (`Mixa Ramirez`, `Chimalma Ramirez`, `<picture>`, `Swap`, `available_xolos_contact_en`) and confirmed the replacements.
- `git diff --check` was executed to confirm there are no whitespace/diff-check issues and it returned clean results.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a07b5b660288332918aeb8b86cd9624)