### PR TITLE
Match English Teyolía profile cards

### DIFF
--- a/en/teyolias-guardianship.html
+++ b/en/teyolias-guardianship.html
@@ -56,6 +56,93 @@
         }
         .flip-card-front { background-color: #f5f5f4; color: #292524; }
         .flip-card-back { background-color: #292524; color: #f5f5f4; transform: rotateY(180deg); }
+        .carousel-scrollbar-hidden::-webkit-scrollbar { display: none; }
+        .carousel-scrollbar-hidden { -ms-overflow-style: none; scrollbar-width: none; }
+        .teyolia-carousel-track {
+            display: flex;
+            height: 100%;
+            width: 100%;
+            overflow-x: auto;
+            scroll-snap-type: x mandatory;
+            scroll-behavior: smooth;
+            overscroll-behavior-x: contain;
+            -webkit-overflow-scrolling: touch;
+        }
+        .teyolia-carousel-slide {
+            position: relative;
+            width: 100%;
+            height: 100%;
+            flex: 0 0 100%;
+            scroll-snap-align: center;
+        }
+        .teyolia-carousel-image-slide {
+            display: flex;
+            align-items: center;
+            justify-content: center;
+            background: #0c0a09;
+        }
+        .teyolia-carousel-image-slide img {
+            width: 100%;
+            height: 100%;
+            object-fit: contain;
+            object-position: center;
+        }
+        .teyolia-carousel-video-slide {
+            display: flex;
+            align-items: center;
+            justify-content: center;
+            background: #0c0a09;
+        }
+        .teyolia-carousel-video-slide iframe {
+            width: 100%;
+            height: 100%;
+            border: 0;
+        }
+        .teyolia-carousel-button {
+            position: absolute;
+            top: 50%;
+            z-index: 10;
+            display: inline-flex;
+            width: 2.5rem;
+            height: 2.5rem;
+            transform: translateY(-50%);
+            align-items: center;
+            justify-content: center;
+            border-radius: 9999px;
+            border: 1px solid rgba(245, 158, 11, 0.55);
+            background: rgba(12, 10, 9, 0.68);
+            color: #fef3c7;
+            box-shadow: 0 10px 25px -12px rgba(0, 0, 0, 0.6);
+            transition: background-color 0.2s ease, transform 0.2s ease, color 0.2s ease;
+        }
+        .teyolia-carousel-button:hover,
+        .teyolia-carousel-button:focus-visible {
+            background: rgba(217, 119, 6, 0.92);
+            color: #1c1917;
+            transform: translateY(-50%) scale(1.05);
+            outline: none;
+        }
+        .teyolia-carousel-button--prev { left: 0.75rem; }
+        .teyolia-carousel-button--next { right: 0.75rem; }
+        .teyolia-carousel-dots {
+            display: flex;
+            align-items: center;
+            justify-content: center;
+            gap: 0.5rem;
+        }
+        .teyolia-carousel-dot {
+            width: 0.65rem;
+            height: 0.65rem;
+            border-radius: 9999px;
+            border: 1px solid rgba(245, 158, 11, 0.75);
+            background: rgba(28, 25, 23, 0.45);
+            transition: width 0.2s ease, background-color 0.2s ease, border-color 0.2s ease;
+        }
+        .teyolia-carousel-dot.is-active {
+            width: 1.6rem;
+            background: #f59e0b;
+            border-color: #fbbf24;
+        }
     </style>
 </head>
 <body class="bg-stone-100 text-stone-800 font-sans selection:bg-amber-200">
@@ -159,20 +246,46 @@
 
         <section class="mb-20 bg-white p-8 md:p-12 rounded-3xl shadow-sm border border-stone-200">
             <div class="text-center mb-10">
-                <p class="text-sm uppercase tracking-widest text-amber-700 font-bold mb-3">Open Campaigns</p>
-                <h3 class="text-3xl font-serif font-bold text-stone-800 mb-4">Active Teyolías</h3>
-                <p class="text-stone-600 max-w-2xl mx-auto">These are the Teyolías currently available for application. Each has its own duration, profile, and guardianship process.</p>
+                <p class="text-sm uppercase tracking-widest text-amber-700 font-bold mb-3">
+                    Open Campaigns
+                </p>
+                <h3 class="text-3xl font-serif font-bold text-stone-800 mb-4">
+                    Active Teyolías
+                </h3>
+                <p class="text-stone-600 max-w-2xl mx-auto">
+                    These are the Teyolías currently available for application. Each has its own duration, profile, and guardianship process.
+                </p>
             </div>
 
             <div class="grid grid-cols-1 md:grid-cols-2 gap-6">
                 <article class="rounded-2xl border border-amber-200 bg-amber-50 overflow-hidden shadow-sm">
-                    <div class="grid grid-cols-1 md:grid-cols-3 gap-0">
-                        <div class="md:col-span-1 bg-stone-200">
-                            <img src="https://i.imgur.com/qYusFcs.png" alt="Tonatiuh Ramírez, Active Teyolía" class="w-full h-full object-cover"/>
+                    <div class="grid grid-cols-1 md:grid-cols-5 gap-0 h-full">
+                        <div class="md:col-span-2 bg-stone-950 relative h-[28rem] md:h-full min-h-[430px]" data-carousel data-carousel-name="Tonatiuh Ramírez">
+                            <div class="teyolia-carousel-track carousel-scrollbar-hidden" data-carousel-track aria-label="Photos and video of Tonatiuh Ramírez">
+                                <div class="teyolia-carousel-slide teyolia-carousel-image-slide" data-carousel-slide>
+                                    <img src="https://i.imgur.com/qYusFcs.png" alt="Tonatiuh Ramírez, Active Teyolía" loading="lazy" />
+                                </div>
+                                <div class="teyolia-carousel-slide teyolia-carousel-video-slide" data-carousel-slide>
+                                    <iframe src="https://www.youtube.com/embed/RfcNi1zoJJA?playsinline=1" title="Xolo Personality" loading="lazy" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" referrerpolicy="strict-origin-when-cross-origin" allowfullscreen></iframe>
+                                </div>
+                            </div>
+                            <button class="teyolia-carousel-button teyolia-carousel-button--prev" type="button" data-carousel-prev aria-label="View previous slide of Tonatiuh">‹</button>
+                            <button class="teyolia-carousel-button teyolia-carousel-button--next" type="button" data-carousel-next aria-label="View next slide of Tonatiuh">›</button>
+                            <div class="absolute bottom-4 left-0 right-0 flex flex-col items-center gap-3 pointer-events-none">
+                                <div class="teyolia-carousel-dots pointer-events-auto" data-carousel-dots aria-label="Carousel pagination for Tonatiuh"></div>
+                                <div class="bg-black/60 text-amber-100 text-xs font-bold px-4 py-2 rounded-full backdrop-blur-md flex items-center gap-2 shadow-lg border border-amber-500/30">
+                                    <span aria-hidden="true">↔</span> Swipe
+                                </div>
+                            </div>
                         </div>
-                        <div class="md:col-span-2 p-6 text-left">
-                            <p class="text-xs uppercase tracking-widest text-amber-700 font-bold mb-2">Active · 2 months</p>
-                            <h4 class="text-2xl font-serif font-bold text-stone-900 mb-3">Tonatiuh Ramírez</h4>
+
+                        <div class="md:col-span-3 p-6 text-left flex flex-col justify-center">
+                            <p class="text-xs uppercase tracking-widest text-amber-700 font-bold mb-2">
+                                Active · 2 months
+                            </p>
+                            <h4 class="text-2xl font-serif font-bold text-stone-900 mb-3">
+                                Tonatiuh Ramírez
+                            </h4>
                             <ul class="text-sm text-stone-700 space-y-1 mb-5">
                                 <li><strong>Age:</strong> 6 months</li>
                                 <li><strong>Gender:</strong> Male</li>
@@ -182,13 +295,57 @@
                             <p class="text-stone-700 text-sm leading-relaxed mb-5">
                                 Tonatiuh has been selected as a candidate due to his stage of maturity. During this campaign, interested families can apply as guardians.
                             </p>
-                            <a 
-                                href="https://www.teyolia.cash/campaigns/campaign-1777329953138" 
-                                target="_blank"
-                                rel="noopener noreferrer"
-                                class="inline-block bg-stone-900 text-amber-500 px-5 py-3 rounded-full font-bold hover:bg-amber-600 hover:text-stone-900 transition-all">
-                                View Tonatiuh's Teyolía ✨
-                            </a>
+                            <div>
+                                <a href="https://www.teyolia.cash/campaigns/campaign-1777329953138" target="_blank" rel="noopener noreferrer" class="inline-block bg-stone-900 text-amber-500 px-5 py-3 rounded-full font-bold hover:bg-amber-600 hover:text-stone-900 transition-all">
+                                    View Tonatiuh's Teyolía ✨
+                                </a>
+                            </div>
+                        </div>
+                    </div>
+                </article>
+
+                <article class="rounded-2xl border border-amber-200 bg-amber-50 overflow-hidden shadow-sm">
+                    <div class="grid grid-cols-1 md:grid-cols-5 gap-0 h-full">
+                        <div class="md:col-span-2 bg-stone-950 relative h-[28rem] md:h-full min-h-[430px]" data-carousel data-carousel-name="Tlaloc Ramírez">
+                            <div class="teyolia-carousel-track carousel-scrollbar-hidden" data-carousel-track aria-label="Photos and video of Tlaloc Ramírez">
+                                <div class="teyolia-carousel-slide teyolia-carousel-image-slide" data-carousel-slide>
+                                    <img src="https://i.imgur.com/PchQIix.jpeg" alt="Tlaloc Ramírez, Active Teyolía" loading="lazy" />
+                                </div>
+                                <div class="teyolia-carousel-slide teyolia-carousel-video-slide" data-carousel-slide>
+                                    <iframe src="https://www.youtube.com/embed/4P7DCYJtKsY?playsinline=1" title="Tlaloc Ramírez Video" loading="lazy" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" referrerpolicy="strict-origin-when-cross-origin" allowfullscreen></iframe>
+                                </div>
+                            </div>
+                            <button class="teyolia-carousel-button teyolia-carousel-button--prev" type="button" data-carousel-prev aria-label="View previous slide of Tlaloc">‹</button>
+                            <button class="teyolia-carousel-button teyolia-carousel-button--next" type="button" data-carousel-next aria-label="View next slide of Tlaloc">›</button>
+                            <div class="absolute bottom-4 left-0 right-0 flex flex-col items-center gap-3 pointer-events-none">
+                                <div class="teyolia-carousel-dots pointer-events-auto" data-carousel-dots aria-label="Carousel pagination for Tlaloc"></div>
+                                <div class="bg-black/60 text-amber-100 text-xs font-bold px-4 py-2 rounded-full backdrop-blur-md flex items-center gap-2 shadow-lg border border-amber-500/30">
+                                    <span aria-hidden="true">↔</span> Swipe
+                                </div>
+                            </div>
+                        </div>
+
+                        <div class="md:col-span-3 p-6 text-left flex flex-col justify-center">
+                            <p class="text-xs uppercase tracking-widest text-amber-700 font-bold mb-2">
+                                Active · 3 months
+                            </p>
+                            <h4 class="text-2xl font-serif font-bold text-stone-900 mb-3">
+                                Tlaloc Ramírez
+                            </h4>
+                            <ul class="text-sm text-stone-700 space-y-1 mb-5">
+                                <li><strong>Age:</strong> 1 year</li>
+                                <li><strong>Gender:</strong> Male</li>
+                                <li><strong>Size:</strong> Standard / Intermediate</li>
+                                <li><strong>Color:</strong> Butterfly / Gray</li>
+                            </ul>
+                            <p class="text-stone-700 text-sm leading-relaxed mb-5">
+                                Tlaloc is a beautiful one-year-old young specimen. He stands out for his great nobility and energy. During this campaign, we are looking for the ideal family that can guide his path.
+                            </p>
+                            <div>
+                                <a href="https://www.teyolia.cash/campaigns/campaign-1777329953138" target="_blank" rel="noopener noreferrer" class="inline-block bg-stone-900 text-amber-500 px-5 py-3 rounded-full font-bold hover:bg-amber-600 hover:text-stone-900 transition-all">
+                                    View Tlaloc's Teyolía ✨
+                                </a>
+                            </div>
                         </div>
                     </div>
                 </article>
@@ -267,6 +424,51 @@
                 document.getElementById('step-what').innerHTML = data.what;
                 document.getElementById('step-rule').textContent = data.rule;
             });
+        });
+
+
+        const carousels = document.querySelectorAll('[data-carousel]');
+        carousels.forEach(carousel => {
+            const track = carousel.querySelector('[data-carousel-track]');
+            const slides = Array.from(carousel.querySelectorAll('[data-carousel-slide]'));
+            const prevButton = carousel.querySelector('[data-carousel-prev]');
+            const nextButton = carousel.querySelector('[data-carousel-next]');
+            const dotsContainer = carousel.querySelector('[data-carousel-dots]');
+
+            if (!track || slides.length === 0 || !dotsContainer) return;
+
+            const carouselName = carousel.getAttribute('data-carousel-name') || 'this Teyolía';
+            const dots = slides.map((_, index) => {
+                const dot = document.createElement('button');
+                dot.type = 'button';
+                dot.className = 'teyolia-carousel-dot';
+                dot.setAttribute('data-carousel-dot', String(index));
+                dot.setAttribute('aria-label', `Go to slide ${index + 1} of ${carouselName}`);
+                dot.addEventListener('click', () => {
+                    track.scrollTo({ left: track.clientWidth * index, behavior: 'smooth' });
+                });
+                dotsContainer.appendChild(dot);
+                return dot;
+            });
+
+            const setActiveDot = () => {
+                const activeIndex = Math.round(track.scrollLeft / Math.max(track.clientWidth, 1));
+                dots.forEach((dot, index) => {
+                    const isActive = index === activeIndex;
+                    dot.classList.toggle('is-active', isActive);
+                    dot.setAttribute('aria-current', isActive ? 'true' : 'false');
+                });
+            };
+
+            prevButton?.addEventListener('click', () => {
+                track.scrollBy({ left: -track.clientWidth, behavior: 'smooth' });
+            });
+            nextButton?.addEventListener('click', () => {
+                track.scrollBy({ left: track.clientWidth, behavior: 'smooth' });
+            });
+            track.addEventListener('scroll', () => window.requestAnimationFrame(setActiveDot), { passive: true });
+            window.addEventListener('resize', setActiveDot);
+            setActiveDot();
         });
 
         const ctx = document.getElementById('profileChart').getContext('2d');


### PR DESCRIPTION
### Motivation
- Bring the English page layout, content and interactive carousel behavior in `en/teyolias-guardianship.html` in line with the Spanish version so profile cards look and behave identically. 
- Add the missing Tlaloc card and ensure each profile supports image/video carousels with pagination and prev/next controls.

### Description
- Added carousel CSS rules (hidden scrollbars, snap scrolling, slide sizing, media styling, buttons and dots) inside the existing `<style>` block to support the new UI (`.teyolia-carousel-*`).
- Replaced the `Active Teyolías` section HTML with carousel-enabled profile cards for Tonatiuh and Tlaloc using a 5-column layout on desktop and the same content as the Spanish version. 
- Added JavaScript to initialize every `[data-carousel]`: it builds dots, wires `data-carousel-prev`/`data-carousel-next` buttons, updates active dot state on scroll/resize, and enables smooth slide navigation.

### Testing
- Ran `git diff --check` which completed without reported issues (success).
- Parsed the updated HTML with Python's `html.parser` to confirm the document is syntactically valid (success).
- Used `rg` to verify the inserted markers and media references (`teyolia-carousel-track`, `Tlaloc Ramírez`, `const carousels`, `data-carousel-name`, and the YouTube embeds) were present in `en/teyolias-guardianship.html` (success).
- Installed Playwright browsers and dependencies and captured a full-page screenshot with `npx --yes playwright screenshot file:///workspace/xolosramirez/en/teyolias-guardianship.html /tmp/teyolias-guardianship.png`, which produced a PNG file (success); a separate attempt to run a Node script that required a local `playwright` module failed due to a missing module (non-blocking failure).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1daf1f00788332a0a2f1b1edf991e2)