### PR TITLE
Agregar testimonio de Sandy y Luis en testimonios.html

### DIFF
--- a/testimonios.html
+++ b/testimonios.html
@@ -484,6 +484,20 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
             </div>
           </article>
 
+          <article class="post-card">
+            <div class="video-container" style="position: relative; padding-bottom: 56.25%; height: 0; overflow: hidden;">
+              <iframe src="https://www.youtube.com/embed/Lf0odZQ5eBk?autoplay=1&mute=1&loop=1&playlist=Lf0odZQ5eBk" style="position: absolute; top: 0; left: 0; width: 100%; height: 100%; border: 0;" loading="lazy" allowfullscreen></iframe>
+            </div>
+            <div class="post-card__body">
+              <blockquote style="font-style: italic; margin-bottom: 1rem;">
+                <p>"Realmente si ven correr a los Cholos son como liebres, o sea, realmente corren y brincan, entonces pueden aguantar bastantes distancias corriendo"</p>
+                <p>"Queríamos que realmente nuestra perrita estuviera todo el día con nosotros y que viajara con nosotros y estuviera en el carro, en la cama, en el sillón; entonces estábamos buscando un perro específico que fuera fácil de mantenimiento y fácil de limpiar"</p>
+                <p>"Todo el mundo nos chulea que tiene mejor piel que uno, o sea, que un humano; se la ven y dicen: 'bueno, tiene la piel más hidratada que muchas personas'"</p>
+              </blockquote>
+              <cite>— Sandy y Luis sobre las xoloitzcuintles Nusca y Cuzamá Ramirez</cite>
+            </div>
+          </article>
+
 
         </div>
       </section>


### PR DESCRIPTION
### Motivation
- Agregar el testimonio de Sandy y Luis junto al de Dayanara para ampliar la sección `id="historias-reales"` y mantener la estética de los videos con `iframe` responsivo en autoplay, mute y loop.

### Description
- Inserté un nuevo `<article class="post-card">` en `testimonios.html` con el `iframe` de YouTube `Lf0odZQ5eBk`, las tres citas dentro de un `blockquote` y el `cite` correspondiente, ubicado justo después del artículo de Dayanara y antes del cierre del contenedor.

### Testing
- Parseé el HTML con `HTMLParser` desde un pequeño script en `python` y verifiqué la presencia de la URL del `iframe` con otro script en `python`, y ambas comprobaciones fueron exitosas.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0b3c40ff1c8332a3c627dbabaefe88)