### PR TITLE
Actualizar enlaces de WhatsApp al nuevo enlace QR

### DIFF
--- a/contacto.html
+++ b/contacto.html
@@ -210,7 +210,7 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
 
     <a
       class="wa-float"
-      href="https://wa.me/message/435RTKGJLTX2J1"
+      href="https://wa.me/qr/R2F5PRQYZSJOA1"
       target="_blank"
       rel="noopener noreferrer"
       data-gtm="whatsapp-floating"

--- a/index.html
+++ b/index.html
@@ -435,7 +435,7 @@ NFTs de Linaje Xoloitzcuintle</a></li>
     </script>
     <a
       class="wa-float"
-      href="https://wa.me/message/435RTKGJLTX2J1"
+      href="https://wa.me/qr/R2F5PRQYZSJOA1"
       target="_blank"
       rel="noopener noreferrer"
       data-gtm="whatsapp-floating"

--- a/teyolias-guardiania.html
+++ b/teyolias-guardiania.html
@@ -560,7 +560,7 @@
     </script>
 <a
       class="wa-float"
-      href="https://wa.me/message/435RTKGJLTX2J1"
+      href="https://wa.me/qr/R2F5PRQYZSJOA1"
       target="_blank"
       rel="noopener noreferrer"
       data-gtm="whatsapp-floating"

--- a/xolos-disponibles.html
+++ b/xolos-disponibles.html
@@ -287,7 +287,7 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
     <iframe width="100%" height="100%" src="https://www.youtube.com/embed/w9b_UIjRZiw" title="Ozomatli Ramirez" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen loading="lazy"></iframe>
   </div>
   <div class="puppy-card__actions">
-    <a href="https://wa.me/message/435RTKGJLTX2J1?text=Hola,%20estoy%20interesado%20en%20recibir%20informaci%C3%B3n%20para%20reservar%20a%20Ozomatli%20Ramirez" class="btn-small btn-primary-small" style="background-color: #25D366; border-color: #25D366; width: 100%; justify-content: center;">WhatsApp Directo 📲</a>
+    <a href="https://wa.me/qr/R2F5PRQYZSJOA1?text=Hola,%20estoy%20interesado%20en%20recibir%20informaci%C3%B3n%20para%20reservar%20a%20Ozomatli%20Ramirez" class="btn-small btn-primary-small" style="background-color: #25D366; border-color: #25D366; width: 100%; justify-content: center;">WhatsApp Directo 📲</a>
   </div>
 </div>
   </article>
@@ -348,7 +348,7 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
     <iframe width="100%" height="100%" src="https://www.youtube.com/embed/BmeHIF8FKTM" title="Nox Ramirez" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen loading="lazy"></iframe>
   </div>
   <div class="puppy-card__actions">
-    <a href="https://wa.me/message/435RTKGJLTX2J1?text=Hola,%20me%20gustar%C3%ADa%20reservar%20a%20Nox%20Ramirez" class="btn-small btn-primary-small" style="background-color: #25D366; border-color: #25D366; width: 100%; justify-content: center;">WhatsApp Directo 📲</a>
+    <a href="https://wa.me/qr/R2F5PRQYZSJOA1?text=Hola,%20me%20gustar%C3%ADa%20reservar%20a%20Nox%20Ramirez" class="btn-small btn-primary-small" style="background-color: #25D366; border-color: #25D366; width: 100%; justify-content: center;">WhatsApp Directo 📲</a>
   </div>
     </div>
   </article>
@@ -401,7 +401,7 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
     <iframe width="100%" height="100%" src="https://www.youtube.com/embed/T70O2-REbhg" title="Teyolia Ramirez" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen loading="lazy"></iframe>
   </div>
   <div class="puppy-card__actions">
-    <a href="https://wa.me/message/435RTKGJLTX2J1" class="btn-small btn-primary-small" style="background-color: #25D366; border-color: #25D366; width: 100%; justify-content: center;">WhatsApp Directo 📲</a>
+    <a href="https://wa.me/qr/R2F5PRQYZSJOA1" class="btn-small btn-primary-small" style="background-color: #25D366; border-color: #25D366; width: 100%; justify-content: center;">WhatsApp Directo 📲</a>
   </div>
     </div>
   </article>
@@ -461,7 +461,7 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
     <iframe width="100%" height="100%" src="https://www.youtube.com/embed/_2EGfG77VhE" title="Onix Ramirez" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen loading="lazy"></iframe>
   </div>
   <div class="puppy-card__actions">
-    <a href="https://wa.me/message/435RTKGJLTX2J1?text=Hola,%20estoy%20interesado%20en%20recibir%20informaci%C3%B3n%20para%20reservar%20a%20Onix%20Ramirez" class="btn-small btn-primary-small" style="background-color: #25D366; border-color: #25D366; width: 100%; justify-content: center;">WhatsApp Directo 📲</a>
+    <a href="https://wa.me/qr/R2F5PRQYZSJOA1?text=Hola,%20estoy%20interesado%20en%20recibir%20informaci%C3%B3n%20para%20reservar%20a%20Onix%20Ramirez" class="btn-small btn-primary-small" style="background-color: #25D366; border-color: #25D366; width: 100%; justify-content: center;">WhatsApp Directo 📲</a>
   </div>
     </div>
   </article>
@@ -516,7 +516,7 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
     <iframe width="100%" height="100%" src="https://www.youtube.com/embed/0qcQvELxVpU" title="Chimalma Ramirez" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen loading="lazy"></iframe>
   </div>
   <div class="puppy-card__actions">
-    <a href="https://wa.me/message/435RTKGJLTX2J1?text=Hola,%20estoy%20interesado%20en%20recibir%20informaci%C3%B3n%20para%20reservar%20a%20Chimalma%20Ramirez" class="btn-small btn-primary-small" style="background-color: #25D366; border-color: #25D366; width: 100%; justify-content: center;">WhatsApp Directo 📲</a>
+    <a href="https://wa.me/qr/R2F5PRQYZSJOA1?text=Hola,%20estoy%20interesado%20en%20recibir%20informaci%C3%B3n%20para%20reservar%20a%20Chimalma%20Ramirez" class="btn-small btn-primary-small" style="background-color: #25D366; border-color: #25D366; width: 100%; justify-content: center;">WhatsApp Directo 📲</a>
   </div>
     </div>
   </article> 
@@ -561,7 +561,7 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
     <iframe width="100%" height="100%" src="https://www.youtube.com/embed/swT_Xkc7Kco" title="Mixa Ramirez" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen loading="lazy"></iframe>
   </div>
   <div class="puppy-card__actions">
-         <a href="https://wa.me/message/435RTKGJLTX2J1?text=Hola,%20estoy%20interesado%20en%20recibir%20informaci%C3%B3n%20para%20reservar%20a%20Mixa%20Ramirez" class="btn-small btn-primary-small" style="background-color: #25D366; border-color: #25D366; width: 100%; justify-content: center;">WhatsApp Directo 📲</a>
+         <a href="https://wa.me/qr/R2F5PRQYZSJOA1?text=Hola,%20estoy%20interesado%20en%20recibir%20informaci%C3%B3n%20para%20reservar%20a%20Mixa%20Ramirez" class="btn-small btn-primary-small" style="background-color: #25D366; border-color: #25D366; width: 100%; justify-content: center;">WhatsApp Directo 📲</a>
   
     </div>
     </div>
@@ -608,7 +608,7 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
         <li><strong>Color</strong> Negro</li>
       </ul>
       <div class="puppy-card__actions">
-        <a href="https://wa.me/message/435RTKGJLTX2J1" class="btn-small btn-outline-small" target="_blank" rel="noopener">Ver video Personalidad Xolo 🎥</a>
+        <a href="https://wa.me/qr/R2F5PRQYZSJOA1" class="btn-small btn-outline-small" target="_blank" rel="noopener">Ver video Personalidad Xolo 🎥</a>
         
       </div>
     </div>
@@ -810,7 +810,7 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
 
  <a
       class="wa-float"
-      href="https://wa.me/message/435RTKGJLTX2J1"
+      href="https://wa.me/qr/R2F5PRQYZSJOA1"
       target="_blank"
       rel="noopener noreferrer"
       data-gtm="whatsapp-floating"


### PR DESCRIPTION
### Motivation
- Actualizar el enlace de contacto de WhatsApp para apuntar al nuevo QR en lugar del enlace directo anterior.
- Asegurar que todos los botones y enlaces relevantes en las páginas públicas utilicen el nuevo enlace para mantener coherencia y seguimiento.

### Description
- Reemplazado `https://wa.me/message/435RTKGJLTX2J1` por `https://wa.me/qr/R2F5PRQYZSJOA1` en las páginas afectadas.
- Archivos modificados: `index.html`, `contacto.html`, `teyolias-guardiania.html` y `xolos-disponibles.html`.
- Actualizadas tanto las instancias del botón flotante de WhatsApp como los enlaces de "WhatsApp Directo" que incluían parámetros `?text=`.

### Testing
- Ejecutada búsqueda con `rg -n "wa\.me/message/435RTKGJLTX2J1|wa\.me/qr/R2F5PRQYZSJOA1|whatsapp" .` y verificado que las ocurrencias ahora apuntan al nuevo QR (éxito).
- Verificada búsqueda con `rg -n "https://wa\.me/message/435RTKGJLTX2J1|https://wa\.me/qr/R2F5PRQYZSJOA1" .` para confirmar que no quedan referencias al enlace antiguo (éxito).
- Confirmado que los cuatro archivos esperados fueron modificados y contienen el nuevo enlace (éxito).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a12f8766b648332b7062a0dd69a17b4)