### PR TITLE
Add Humo Ramirez testimonial card

### DIFF
--- a/testimonios.html
+++ b/testimonios.html
@@ -149,6 +149,23 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
         <h2>Historias Reales</h2>
         <div class="grid" style="display: grid; grid-template-columns: repeat(auto-fit, minmax(300px, 1fr)); gap: 2rem; padding: 2rem 0;">
           
+          <article class="post-card">
+            <div class="video-container" style="position: relative; padding-bottom: 56.25%; height: 0; overflow: hidden;">
+              <iframe src="https://www.youtube.com/embed/ZytyCBXOjDQ?autoplay=1&mute=1&loop=1&playlist=ZytyCBXOjDQ" style="position: absolute; top: 0; left: 0; width: 100%; height: 100%; border: 0;" loading="lazy" allowfullscreen></iframe>
+            </div>
+            <div class="post-card__body">
+              <blockquote style="font-style: italic; margin-bottom: 1rem;">
+                <p>"Es un compañero leal y cariñoso que respeta el espacio personal."</p>
+                <p>"Percibe la energía de su entorno y se mimetiza con el estado de ánimo de su persona."</p>
+                <p>"Tiene una gran capacidad para relajarse cuando ella trabaja desde casa."</p>
+                <p>"Se tuvo que trabajar con un entrenador para dar confianza a Humo Ramírez al salir a la calle, debido a que el comportamiento de esta raza tiende a ser reservado."</p>
+                <p>"Son perros que conservan energía, no obedecen ciegamente por complacer y son selectivos tanto con humanos como con otros perros."</p>
+                <p>"Cuando se emociona, suele azotar o aplaudir con sus orejas."</p>
+              </blockquote>
+              <cite>— Luciana sobre el xoloitzcuintle Humo Ramirez</cite>
+            </div>
+          </article>
+
            <article class="post-card">
             <div class="video-container" style="position: relative; padding-bottom: 56.25%; height: 0; overflow: hidden;">
               <iframe src="https://www.youtube.com/embed/CaFq2rbF4Io&si=pgbJw5bhweJfCoAh?autoplay=1&mute=1&loop=1&playlist=CaFq2rbF4Io" style="position: absolute; top: 0; left: 0; width: 100%; height: 100%; border: 0;" loading="lazy" allowfullscreen></iframe>


### PR DESCRIPTION
### Motivation
- Agregar el testimonio de Luciana sobre Humo Ramirez a la sección `Historias Reales` para mostrar más historias de propietarios con el mismo formato visual que las demás tarjetas.
- Incrustar el video de YouTube en formato `embed` con los parámetros `autoplay`, `mute`, `loop` y `playlist` para mantener la experiencia audiovisual coherente con el resto del sitio.

### Description
- Se insertó un `article` con clase `post-card` dentro del `div.grid` de la sección `#historias-reales` que contiene el `iframe` de YouTube en formato `https://www.youtube.com/embed/ZytyCBXOjDQ?autoplay=1&mute=1&loop=1&playlist=ZytyCBXOjDQ`.
- El contenido textual quedó dentro de `div.post-card__body` usando un `blockquote` con las citas de Luciana y un `cite` para la atribución, manteniendo la estructura y clases usadas por las demás tarjetas.
- Se preservaron los estilos en línea de la contenedor de video (`.video-container`) para mantener la proporción 16:9 y la carga diferida con `loading="lazy"`.

### Testing
- Ejecutado `git diff --check` como verificación de formato y pasó correctamente.
- Ejecutado un chequeo rápido de parsing HTML con `python3` usando `html.parser` y el archivo se parseó sin errores.
- Generada una captura de pantalla con `npx --yes playwright@latest screenshot` de la página `http://127.0.0.1:8000/testimonios.html` y la imagen fue creada con éxito.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0a6e320ef88332a48e636d0d1d59d1)