### PR TITLE
Add blockchain archive section to Yanga article

### DIFF
--- a/blog/2026-05-28-the-xolos-ramirez-show.html
+++ b/blog/2026-05-28-the-xolos-ramirez-show.html
@@ -175,6 +175,25 @@
       border: 0;
     }
 
+    .btn-nft {
+      display: inline-block;
+      margin-top: 12px;
+      padding: 12px 24px;
+      background-color: var(--earth);
+      color: #fffaf2;
+      border-radius: 12px;
+      font-size: 1rem;
+      font-weight: bold;
+      box-shadow: 0 4px 12px rgba(122,75,42,0.2);
+      transition: background-color 0.3s ease;
+    }
+    
+    .btn-nft:hover {
+      background-color: var(--gold);
+      color: #fffaf2;
+      text-decoration: none;
+    }
+
     .closing {
       margin-top: 36px;
       padding: 26px;
@@ -269,6 +288,19 @@
             </iframe>
           </div>
         </div>
+
+        <h2>Archivo Vivo: Inmortalizado en la Blockchain</h2>
+        <p>
+          Para coronar esta increíble historia y como parte de nuestro compromiso con la soberanía digital, este episodio ha sido acuñado mediante nuestra propia <strong>Tonalli Wallet</strong>.
+        </p>
+        <p>
+          Bajo el nombre de colección oficial <strong>The Xolos Ramirez Show #001 – Yanga</strong>, la narrativa de su herencia "Blaxican" y su exitosa adaptación al Caribe ahora vive de forma inmutable en la blockchain de eCash, documentando para siempre este hito de nuestro linaje.
+        </p>
+        <p>
+          <a href="https://explorer.xolosarmy.xyz/tx/bafd926497cc424276299297cc14697dda91a0029cbc2124d2ad5f3b4faeea0c" target="_blank" rel="noopener noreferrer" class="btn-nft">
+            🔗 Ver registro NFT en el Explorador
+          </a>
+        </p>
 
         <div class="closing">
           <strong>La historia de Yanga es el ejemplo perfecto de nuestra misión.</strong>


### PR DESCRIPTION
### Motivation
- Surface the NFT/transaction that documents the episode directly in the article so readers can view the immutable record and close the loop between the story and the project's blockchain infrastructure.

### Description
- Updated `blog/2026-05-28-the-xolos-ramirez-show.html` to insert an “Archivo Vivo: Inmortalizado en la Blockchain” section beneath the embedded YouTube video with explanatory text and a CTA link to the eCash explorer transaction.
- Added themed CTA markup (`<a class="btn-nft">`) that links to `https://explorer.xolosarmy.xyz/tx/bafd926497cc424276299297cc14697dda91a0029cbc2124d2ad5f3b4faeea0c`.
- Introduced `.btn-nft` CSS and a hover state using the article palette (earth/gold) to match the existing theme.
- Committed the change to the repository and prepared the PR titled `Add blockchain archive section to Yanga article`.

### Testing
- Ran an HTML smoke parse with `python3` using `html.parser` on `blog/2026-05-28-the-xolos-ramirez-show.html`, which parsed successfully.
- Checked for a browser/Playwright runtime and found none, so browser-based rendering or screenshot tests were skipped.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1a29f4345883329cd7a770b1f59541)