### PR TITLE
Align Tonatiuh profile cards

### DIFF
--- a/en/available-xolos.html
+++ b/en/available-xolos.html
@@ -164,16 +164,23 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
             <span class="puppy-card__status status-disponible">Available</span>
             <span class="puppy-card__status" style="top: 40px; background-color: #d4af37; color: #000; font-weight: bold;">✨ Teyolía Candidate</span>
 
-            <picture>
+            <div class="swipe-indicator" aria-hidden="true">
+              <span>Swipe</span>
+              <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M5 12h14M12 5l7 7-7 7"/></svg>
+            </div>
+
+            <div style="display: flex; overflow-x: auto; scroll-snap-type: x mandatory; scrollbar-width: none; -ms-overflow-style: none;">
+              <style>
+                .puppy-card__image-wrapper div::-webkit-scrollbar { display: none; }
+              </style>
               <img
                 src="https://i.imgur.com/uRMgiE2.png"
                 alt="Xoloitzcuintle Tonatiuh Ramirez"
                 class="puppy-card__image"
                 loading="lazy"
-                width="600"
-                height="450"
+                style="flex: 0 0 100%; scroll-snap-align: start; object-fit: cover;"
               />
-            </picture>
+            </div>
           </div>
           <div class="puppy-card__content">
             <h3 class="puppy-card__name">Tonatiuh Ramirez</h3>
@@ -184,13 +191,14 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
               <li><strong>Color</strong> Black</li>
               <li><strong>Teyolía</strong> Candidate by age</li>
             </ul>
+            <div class="puppy-video-container" style="margin: 1rem 0; border-radius: 8px; overflow: hidden; aspect-ratio: 16/9;">
+              <iframe width="100%" height="100%" src="https://www.youtube.com/embed/mwlofFThWwA" title="Tonatiuh Ramirez" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen loading="lazy"></iframe>
+            </div>
             <div class="puppy-card__actions">
-              <a href="https://www.youtube.com/watch?v=mwlofFThWwA" class="btn-small btn-outline-small" target="_blank" rel="noopener">Watch video 🎥</a>
               <a href="teyolias-guardianship.html" class="btn-small btn-primary-small" style="background-color: #d4af37; border-color: #d4af37; color: #000;">Participate in Teyolías ✨</a>
             </div>
           </div>
         </article>
-        
 
         <article class="puppy-card" data-aos="fade-up" data-aos-duration="800" data-aos-delay="200">
           <div class="puppy-card__image-wrapper">

--- a/xolos-disponibles.html
+++ b/xolos-disponibles.html
@@ -229,50 +229,46 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
 
   
           <article class="puppy-card" data-aos="fade-up" data-aos-duration="800" data-aos-delay="200">
-    <div class="puppy-card__image-wrapper">
-      <span class="puppy-card__status status-disponible">Disponible</span>
-      <span class="puppy-card__status" style="top: 40px; background-color: #d4af37; color: #000; font-weight: bold;">✨ Candidatos a Teyolía</span>
-           
-      <div class="swipe-indicator" aria-hidden="true">
-        <span>Desliza</span>
-        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M5 12h14M12 5l7 7-7 7"/></svg>
-      </div>
+            <div class="puppy-card__image-wrapper">
+              <span class="puppy-card__status status-disponible">Disponible</span>
+              <span class="puppy-card__status" style="top: 40px; background-color: #d4af37; color: #000; font-weight: bold;">✨ Candidato a Teyolía</span>
 
-      <div style="display: flex; overflow-x: auto; scroll-snap-type: x mandatory; scrollbar-width: none; -ms-overflow-style: none;">
-        <style>
-          /* Ocultar barra de scroll para mantener la estética limpia */
-          .puppy-card__image-wrapper div::-webkit-scrollbar { display: none; }
-        </style>
-           
-      <picture>
-        <img
-          src="https://i.imgur.com/uRMgiE2.png"
-          alt="Xoloitzcuintle Tonatiuh Ramirez"
-          class="puppy-card__image"
-          loading="lazy"
-          width="600"
-          height="450"
-        />
-      </picture>
-    </div>
-    <div class="puppy-card__content">
-      <h3 class="puppy-card__name">Tonatiuh Ramirez</h3>
-      <ul class="puppy-card__details">
-        <li><strong>Edad</strong> 6 meses</li>
-        <li><strong>Género</strong> Macho</li>
-        <li><strong>Talla</strong> Miniatura</li>
-        <li><strong>Color</strong> Negro</li>
-        <li><strong>Teyolía</strong> Candidato por edad</li>
-      </ul>
-      <div class="puppy-video-container" style="margin: 1rem 0; border-radius: 8px; overflow: hidden; aspect-ratio: 16/9;">
-           
-      <div class="puppy-card__actions">
-            <iframe width="100%" height="100%" src="https://www.youtube.com/embed/mwlofFThWwA" title="Ozomatli Ramirez" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen loading="lazy"></iframe>
-        <a href="https://xolosramirez.com/teyolias-guardiania.html" class="btn-small btn-primary-small" style="background-color: #d4af37; border-color: #d4af37; color: #000;">Participar en Teyolías ✨</a>
-      </div>
-    </div>
-  </article>
-          
+              <div class="swipe-indicator" aria-hidden="true">
+                <span>Desliza</span>
+                <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M5 12h14M12 5l7 7-7 7"/></svg>
+              </div>
+
+              <div style="display: flex; overflow-x: auto; scroll-snap-type: x mandatory; scrollbar-width: none; -ms-overflow-style: none;">
+                <style>
+                  /* Ocultar barra de scroll para mantener la estética limpia */
+                  .puppy-card__image-wrapper div::-webkit-scrollbar { display: none; }
+                </style>
+                <img
+                  src="https://i.imgur.com/uRMgiE2.png"
+                  alt="Xoloitzcuintle Tonatiuh Ramirez"
+                  class="puppy-card__image"
+                  loading="lazy"
+                  style="flex: 0 0 100%; scroll-snap-align: start; object-fit: cover;"
+                />
+              </div>
+            </div>
+            <div class="puppy-card__content">
+              <h3 class="puppy-card__name">Tonatiuh Ramirez</h3>
+              <ul class="puppy-card__details">
+                <li><strong>Edad</strong> 6 meses</li>
+                <li><strong>Género</strong> Macho</li>
+                <li><strong>Talla</strong> Miniatura</li>
+                <li><strong>Color</strong> Negro</li>
+                <li><strong>Teyolía</strong> Candidato por edad</li>
+              </ul>
+              <div class="puppy-video-container" style="margin: 1rem 0; border-radius: 8px; overflow: hidden; aspect-ratio: 16/9;">
+                <iframe width="100%" height="100%" src="https://www.youtube.com/embed/mwlofFThWwA" title="Tonatiuh Ramirez" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen loading="lazy"></iframe>
+              </div>
+              <div class="puppy-card__actions">
+                <a href="teyolias-guardiania.html" class="btn-small btn-primary-small" style="background-color: #d4af37; border-color: #d4af37; color: #000;">Participar en Teyolías ✨</a>
+              </div>
+            </div>
+          </article>
 
   <article class="puppy-card" data-aos="fade-up" data-aos-duration="800" data-aos-delay="200">
     <div class="puppy-card__image-wrapper">


### PR DESCRIPTION
### Motivation
- Garantizar que la tarjeta de perfil de Tonatiuh Ramirez tenga la misma estructura, estilos y comportamiento visual en `xolos-disponibles.html` y en `en/available-xolos.html` para mantener consistencia en el sitio. 
- Alinear la semántica y la experiencia (imagen, carrusel/deslizado, detalles, video y CTA) con el patrón usado por las demás tarjetas destacadas. 

### Description
- Updated `xolos-disponibles.html` to replace the existing Tonatiuh block with the project's `puppy-card` pattern using `puppy-card__image-wrapper`, a swipe indicator, a scrollable image container with hidden scrollbar CSS, and a details list. 
- Updated `en/available-xolos.html` to match the same structure and to embed the Tonatiuh video inline via an iframe (`https://www.youtube.com/embed/mwlofFThWwA`) instead of an external watch link. 
- Unified CTA buttons to point to the Teyolías guardianía page (`teyolias-guardiania.html` / `teyolias-guardianship.html`) and kept localized status labels (`Disponible` / `Available`) consistent with other cards. 
- Cleaned up duplicate/old markup around the original card so the HTML structure remains balanced and consistent with the rest of the `puppy-grid`. 

### Testing
- Ran `git diff --check` to confirm no whitespace/merge issues, which passed. 
- Executed a Python HTML tag-balance check on `xolos-disponibles.html` and `en/available-xolos.html` and it reported no errors. 
- Served the site locally and captured screenshots with `npx playwright screenshot` for both pages (`/tmp/xolos-disponibles-tonatiuh.png` and `/tmp/available-xolos-tonatiuh.png`), which completed successfully. 
- Verified the modified pages load assets (CSS/JS) when served locally and that the embedded iframe renders as expected.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1e181aa274833297788a51e18ba2a2)