### PR TITLE
Update WhatsApp links to new QR URL

### DIFF
--- a/contacto.html
+++ b/contacto.html
@@ -210,7 +210,7 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
 
     <a
       class="wa-float"
-      href="https://wa.me/message/435RTKGJLTX2J1"
+      href="https://wa.me/qr/5G35SPDG3AMRK1"
       target="_blank"
       rel="noopener noreferrer"
       data-gtm="whatsapp-floating"

--- a/en/available-xolos.html
+++ b/en/available-xolos.html
@@ -689,7 +689,7 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
       </div>
       <div>
         <h4>Social</h4>
-        <a href="https://wa.me/message/435RTKGJLTX2J1">WhatsApp</a><br>
+        <a href="https://wa.me/qr/5G35SPDG3AMRK1">WhatsApp</a><br>
         <a href="https://x.com/xolosArmy">Twitter/X</a>
       </div>
     </div>

--- a/import/jimdo-sitemap.html
+++ b/import/jimdo-sitemap.html
@@ -278,7 +278,7 @@ Xoloitzcuintle en nuestra Historia mexicana | Xolos Ramirez</a></li><li><a href=
             <a href="https://www.tiktok.com/@xolosramirezoficial" target="_blank" style="margin:0 10px;display:inline-block;"><img src="jimdo-sitemap_files/3046121.png" alt="TikTok" width="30" height="30"></a> <!-- X / Twitter -->
              <a href="https://x.com/xolosramirez1" target="_blank" style="margin:0 10px;display:inline-block;"><img src="jimdo-sitemap_files/3670151.png" alt="X (Twitter)" width="30" height="30"></a> <!-- YouTube -->
              <a href="https://www.youtube.com/c/XolosRamirez" target="_blank" style="margin:0 10px;display:inline-block;"><img src="jimdo-sitemap_files/1384060.png" alt="YouTube" width="30" height="30"></a> <!-- WhatsApp -->
-             <a href="https://wa.me/message/435RTKGJLTX2J1" target="_blank" style="margin:0 10px;display:inline-block;"><img src="jimdo-sitemap_files/733585.png" alt="WhatsApp" width="30" height="30"></a> <!-- Snapchat (fantasmita blanco sobre amarillo) -->
+             <a href="https://wa.me/qr/5G35SPDG3AMRK1" target="_blank" style="margin:0 10px;display:inline-block;"><img src="jimdo-sitemap_files/733585.png" alt="WhatsApp" width="30" height="30"></a> <!-- Snapchat (fantasmita blanco sobre amarillo) -->
              <a href="https://www.snapchat.com/add/xolos_ramirez?share_id=hsgphr8jjdg&amp;locale=es-MX" target="_blank" style="margin:0 10px;display:inline-block;"><img src="jimdo-sitemap_files/Rk3Vks0.png" alt="Snapchat" width="30" height="30"></a> <!-- Pixelfed -->
              <a href="https://xolosramirez.club/xolosramirez" target="_blank" rel="me" style="margin:0 10px;display:inline-block;"><img src="jimdo-sitemap_files/Instagram_icon.png" alt="Pixelfed" width="30" height="30"></a>
         </div>

--- a/index.html
+++ b/index.html
@@ -432,7 +432,7 @@ NFTs de Linaje Xoloitzcuintle</a></li>
     </script>
     <a
       class="wa-float"
-      href="https://wa.me/message/435RTKGJLTX2J1"
+      href="https://wa.me/qr/5G35SPDG3AMRK1"
       target="_blank"
       rel="noopener noreferrer"
       data-gtm="whatsapp-floating"

--- a/public/xolos-disponibles.html
+++ b/public/xolos-disponibles.html
@@ -118,7 +118,7 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
           <p><strong>Estado:</strong> <span class="estado disponible">Disponible</span></p>
           <a
             class="btn-whatsapp"
-            href="https://wa.me/message/435RTKGJLTX2J1"
+            href="https://wa.me/qr/5G35SPDG3AMRK1"
             target="_blank"
             rel="noopener"
             data-gtm="whatsapp"
@@ -145,7 +145,7 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
           <p><strong>Estado:</strong> <span class="estado reservado">Reservado</span></p>
           <a
             class="btn-whatsapp"
-            href="https://wa.me/message/435RTKGJLTX2J1"
+            href="https://wa.me/qr/5G35SPDG3AMRK1"
             target="_blank"
             rel="noopener"
             data-gtm="whatsapp"
@@ -172,7 +172,7 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
           <p><strong>Estado:</strong> <span class="estado lista-espera">Lista de espera</span></p>
           <a
             class="btn-whatsapp"
-            href="https://wa.me/message/435RTKGJLTX2J1"
+            href="https://wa.me/qr/5G35SPDG3AMRK1"
             target="_blank"
             rel="noopener"
             data-gtm="whatsapp"
@@ -272,7 +272,7 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
           <a href="https://www.youtube.com/channel/UCKtNKCavbBmxtcdHSDd9BsA" target="_blank">YouTube</a><br>
           <a href="https://x.com/xolosArmy" target="_blank">Twitter</a><br>
           <a href="https://t.me/xolosramirez" target="_blank">Telegram</a><br>
-          <a href="https://wa.me/message/435RTKGJLTX2J1" target="_blank">WhatsApp</a>
+          <a href="https://wa.me/qr/5G35SPDG3AMRK1" target="_blank">WhatsApp</a>
         </p>
       </div>
     </div>

--- a/xolos-disponibles.html
+++ b/xolos-disponibles.html
@@ -287,7 +287,7 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
     <iframe width="100%" height="100%" src="https://www.youtube.com/embed/w9b_UIjRZiw" title="Ozomatli Ramirez" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen loading="lazy"></iframe>
   </div>
   <div class="puppy-card__actions">
-    <a href="https://wa.me/message/435RTKGJLTX2J1?text=Hola,%20estoy%20interesado%20en%20recibir%20informaci%C3%B3n%20para%20reservar%20a%20Ozomatli%20Ramirez" class="btn-small btn-primary-small" style="background-color: #25D366; border-color: #25D366; width: 100%; justify-content: center;">WhatsApp Directo 📲</a>
+    <a href="https://wa.me/qr/5G35SPDG3AMRK1?text=Hola,%20estoy%20interesado%20en%20recibir%20informaci%C3%B3n%20para%20reservar%20a%20Ozomatli%20Ramirez" class="btn-small btn-primary-small" style="background-color: #25D366; border-color: #25D366; width: 100%; justify-content: center;">WhatsApp Directo 📲</a>
   </div>
 </div>
   </article>
@@ -348,7 +348,7 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
     <iframe width="100%" height="100%" src="https://www.youtube.com/embed/BmeHIF8FKTM" title="Nox Ramirez" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen loading="lazy"></iframe>
   </div>
   <div class="puppy-card__actions">
-    <a href="https://wa.me/message/435RTKGJLTX2J1?text=Hola,%20me%20gustar%C3%ADa%20reservar%20a%20Nox%20Ramirez" class="btn-small btn-primary-small" style="background-color: #25D366; border-color: #25D366; width: 100%; justify-content: center;">WhatsApp Directo 📲</a>
+    <a href="https://wa.me/qr/5G35SPDG3AMRK1?text=Hola,%20me%20gustar%C3%ADa%20reservar%20a%20Nox%20Ramirez" class="btn-small btn-primary-small" style="background-color: #25D366; border-color: #25D366; width: 100%; justify-content: center;">WhatsApp Directo 📲</a>
   </div>
     </div>
   </article>
@@ -401,7 +401,7 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
     <iframe width="100%" height="100%" src="https://www.youtube.com/embed/BU9UAqBOn1g" title="Teyolia Ramirez" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen loading="lazy"></iframe>
   </div>
   <div class="puppy-card__actions">
-    <a href="https://wa.me/message/435RTKGJLTX2J1" class="btn-small btn-primary-small" style="background-color: #25D366; border-color: #25D366; width: 100%; justify-content: center;">WhatsApp Directo 📲</a>
+    <a href="https://wa.me/qr/5G35SPDG3AMRK1" class="btn-small btn-primary-small" style="background-color: #25D366; border-color: #25D366; width: 100%; justify-content: center;">WhatsApp Directo 📲</a>
   </div>
     </div>
   </article>
@@ -460,7 +460,7 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
     <iframe width="100%" height="100%" src="https://youtube.com/embed/GF1cuAVZ1Zw" title="Onix Ramirez" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen loading="lazy"></iframe>
   </div>
   <div class="puppy-card__actions">
-    <a href="https://wa.me/message/435RTKGJLTX2J1?text=Hola,%20estoy%20interesado%20en%20recibir%20informaci%C3%B3n%20para%20reservar%20a%20Onix%20Ramirez" class="btn-small btn-primary-small" style="background-color: #25D366; border-color: #25D366; width: 100%; justify-content: center;">WhatsApp Directo 📲</a>
+    <a href="https://wa.me/qr/5G35SPDG3AMRK1?text=Hola,%20estoy%20interesado%20en%20recibir%20informaci%C3%B3n%20para%20reservar%20a%20Onix%20Ramirez" class="btn-small btn-primary-small" style="background-color: #25D366; border-color: #25D366; width: 100%; justify-content: center;">WhatsApp Directo 📲</a>
   </div>
     </div>
   </article>
@@ -507,7 +507,7 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
     <iframe width="100%" height="100%" src="https://www.youtube.com/embed/7mRvkDOoHXk" title="Chimalma Ramirez" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen loading="lazy"></iframe>
   </div>
   <div class="puppy-card__actions">
-    <a href="https://wa.me/message/435RTKGJLTX2J1?text=Hola,%20estoy%20interesado%20en%20recibir%20informaci%C3%B3n%20para%20reservar%20a%20Chimalma%20Ramirez" class="btn-small btn-primary-small" style="background-color: #25D366; border-color: #25D366; width: 100%; justify-content: center;">WhatsApp Directo 📲</a>
+    <a href="https://wa.me/qr/5G35SPDG3AMRK1?text=Hola,%20estoy%20interesado%20en%20recibir%20informaci%C3%B3n%20para%20reservar%20a%20Chimalma%20Ramirez" class="btn-small btn-primary-small" style="background-color: #25D366; border-color: #25D366; width: 100%; justify-content: center;">WhatsApp Directo 📲</a>
   </div>
     </div>
   </article> 
@@ -551,7 +551,7 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
     <iframe width="100%" height="100%" src="https://www.youtube.com/embed/swT_Xkc7Kco" title="Mixa Ramirez" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen loading="lazy"></iframe>
   </div>
   <div class="puppy-card__actions">
-         <a href="https://wa.me/message/435RTKGJLTX2J1?text=Hola,%20estoy%20interesado%20en%20recibir%20informaci%C3%B3n%20para%20reservar%20a%20Mixa%20Ramirez" class="btn-small btn-primary-small" style="background-color: #25D366; border-color: #25D366; width: 100%; justify-content: center;">WhatsApp Directo 📲</a>
+         <a href="https://wa.me/qr/5G35SPDG3AMRK1?text=Hola,%20estoy%20interesado%20en%20recibir%20informaci%C3%B3n%20para%20reservar%20a%20Mixa%20Ramirez" class="btn-small btn-primary-small" style="background-color: #25D366; border-color: #25D366; width: 100%; justify-content: center;">WhatsApp Directo 📲</a>
   
     </div>
     </div>
@@ -781,7 +781,7 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
           <a href="https://www.youtube.com/channel/UCKtNKCavbBmxtcdHSDd9BsA">YouTube</a><br>
           <a href="https://x.com/xolosArmy">Twitter</a><br>
           <a href="https://t.me/xolosramirez">Telegram</a><br>
-          <a href="https://wa.me/message/435RTKGJLTX2J1">WhatsApp</a>
+          <a href="https://wa.me/qr/5G35SPDG3AMRK1">WhatsApp</a>
         </div>
       </div>
       <p class="copyright">© 2025 Xolos Ramírez. Todos los derechos reservados.</p>


### PR DESCRIPTION
### Motivation
- Replace the old WhatsApp message link `https://wa.me/message/435RTKGJLTX2J1` with the new QR URL `https://wa.me/qr/5G35SPDG3AMRK1` across the site to point users to the updated contact method. 
- Ensure all floating buttons, footer/social links and puppy-profile buttons use the new base URL while keeping any existing prefilled message text. 

### Description
- Updated WhatsApp floating buttons and footer links in `index.html` and `contacto.html` to use `https://wa.me/qr/5G35SPDG3AMRK1`. 
- Replaced the base WhatsApp URL in the puppy/profile pages and cards in `xolos-disponibles.html` and `public/xolos-disponibles.html`, preserving existing `?text=...` prefilled messages for each puppy. 
- Updated English/social sitemap entries in `en/available-xolos.html` and `import/jimdo-sitemap.html` to point to the new QR link. 

### Testing
- Ran `rg -n "https://wa\.me/message/435RTKGJLTX2J1" . -g '!node_modules'; test $? -eq 1` to confirm no remaining references to the old message URL, and it succeeded. 
- Verified presence of the new URL with `rg -n "https://wa\.me/qr/5G35SPDG3AMRK1" index.html contacto.html xolos-disponibles.html public/xolos-disponibles.html en/available-xolos.html import/jimdo-sitemap.html` and confirmed matches in the updated files. 
- Performed a scripted replace check that printed the modified files (`contacto.html`, `index.html`, `xolos-disponibles.html`, `public/xolos-disponibles.html`, `en/available-xolos.html`, `import/jimdo-sitemap.html`) and the check completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0903fef45c8332a0904b8062a5d6ca)