### PR TITLE
Agregar Tlaloc Ramírez a Teyolías activas

### DIFF
--- a/teyolias-guardiania.html
+++ b/teyolias-guardiania.html
@@ -259,9 +259,9 @@
     </div>
 
     <div class="grid grid-cols-1 md:grid-cols-2 gap-6">
-        <article class="rounded-2xl border border-amber-200 bg-amber-50 overflow-hidden shadow-sm md:col-span-2">
-            <div class="grid grid-cols-1 md:grid-cols-5 gap-0">
-                <div class="md:col-span-2 bg-stone-950 relative h-[28rem] md:h-full min-h-[430px]" data-carousel>
+        <article class="rounded-2xl border border-amber-200 bg-amber-50 overflow-hidden shadow-sm">
+            <div class="grid grid-cols-1 md:grid-cols-5 gap-0 h-full">
+                <div class="md:col-span-2 bg-stone-950 relative h-[28rem] md:h-full min-h-[430px]" data-carousel data-carousel-name="Tonatiuh Ramírez">
                     <div class="teyolia-carousel-track carousel-scrollbar-hidden" data-carousel-track aria-label="Fotos y video de Tonatiuh Ramírez">
                         <div class="teyolia-carousel-slide teyolia-carousel-image-slide" data-carousel-slide>
                             <img
@@ -329,6 +329,80 @@
                             class="inline-block bg-stone-900 text-amber-500 px-5 py-3 rounded-full font-bold hover:bg-amber-600 hover:text-stone-900 transition-all"
                         >
                             Ver Teyolía de Tonatiuh ✨
+                        </a>
+                    </div>
+                </div>
+            </div>
+        </article>
+
+        <article class="rounded-2xl border border-amber-200 bg-amber-50 overflow-hidden shadow-sm">
+            <div class="grid grid-cols-1 md:grid-cols-5 gap-0 h-full">
+                <div class="md:col-span-2 bg-stone-950 relative h-[28rem] md:h-full min-h-[430px]" data-carousel data-carousel-name="Tlaloc Ramírez">
+                    <div class="teyolia-carousel-track carousel-scrollbar-hidden" data-carousel-track aria-label="Fotos y video de Tlaloc Ramírez">
+                        <div class="teyolia-carousel-slide teyolia-carousel-image-slide" data-carousel-slide>
+                            <img
+                                src="https://i.imgur.com/PchQIix.jpeg"
+                                alt="Tlaloc Ramírez, Teyolía activa"
+                                loading="lazy"
+                            />
+                        </div>
+
+                        <div class="teyolia-carousel-slide teyolia-carousel-video-slide" data-carousel-slide>
+                            <iframe
+                                src="https://www.youtube.com/embed/4P7DCYJtKsY?playsinline=1"
+                                title="Video Tlaloc Ramírez"
+                                loading="lazy"
+                                allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share"
+                                referrerpolicy="strict-origin-when-cross-origin"
+                                allowfullscreen
+                            ></iframe>
+                        </div>
+                    </div>
+
+                    <button class="teyolia-carousel-button teyolia-carousel-button--prev" type="button" data-carousel-prev aria-label="Ver slide anterior de Tlaloc">
+                        ‹
+                    </button>
+                    <button class="teyolia-carousel-button teyolia-carousel-button--next" type="button" data-carousel-next aria-label="Ver slide siguiente de Tlaloc">
+                        ›
+                    </button>
+
+                    <div class="absolute bottom-4 left-0 right-0 flex flex-col items-center gap-3 pointer-events-none">
+                        <div class="teyolia-carousel-dots pointer-events-auto" data-carousel-dots aria-label="Paginación del carrusel de Tlaloc"></div>
+                        <div class="bg-black/60 text-amber-100 text-xs font-bold px-4 py-2 rounded-full backdrop-blur-md flex items-center gap-2 shadow-lg border border-amber-500/30">
+                            <span aria-hidden="true">↔</span> Desliza
+                        </div>
+                    </div>
+                </div>
+
+                <div class="md:col-span-3 p-6 text-left flex flex-col justify-center">
+                    <p class="text-xs uppercase tracking-widest text-amber-700 font-bold mb-2">
+                        Activa · 1 mes
+                    </p>
+
+                    <h4 class="text-2xl font-serif font-bold text-stone-900 mb-3">
+                        Tlaloc Ramírez
+                    </h4>
+
+                    <ul class="text-sm text-stone-700 space-y-1 mb-5">
+                        <li><strong>Edad:</strong> 1 año</li>
+                        <li><strong>Género:</strong> Macho</li>
+                        <li><strong>Talla:</strong> Estándar / Intermedio</li>
+                        <li><strong>Color:</strong> Mariposa / Gris</li>
+                    </ul>
+
+                    <p class="text-stone-700 text-sm leading-relaxed mb-5">
+                        Tlaloc es un hermoso ejemplar joven de un año de edad. Destaca por su gran nobleza y energía.
+                        Durante esta campaña, buscamos a la familia ideal que pueda guiar su camino.
+                    </p>
+
+                    <div>
+                        <a
+                            href="https://www.teyolia.cash/"
+                            target="_blank"
+                            rel="noopener noreferrer"
+                            class="inline-block bg-stone-900 text-amber-500 px-5 py-3 rounded-full font-bold hover:bg-amber-600 hover:text-stone-900 transition-all"
+                        >
+                            Ver Teyolía de Tlaloc ✨
                         </a>
                     </div>
                 </div>
@@ -437,12 +511,13 @@
 
             if (!track || slides.length === 0 || !dotsContainer) return;
 
+            const carouselName = carousel.getAttribute('data-carousel-name') || 'esta Teyolía';
             const dots = slides.map((_, index) => {
                 const dot = document.createElement('button');
                 dot.type = 'button';
                 dot.className = 'teyolia-carousel-dot';
                 dot.setAttribute('data-carousel-dot', String(index));
-                dot.setAttribute('aria-label', `Ir al slide ${index + 1} de Tonatiuh`);
+                dot.setAttribute('aria-label', `Ir al slide ${index + 1} de ${carouselName}`);
                 dot.addEventListener('click', () => {
                     track.scrollTo({ left: track.clientWidth * index, behavior: 'smooth' });
                 });


### PR DESCRIPTION
### Motivation
- Añadir la ficha de la nueva campaña Tlaloc Ramírez dentro del listado de Teyolías activas para que aparezca junto a Tonatiuh en pantallas grandes y apilada en móviles.

### Description
- Inserté un nuevo `<article>` con imagen y video incrustado (`/embed/4P7DCYJtKsY`) para Tlaloc Ramírez en `teyolias-guardiania.html` justo debajo del artículo de Tonatiuh.
- Modifiqué la tarjeta de Tonatiuh para que ya no abarque ambas columnas en desktop y así permitir el diseño de dos columnas (`grid grid-cols-1 md:grid-cols-2`).
- Añadí `data-carousel-name` a cada carrusel y actualicé el JavaScript de puntos del carrusel para usar el nombre configurado en la etiqueta y generar etiquetas accesibles (`aria-label`) dinámicas por tarjeta.
- Mantengo textos de relleno (talla, color, href del botón) para que se personalicen posteriormente.

### Testing
- Verifiqué por script que `Tlaloc Ramírez`, el `embed` de YouTube y `data-carousel-name="Tlaloc Ramírez"` aparecen en el HTML y que el layout de dos columnas no contiene la antigua `md:col-span-2` ocupando todo el ancho; la comprobación pasó.
- Ejecuté `git diff --check` para revisar problemas de formato y el chequeo no reportó errores.
- Levanté un servidor estático local con `python3 -m http.server` y capturé capturas de pantalla con Playwright para validar render en viewport grande, y la captura se generó correctamente.
- Todas las pruebas automáticas descritas concluyeron sin fallos.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a09da8147f08332aee8f6e5f2dcc462)