### PR TITLE
Add NFT minting card to Xolos show blog post

### DIFF
--- a/blog/2026-05-17-the-xolos-ramirez-show.html
+++ b/blog/2026-05-17-the-xolos-ramirez-show.html
@@ -45,6 +45,23 @@
         <p style="margin-bottom: 1.5rem;">La salud del xoloitzcuintle exige cuidados especializados, especialmente en una urbe con climas cambiantes. Durante el programa se extendió una mención especial al uso de la medicina y cosmética natural de <em>xolosArmy</em>, tales como los bálsamos orgánicos, ceras protectoras y bloqueadores solares a base de ingredientes limpios que Luciana emplea diariamente para salvaguardar la delicada barrera cutánea de Humo Ramírez.</p>
 
         <p style="margin-bottom: 1.5rem;">Hacia el cierre del programa, Luciana Renner extendió una cálida invitación a toda la audiencia a derribar prejuicios, educarse sobre el linaje prehispánico y sumarse activamente a las próximas dinámicas de la comunidad de dueños informados. Compartió entusiasmada su deseo de integrar dinámicas comunitarias, tales como ceremonias tradicionales de <strong>Temazcal</strong> junto a nuestros guardianes caninos, consolidando así el puente viviente entre nuestra herencia histórica y el futuro digital de la comunidad de Xolos Ramírez.</p>
+
+        <h2 style="font-size: 1.8rem; margin: 2rem 0 1rem; color: #111;">Soberanía Digital: El NFT de la Crónica</h2>
+        <p style="margin-bottom: 1.5rem;">Como parte de la evolución tecnológica y el resguardo del linaje prehispánico en la era Web3, esta entrega de <strong>The Xolos Ramírez Show</strong> ha sido inmortalizada en la cadena de bloques. El minteo de este episodio no solo celebra la historia de Humo Ramírez, sino que consolida la soberanía digital de nuestra comunidad.</p>
+
+        <div class="nft-card" style="background: linear-gradient(135deg, #f9f6f0 0%, #f1ebdc 100%); border-left: 4px solid var(--primary-color, #b8860b); padding: 1.5rem; margin: 2rem 0; border-radius: 0 8px 8px 0; box-shadow: 0 2px 8px rgba(0,0,0,0.05);">
+          <div style="display: flex; align-items: center; margin-bottom: 0.75rem;">
+            <span style="font-size: 1.5rem; margin-right: 0.5rem;">💎</span>
+            <strong style="font-size: 1.1rem; color: #111; text-transform: uppercase; letter-spacing: 1px;">Registro de Autenticidad Web3</strong>
+          </div>
+          <p style="margin: 0 0 1rem 0; font-size: 0.95rem; color: #555; line-height: 1.6;">El identificador criptográfico (Hash de la transacción) garantiza que esta crónica y su sello sonoro forman parte del archivo histórico e inmutable de la <em>xolosArmy Network</em>.</p>
+          <div style="background: rgba(255,255,255,0.7); padding: 0.75rem; border-radius: 4px; border: 1px dashed #ccc; overflow-x: auto; font-family: monospace; font-size: 0.85rem; color: #333; margin-bottom: 1rem; white-space: nowrap;">
+            TX: 99c67c2e02f3ceba314c65cabd81c3c254b1ef6e110f82572e7ae8b438c65d37
+          </div>
+          <a href="https://explorer.xolosarmy.xyz/tx/99c67c2e02f3ceba314c65cabd81c3c254b1ef6e110f82572e7ae8b438c65d37" target="_blank" rel="noopener noreferrer" style="display: inline-flex; align-items: center; color: var(--primary-color, #b8860b); text-decoration: none; font-weight: bold; font-size: 0.95rem;">
+            Verificar Minteo en el Explorador <span style="margin-left: 0.25rem;">→</span>
+          </a>
+        </div>
       </div>
 
       <footer class="blog-post__footer" style="margin-top: 3rem; padding-top: 1.5rem; border-top: 1px solid #eee; text-align: center;">


### PR DESCRIPTION
### Motivation
- Add an elegant, integrated Web3/NFT minting notice to the article so readers can verify the episode's authenticity on-chain. 
- Keep the visual language consistent with the existing blog design while exposing the transaction hash and explorer link.

### Description
- Inserted a new `h2` titled "Soberanía Digital: El NFT de la Crónica" and accompanying explanatory paragraph into `blog/2026-05-17-the-xolos-ramirez-show.html`.
- Added a styled `div` `.nft-card` containing a Web3 authenticity label, the transaction hash (TX: `99c67c2e02f3ceba314c65cabd81c3c254b1ef6e110f82572e7ae8b438c65d37`) and a verification link to the explorer.
- Placed the block immediately before the closing of the `div.blog-post__content` so it appears just above the `<footer>`.
- Change is limited to the single HTML file `blog/2026-05-17-the-xolos-ramirez-show.html` (roughly 17 lines inserted).

### Testing
- Parsed the updated HTML with `python3` using `html.parser` to ensure syntactic validity, and the parse completed successfully.
- Render/screenshot test performed with Playwright after installing browsers and dependencies via `npx playwright install-deps chromium`, and `node screenshot.js` produced a screenshot file `nft-section-screenshot.png`, indicating the section rendered as expected.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0b22e611008332b7604e5c36fe6f73)