### PR TITLE
Add Guardianía Teyolías highlight card to xolos-disponibles.html

### DIFF
--- a/xolos-disponibles.html
+++ b/xolos-disponibles.html
@@ -144,6 +144,23 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
         </p>
       </section>
 
+      <section class="container" data-aos="fade-up" data-aos-duration="1000" data-aos-delay="150" style="margin-top: 40px; margin-bottom: 40px;">
+        <div class="grid grid-2">
+          <article class="card highlight-card" data-aos="zoom-in" data-aos-delay="200" style="border-left: 4px solid #d4af37; background: rgba(212, 175, 55, 0.03); padding: 30px;">
+            <h3 style="color: #d4af37;">Guardianía Teyolías ✨</h3>
+            <p>
+              Algunos xoloitzcuintles de 6 meses o más han alcanzado la madurez ideal para participar en nuestro programa especial de <strong>Guardianía Teyolías</strong>: una forma de conectar con perros seleccionados desde una perspectiva cultural, comunitaria y de compañía.
+            </p>
+            <a href="teyolias-guardiania.html" style="font-weight: 600; color: #d4af37; text-decoration: none;">
+              Conoce el programa y cómo participar →
+            </a>
+            <p class="callout" style="margin-top: 15px; font-size: 0.9rem; color: #666; font-style: italic;">
+              Los candidatos estarán identificados con la etiqueta <strong>✨ Candidato a Teyolía</strong> dentro de los perfiles disponibles a continuación.
+            </p>
+          </article>
+        </div>
+      </section>
+
       <section class="trust" data-aos="fade-up" data-aos-duration="1000" data-aos-delay="80">
         <h2>Confianza y garantías</h2>
         <div class="trust-grid">


### PR DESCRIPTION
### Motivation
- Promote the Spanish "Guardianía Teyolías" program on the available xolos page so visitors can discover and join the initiative. 
- Ensure the callout links to the correct Spanish page (`teyolias-guardiania.html`) and appears in context with the adoption process information. 

### Description
- Inserted a new `<section class="container">` containing a highlighted card titled "Guardianía Teyolías ✨" directly after the `Proceso de adopción responsable` section and before the `Confianza y garantías` section in `xolos-disponibles.html`. 
- The card includes descriptive text, a link to `teyolias-guardiania.html`, and a callout note that candidates will be labeled `✨ Candidato a Teyolía` in profiles. 
- The added markup includes AOS animation attributes and inline styles (accent border color `#d4af37` and subtle background) to match the page style. 

### Testing
- Ran `git diff --check` to verify there are no trailing whitespace or diff issues and it succeeded. 
- Verified the insertion and links with `rg -n "Guardianía Teyolías|teyolias-guardiania.html|Confianza y garantías" xolos-disponibles.html` which returned the expected matches. 
- Previewed the surrounding lines with `nl -ba xolos-disponibles.html | sed -n '136,170p'` to confirm the section placement and it matched the intended location.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1da60e50bc83329e62ad545919d6d2)