### PR TITLE
Actualizar enlaces de WhatsApp al nuevo URL

### DIFF
--- a/contacto.html
+++ b/contacto.html
@@ -210,7 +210,7 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
 
     <a
       class="wa-float"
-      href="https://wa.me/qr/R2F5PRQYZSJOA1"
+      href="https://wa.me/message/435RTKGJLTX2J1"
       target="_blank"
       rel="noopener noreferrer"
       data-gtm="whatsapp-floating"

--- a/index.html
+++ b/index.html
@@ -435,7 +435,7 @@ NFTs de Linaje Xoloitzcuintle</a></li>
     </script>
     <a
       class="wa-float"
-      href="https://wa.me/qr/R2F5PRQYZSJOA1"
+      href="https://wa.me/message/435RTKGJLTX2J1"
       target="_blank"
       rel="noopener noreferrer"
       data-gtm="whatsapp-floating"

--- a/teyolias-guardiania.html
+++ b/teyolias-guardiania.html
@@ -560,7 +560,7 @@
     </script>
 <a
       class="wa-float"
-      href="https://wa.me/qr/R2F5PRQYZSJOA1"
+      href="https://wa.me/message/435RTKGJLTX2J1"
       target="_blank"
       rel="noopener noreferrer"
       data-gtm="whatsapp-floating"

--- a/xolos-disponibles.html
+++ b/xolos-disponibles.html
@@ -287,7 +287,7 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
     <iframe width="100%" height="100%" src="https://www.youtube.com/embed/w9b_UIjRZiw" title="Ozomatli Ramirez" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen loading="lazy"></iframe>
   </div>
   <div class="puppy-card__actions">
-    <a href="https://wa.me/qr/R2F5PRQYZSJOA1?text=Hola,%20estoy%20interesado%20en%20recibir%20informaci%C3%B3n%20para%20reservar%20a%20Ozomatli%20Ramirez" class="btn-small btn-primary-small" style="background-color: #25D366; border-color: #25D366; width: 100%; justify-content: center;">WhatsApp Directo 📲</a>
+    <a href="https://wa.me/message/435RTKGJLTX2J1?text=Hola,%20estoy%20interesado%20en%20recibir%20informaci%C3%B3n%20para%20reservar%20a%20Ozomatli%20Ramirez" class="btn-small btn-primary-small" style="background-color: #25D366; border-color: #25D366; width: 100%; justify-content: center;">WhatsApp Directo 📲</a>
   </div>
 </div>
   </article>
@@ -348,7 +348,7 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
     <iframe width="100%" height="100%" src="https://www.youtube.com/embed/BmeHIF8FKTM" title="Nox Ramirez" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen loading="lazy"></iframe>
   </div>
   <div class="puppy-card__actions">
-    <a href="https://wa.me/qr/R2F5PRQYZSJOA1?text=Hola,%20me%20gustar%C3%ADa%20reservar%20a%20Nox%20Ramirez" class="btn-small btn-primary-small" style="background-color: #25D366; border-color: #25D366; width: 100%; justify-content: center;">WhatsApp Directo 📲</a>
+    <a href="https://wa.me/message/435RTKGJLTX2J1?text=Hola,%20me%20gustar%C3%ADa%20reservar%20a%20Nox%20Ramirez" class="btn-small btn-primary-small" style="background-color: #25D366; border-color: #25D366; width: 100%; justify-content: center;">WhatsApp Directo 📲</a>
   </div>
     </div>
   </article>
@@ -401,7 +401,7 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
     <iframe width="100%" height="100%" src="https://www.youtube.com/embed/T70O2-REbhg" title="Teyolia Ramirez" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen loading="lazy"></iframe>
   </div>
   <div class="puppy-card__actions">
-    <a href="https://wa.me/qr/R2F5PRQYZSJOA1" class="btn-small btn-primary-small" style="background-color: #25D366; border-color: #25D366; width: 100%; justify-content: center;">WhatsApp Directo 📲</a>
+    <a href="https://wa.me/message/435RTKGJLTX2J1" class="btn-small btn-primary-small" style="background-color: #25D366; border-color: #25D366; width: 100%; justify-content: center;">WhatsApp Directo 📲</a>
   </div>
     </div>
   </article>
@@ -461,7 +461,7 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
     <iframe width="100%" height="100%" src="https://www.youtube.com/embed/_2EGfG77VhE" title="Onix Ramirez" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen loading="lazy"></iframe>
   </div>
   <div class="puppy-card__actions">
-    <a href="https://wa.me/qr/R2F5PRQYZSJOA1?text=Hola,%20estoy%20interesado%20en%20recibir%20informaci%C3%B3n%20para%20reservar%20a%20Onix%20Ramirez" class="btn-small btn-primary-small" style="background-color: #25D366; border-color: #25D366; width: 100%; justify-content: center;">WhatsApp Directo 📲</a>
+    <a href="https://wa.me/message/435RTKGJLTX2J1?text=Hola,%20estoy%20interesado%20en%20recibir%20informaci%C3%B3n%20para%20reservar%20a%20Onix%20Ramirez" class="btn-small btn-primary-small" style="background-color: #25D366; border-color: #25D366; width: 100%; justify-content: center;">WhatsApp Directo 📲</a>
   </div>
     </div>
   </article>
@@ -516,7 +516,7 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
     <iframe width="100%" height="100%" src="https://www.youtube.com/embed/0qcQvELxVpU" title="Chimalma Ramirez" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen loading="lazy"></iframe>
   </div>
   <div class="puppy-card__actions">
-    <a href="https://wa.me/qr/R2F5PRQYZSJOA1?text=Hola,%20estoy%20interesado%20en%20recibir%20informaci%C3%B3n%20para%20reservar%20a%20Chimalma%20Ramirez" class="btn-small btn-primary-small" style="background-color: #25D366; border-color: #25D366; width: 100%; justify-content: center;">WhatsApp Directo 📲</a>
+    <a href="https://wa.me/message/435RTKGJLTX2J1?text=Hola,%20estoy%20interesado%20en%20recibir%20informaci%C3%B3n%20para%20reservar%20a%20Chimalma%20Ramirez" class="btn-small btn-primary-small" style="background-color: #25D366; border-color: #25D366; width: 100%; justify-content: center;">WhatsApp Directo 📲</a>
   </div>
     </div>
   </article> 
@@ -561,7 +561,7 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
     <iframe width="100%" height="100%" src="https://www.youtube.com/embed/swT_Xkc7Kco" title="Mixa Ramirez" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen loading="lazy"></iframe>
   </div>
   <div class="puppy-card__actions">
-         <a href="https://wa.me/qr/R2F5PRQYZSJOA1?text=Hola,%20estoy%20interesado%20en%20recibir%20informaci%C3%B3n%20para%20reservar%20a%20Mixa%20Ramirez" class="btn-small btn-primary-small" style="background-color: #25D366; border-color: #25D366; width: 100%; justify-content: center;">WhatsApp Directo 📲</a>
+         <a href="https://wa.me/message/435RTKGJLTX2J1?text=Hola,%20estoy%20interesado%20en%20recibir%20informaci%C3%B3n%20para%20reservar%20a%20Mixa%20Ramirez" class="btn-small btn-primary-small" style="background-color: #25D366; border-color: #25D366; width: 100%; justify-content: center;">WhatsApp Directo 📲</a>
   
     </div>
     </div>
@@ -608,7 +608,7 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
         <li><strong>Color</strong> Negro</li>
       </ul>
       <div class="puppy-card__actions">
-        <a href="https://wa.me/qr/R2F5PRQYZSJOA1" class="btn-small btn-outline-small" target="_blank" rel="noopener">Ver video Personalidad Xolo 🎥</a>
+        <a href="https://wa.me/message/435RTKGJLTX2J1" class="btn-small btn-outline-small" target="_blank" rel="noopener">Ver video Personalidad Xolo 🎥</a>
         
       </div>
     </div>
@@ -810,7 +810,7 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
 
  <a
       class="wa-float"
-      href="https://wa.me/qr/R2F5PRQYZSJOA1"
+      href="https://wa.me/message/435RTKGJLTX2J1"
       target="_blank"
       rel="noopener noreferrer"
       data-gtm="whatsapp-floating"


### PR DESCRIPTION
### Motivation
- Actualizar el enlace antiguo de WhatsApp `https://wa.me/qr/R2F5PRQYZSJOA1` por el nuevo `https://wa.me/message/435RTKGJLTX2J1` en el sitio para que los botones y enlaces apunten al destino de contacto correcto.

### Description
- Reemplacé la base del enlace WhatsApp en `index.html`, `contacto.html`, `teyolias-guardiania.html` y `xolos-disponibles.html` donde aparecía el enlace antiguo.
- Se conservaron los parámetros de consulta existentes como `?text=...` cuando aplicaba, cambiando únicamente la parte base del `href`.
- Se actualizaron tanto los botones flotantes de WhatsApp como los enlaces de acción de cada tarjeta (`WhatsApp Directo 📲` y `Ver video Personalidad Xolo 🎥`).
- Los cambios están limitados a atributos `href` en las cuatro páginas mencionadas.

### Testing
- Se ejecutó `rg -n` para localizar las referencias al enlace antiguo y confirmar su presencia antes de los cambios, y la búsqueda devolvió las coincidencias esperadas; operación exitosa.
- Se ejecutó el script de reemplazo en Python para aplicar las actualizaciones y el script terminó sin errores; operación exitosa.
- Se verificó mediante `rg -n "https://wa.me/message/435RTKGJLTX2J1"` que el nuevo enlace aparece en las páginas modificadas y que la clave antigua `R2F5PRQYZSJOA1` ya no aparece; verificación exitosa.
- Se comprobó el estado del árbol de trabajo con `git status --short` para confirmar que las cuatro páginas quedaron modificadas; comprobación exitosa.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a14abe2ddcc8332be58e7927dd3d0cd)