### PR TITLE
Update WhatsApp links sitewide

### DIFF
--- a/blog/2026-01-24-entrega-ceniza-ramirez.html
+++ b/blog/2026-01-24-entrega-ceniza-ramirez.html
@@ -212,7 +212,7 @@
         <section class="cta">
             <h3>¿Buscas un compañero ancestral?</h3>
             <p>En Criadero Xolos Ramírez contamos con ejemplares únicos y asesoría completa para entregas nacionales e internacionales.</p>
-            <a href="#" class="btn">Contáctanos por WhatsApp</a>
+            <a href="https://wa.me/qr/R2F5PRQYZSJOA1" class="btn" target="_blank" rel="noopener noreferrer">Contáctanos por WhatsApp</a>
         </section>
     </main>
 

--- a/contacto.html
+++ b/contacto.html
@@ -210,7 +210,7 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
 
     <a
       class="wa-float"
-      href="https://wa.me/message/435RTKGJLTX2J1"
+      href="https://wa.me/qr/R2F5PRQYZSJOA1"
       target="_blank"
       rel="noopener noreferrer"
       data-gtm="whatsapp-floating"

--- a/en/available-xolos.html
+++ b/en/available-xolos.html
@@ -707,7 +707,7 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
       </div>
       <div>
         <h4>Social</h4>
-        <a href="https://wa.me/qr/5G35SPDG3AMRK1">WhatsApp</a><br>
+        <a href="https://wa.me/qr/R2F5PRQYZSJOA1">WhatsApp</a><br>
         <a href="https://x.com/xolosArmy">Twitter/X</a>
       </div>
     </div>

--- a/import/jimdo-sitemap.html
+++ b/import/jimdo-sitemap.html
@@ -278,7 +278,7 @@ Xoloitzcuintle en nuestra Historia mexicana | Xolos Ramirez</a></li><li><a href=
             <a href="https://www.tiktok.com/@xolosramirezoficial" target="_blank" style="margin:0 10px;display:inline-block;"><img src="jimdo-sitemap_files/3046121.png" alt="TikTok" width="30" height="30"></a> <!-- X / Twitter -->
              <a href="https://x.com/xolosramirez1" target="_blank" style="margin:0 10px;display:inline-block;"><img src="jimdo-sitemap_files/3670151.png" alt="X (Twitter)" width="30" height="30"></a> <!-- YouTube -->
              <a href="https://www.youtube.com/c/XolosRamirez" target="_blank" style="margin:0 10px;display:inline-block;"><img src="jimdo-sitemap_files/1384060.png" alt="YouTube" width="30" height="30"></a> <!-- WhatsApp -->
-             <a href="https://wa.me/qr/5G35SPDG3AMRK1" target="_blank" style="margin:0 10px;display:inline-block;"><img src="jimdo-sitemap_files/733585.png" alt="WhatsApp" width="30" height="30"></a> <!-- Snapchat (fantasmita blanco sobre amarillo) -->
+             <a href="https://wa.me/qr/R2F5PRQYZSJOA1" target="_blank" style="margin:0 10px;display:inline-block;"><img src="jimdo-sitemap_files/733585.png" alt="WhatsApp" width="30" height="30"></a> <!-- Snapchat (fantasmita blanco sobre amarillo) -->
              <a href="https://www.snapchat.com/add/xolos_ramirez?share_id=hsgphr8jjdg&amp;locale=es-MX" target="_blank" style="margin:0 10px;display:inline-block;"><img src="jimdo-sitemap_files/Rk3Vks0.png" alt="Snapchat" width="30" height="30"></a> <!-- Pixelfed -->
              <a href="https://xolosramirez.club/xolosramirez" target="_blank" rel="me" style="margin:0 10px;display:inline-block;"><img src="jimdo-sitemap_files/Instagram_icon.png" alt="Pixelfed" width="30" height="30"></a>
         </div>

--- a/index.html
+++ b/index.html
@@ -435,7 +435,7 @@ NFTs de Linaje Xoloitzcuintle</a></li>
     </script>
     <a
       class="wa-float"
-      href="https://wa.me/message/435RTKGJLTX2J1"
+      href="https://wa.me/qr/R2F5PRQYZSJOA1"
       target="_blank"
       rel="noopener noreferrer"
       data-gtm="whatsapp-floating"

--- a/public/xolos-disponibles.html
+++ b/public/xolos-disponibles.html
@@ -118,7 +118,7 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
           <p><strong>Estado:</strong> <span class="estado disponible">Disponible</span></p>
           <a
             class="btn-whatsapp"
-            href="https://wa.me/qr/5G35SPDG3AMRK1"
+            href="https://wa.me/qr/R2F5PRQYZSJOA1"
             target="_blank"
             rel="noopener"
             data-gtm="whatsapp"
@@ -145,7 +145,7 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
           <p><strong>Estado:</strong> <span class="estado reservado">Reservado</span></p>
           <a
             class="btn-whatsapp"
-            href="https://wa.me/qr/5G35SPDG3AMRK1"
+            href="https://wa.me/qr/R2F5PRQYZSJOA1"
             target="_blank"
             rel="noopener"
             data-gtm="whatsapp"
@@ -172,7 +172,7 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
           <p><strong>Estado:</strong> <span class="estado lista-espera">Lista de espera</span></p>
           <a
             class="btn-whatsapp"
-            href="https://wa.me/qr/5G35SPDG3AMRK1"
+            href="https://wa.me/qr/R2F5PRQYZSJOA1"
             target="_blank"
             rel="noopener"
             data-gtm="whatsapp"
@@ -272,7 +272,7 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
           <a href="https://www.youtube.com/channel/UCKtNKCavbBmxtcdHSDd9BsA" target="_blank">YouTube</a><br>
           <a href="https://x.com/xolosArmy" target="_blank">Twitter</a><br>
           <a href="https://t.me/xolosramirez" target="_blank">Telegram</a><br>
-          <a href="https://wa.me/qr/5G35SPDG3AMRK1" target="_blank">WhatsApp</a>
+          <a href="https://wa.me/qr/R2F5PRQYZSJOA1" target="_blank">WhatsApp</a>
         </p>
       </div>
     </div>

--- a/teyolias-guardiania.html
+++ b/teyolias-guardiania.html
@@ -609,7 +609,7 @@
     </script>
 <a
       class="wa-float"
-      href="https://wa.me/message/435RTKGJLTX2J1"
+      href="https://wa.me/qr/R2F5PRQYZSJOA1"
       target="_blank"
       rel="noopener noreferrer"
       data-gtm="whatsapp-floating"

--- a/xolo-skin-care/index.html
+++ b/xolo-skin-care/index.html
@@ -1672,7 +1672,7 @@
           Abrir wallet Tonalli (paso 2)
         </a>
         <button class="tonalli-guide" type="button" data-open-tonalli-modal>Guía Tonalli (paso a paso)</button>
-        <a href="https://wa.me/message/435RTKGJLTX2J1?text=Hola%2C+quiero+comprar+el+Bálsamo+Arbol+de+té"
+        <a href="https://wa.me/qr/R2F5PRQYZSJOA1"
            class="whatsapp-buy" target="_blank" rel="noopener noreferrer"
            data-ga-event="whatsapp_lead"
            data-item="Ungüento Solar del Guardián Xólotl"
@@ -1716,7 +1716,7 @@
           Abrir wallet Tonalli (paso 2)
         </a>
         <button class="tonalli-guide" type="button" data-open-tonalli-modal>Guía Tonalli (paso a paso)</button>
-        <a href="https://wa.me/message/435RTKGJLTX2J1?text=Hola%2C+quiero+comprar+el+Bálsamo+Lavanda"
+        <a href="https://wa.me/qr/R2F5PRQYZSJOA1"
            class="whatsapp-buy" target="_blank" rel="noopener noreferrer" data-ga-event="whatsapp_lead"
            data-item="Néctar Onírico de Tlazōlteōtl"
            aria-label="Abrir WhatsApp para comprar el Néctar Onírico de Tlazōlteōtl mediante transferencia bancaria">
@@ -1749,7 +1749,7 @@
           <button class="copy-offer-btn" type="button">Copiar Offer ID</button>
         </div>
         <a href="https://cartera.xolosarmy.xyz" target="_blank" rel="noopener noreferrer">Abrir wallet Tonalli (paso 2)</a>
-        <a href="https://wa.me/message/435RTKGJLTX2J1?text=Hola%2C+quiero+comprar+el+Bálsamo+Solar+Ancestral"
+        <a href="https://wa.me/qr/R2F5PRQYZSJOA1"
            class="whatsapp-buy" target="_blank" rel="noopener noreferrer"
            aria-label="Comprar por WhatsApp">
           <span aria-hidden="true">🟢</span>
@@ -1786,7 +1786,7 @@
           Abrir wallet Tonalli (paso 2)
         </a>
         <button class="tonalli-guide" type="button" data-open-tonalli-modal>Guía Tonalli (paso a paso)</button>
-        <a href="https://wa.me/message/435RTKGJLTX2J1?text=Hola%2C+quiero+comprar+el+Bálsamo+Limón"
+        <a href="https://wa.me/qr/R2F5PRQYZSJOA1"
            class="whatsapp-buy" target="_blank" rel="noopener noreferrer" data-ga-event="whatsapp_lead"
            data-item="Esencia Citlalinahuatl del Amanecer"
            aria-label="Abrir WhatsApp para comprar la Esencia Citlalinahuatl del Amanecer mediante transferencia bancaria">
@@ -1829,7 +1829,7 @@
           Abrir wallet Tonalli (paso 2)
         </a>
         <button class="tonalli-guide" type="button" data-open-tonalli-modal>Guía Tonalli (paso a paso)</button>
-        <a href="https://wa.me/message/435RTKGJLTX2J1?text=Hola%2C+quiero+comprar+el+Repelente+Limón"
+        <a href="https://wa.me/qr/R2F5PRQYZSJOA1"
            class="whatsapp-buy" target="_blank" rel="noopener noreferrer" data-ga-event="whatsapp_lead"
            data-item="Escudo de Bruma de Quetzalcóatl"
            aria-label="Abrir WhatsApp para comprar el Escudo de Bruma de Quetzalcóatl mediante transferencia bancaria">
@@ -1877,7 +1877,7 @@
           Abrir wallet Tonalli (paso 2)
         </a>
         <button class="tonalli-guide" type="button" data-open-tonalli-modal>Guía Tonalli (paso a paso)</button>
-        <a href="https://wa.me/message/435RTKGJLTX2J1?text=Hola%2C+quiero+comprar+jabon+exfoliante"
+        <a href="https://wa.me/qr/R2F5PRQYZSJOA1"
            class="whatsapp-buy" target="_blank" rel="noopener noreferrer" data-ga-event="whatsapp_lead"
            data-item="Dúo Ritual de Espuma del Mictlán"
            aria-label="Abrir WhatsApp para comprar el Dúo Ritual de Espuma del Mictlán mediante transferencia bancaria">
@@ -1928,8 +1928,8 @@
         <a href="https://cartera.xolosarmy.xyz" target="_blank" rel="noopener noreferrer">
           Abrir wallet Tonalli (paso 2)
         </a>
-        <a href="https://wa.me/message/435RTKGJLTX2J1?text=Hola%2C+quiero+el+Paquete+Bienestar+y+quiero+elegir+el+Bálsamo+Protector+Solar." class="btn-highlight" target="_blank" rel="noopener noreferrer">Personalizar mi Paquete</a>
-        <a href="https://wa.me/message/435RTKGJLTX2J1?text=Hola%2C+quiero+comprar+el+Paquete+Bienestar+Integral+Xoloitzcuintle"
+        <a href="https://wa.me/qr/R2F5PRQYZSJOA1" class="btn-highlight" target="_blank" rel="noopener noreferrer">Personalizar mi Paquete</a>
+        <a href="https://wa.me/qr/R2F5PRQYZSJOA1"
            class="whatsapp-buy" target="_blank" rel="noopener noreferrer" data-ga-event="whatsapp_lead"
            data-item="Paquete Bienestar Integral Xoloitzcuintle"
            aria-label="Abrir WhatsApp para comprar el Paquete Bienestar Integral Xoloitzcuintle mediante transferencia bancaria">
@@ -1980,7 +1980,7 @@
 
       <a
         class="sticky-buy__action sticky-buy__action--whatsapp"
-        href="https://wa.me/message/435RTKGJLTX2J1"
+        href="https://wa.me/qr/R2F5PRQYZSJOA1"
         target="_blank"
         rel="noopener noreferrer"
         data-ga-event="whatsapp_lead"

--- a/xolos-disponibles.html
+++ b/xolos-disponibles.html
@@ -319,7 +319,7 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
     <iframe width="100%" height="100%" src="https://www.youtube.com/embed/BmeHIF8FKTM" title="Ozomatli Ramirez" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen loading="lazy"></iframe>
   </div>
   <div class="puppy-card__actions">
-    <a href="https://wa.me/message/435RTKGJLTX2J1?text=Hola,%20estoy%20interesado%20en%20recibir%20informaci%C3%B3n%20para%20reservar%20a%20Ozomatli%20Ramirez" class="btn-small btn-primary-small" style="background-color: #25D366; border-color: #25D366; width: 100%; justify-content: center;">WhatsApp Directo 📲</a>
+    <a href="https://wa.me/qr/R2F5PRQYZSJOA1" class="btn-small btn-primary-small" style="background-color: #25D366; border-color: #25D366; width: 100%; justify-content: center;">WhatsApp Directo 📲</a>
   </div>
 </div>
   </article>
@@ -380,7 +380,7 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
     <iframe width="100%" height="100%" src="https://www.youtube.com/embed/BmeHIF8FKTM" title="Nox Ramirez" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen loading="lazy"></iframe>
   </div>
   <div class="puppy-card__actions">
-    <a href="https://wa.me/message/435RTKGJLTX2J1?text=Hola,%20me%20gustar%C3%ADa%20reservar%20a%20Nox%20Ramirez" class="btn-small btn-primary-small" style="background-color: #25D366; border-color: #25D366; width: 100%; justify-content: center;">WhatsApp Directo 📲</a>
+    <a href="https://wa.me/qr/R2F5PRQYZSJOA1" class="btn-small btn-primary-small" style="background-color: #25D366; border-color: #25D366; width: 100%; justify-content: center;">WhatsApp Directo 📲</a>
   </div>
     </div>
   </article>
@@ -442,7 +442,7 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
     <iframe width="100%" height="100%" src="https://www.youtube.com/embed/FROucQHEBsw" title="Teyolia Ramirez" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen loading="lazy"></iframe>
   </div>
   <div class="puppy-card__actions">
-    <a href="https://wa.me/message/435RTKGJLTX2J1" class="btn-small btn-primary-small" style="background-color: #25D366; border-color: #25D366; width: 100%; justify-content: center;">WhatsApp Directo 📲</a>
+    <a href="https://wa.me/qr/R2F5PRQYZSJOA1" class="btn-small btn-primary-small" style="background-color: #25D366; border-color: #25D366; width: 100%; justify-content: center;">WhatsApp Directo 📲</a>
   </div>
     </div>
   </article>
@@ -503,7 +503,7 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
     <iframe width="100%" height="100%" src="https://www.youtube.com/embed/_2EGfG77VhE" title="Onix Ramirez" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen loading="lazy"></iframe>
   </div>
   <div class="puppy-card__actions">
-    <a href="https://wa.me/message/435RTKGJLTX2J1?text=Hola,%20estoy%20interesado%20en%20recibir%20informaci%C3%B3n%20para%20reservar%20a%20Onix%20Ramirez" class="btn-small btn-primary-small" style="background-color: #25D366; border-color: #25D366; width: 100%; justify-content: center;">WhatsApp Directo 📲</a>
+    <a href="https://wa.me/qr/R2F5PRQYZSJOA1" class="btn-small btn-primary-small" style="background-color: #25D366; border-color: #25D366; width: 100%; justify-content: center;">WhatsApp Directo 📲</a>
   </div>
     </div>
   </article>
@@ -558,7 +558,7 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
     <iframe width="100%" height="100%" src="https://www.youtube.com/embed/0qcQvELxVpU" title="Chimalma Ramirez" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen loading="lazy"></iframe>
   </div>
   <div class="puppy-card__actions">
-    <a href="https://wa.me/message/435RTKGJLTX2J1?text=Hola,%20estoy%20interesado%20en%20recibir%20informaci%C3%B3n%20para%20reservar%20a%20Chimalma%20Ramirez" class="btn-small btn-primary-small" style="background-color: #25D366; border-color: #25D366; width: 100%; justify-content: center;">WhatsApp Directo 📲</a>
+    <a href="https://wa.me/qr/R2F5PRQYZSJOA1" class="btn-small btn-primary-small" style="background-color: #25D366; border-color: #25D366; width: 100%; justify-content: center;">WhatsApp Directo 📲</a>
   </div>
     </div>
   </article> 
@@ -603,7 +603,7 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
     <iframe width="100%" height="100%" src="https://www.youtube.com/embed/swT_Xkc7Kco" title="Mixa Ramirez" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen loading="lazy"></iframe>
   </div>
   <div class="puppy-card__actions">
-         <a href="https://wa.me/message/435RTKGJLTX2J1?text=Hola,%20estoy%20interesado%20en%20recibir%20informaci%C3%B3n%20para%20reservar%20a%20Mixa%20Ramirez" class="btn-small btn-primary-small" style="background-color: #25D366; border-color: #25D366; width: 100%; justify-content: center;">WhatsApp Directo 📲</a>
+         <a href="https://wa.me/qr/R2F5PRQYZSJOA1" class="btn-small btn-primary-small" style="background-color: #25D366; border-color: #25D366; width: 100%; justify-content: center;">WhatsApp Directo 📲</a>
   
     </div>
     </div>
@@ -650,7 +650,7 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
         <li><strong>Color</strong> Negro</li>
       </ul>
       <div class="puppy-card__actions">
-        <a href="https://wa.me/message/435RTKGJLTX2J1" class="btn-small btn-outline-small" target="_blank" rel="noopener">Ver video Personalidad Xolo 🎥</a>
+        <a href="https://wa.me/qr/R2F5PRQYZSJOA1" class="btn-small btn-outline-small" target="_blank" rel="noopener">Ver video Personalidad Xolo 🎥</a>
         
       </div>
     </div>
@@ -833,7 +833,7 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
           <a href="https://www.youtube.com/channel/UCKtNKCavbBmxtcdHSDd9BsA">YouTube</a><br>
           <a href="https://x.com/xolosArmy">Twitter</a><br>
           <a href="https://t.me/xolosramirez">Telegram</a><br>
-          <a href="https://wa.me/qr/5G35SPDG3AMRK1">WhatsApp</a>
+          <a href="https://wa.me/qr/R2F5PRQYZSJOA1">WhatsApp</a>
         </div>
       </div>
       <p class="copyright">© 2025 Xolos Ramírez. Todos los derechos reservados.</p>
@@ -852,7 +852,7 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
 
  <a
       class="wa-float"
-      href="https://wa.me/message/435RTKGJLTX2J1"
+      href="https://wa.me/qr/R2F5PRQYZSJOA1"
       target="_blank"
       rel="noopener noreferrer"
       data-gtm="whatsapp-floating"


### PR DESCRIPTION
### Motivation
- Normalizar y actualizar todos los enlaces de WhatsApp del sitio y sus subpáginas para apuntar al nuevo destino QR `https://wa.me/qr/R2F5PRQYZSJOA1` donde corresponda.
- Reemplazar enlaces antiguos tipo `https://wa.me/message/...` y las referencias anteriores al otro QR para evitar destinos rotos o inconsistentes en CTAs y botones flotantes.

### Description
- Replaced WhatsApp links across the site (9 files) including main pages, product CTAs, puppy listings, floating WhatsApp buttons and the imported sitemap to `https://wa.me/qr/R2F5PRQYZSJOA1` (files changed: `index.html`, `contacto.html`, `teyolias-guardiania.html`, `xolo-skin-care/index.html`, `xolos-disponibles.html`, `public/xolos-disponibles.html`, `blog/2026-01-24-entrega-ceniza-ramirez.html`, `en/available-xolos.html`, `import/jimdo-sitemap.html`).
- Converted an inline blog CTA that used `href="#"` into a real WhatsApp link and added `target="_blank" rel="noopener noreferrer"` to open in a new tab safely.
- Updated multiple CTA formats (direct message links with prefilled text and QR links) to the single QR URL to maintain a consistent destination for users.

### Testing
- Ejecutado búsqueda para detectar URLs antiguas con `rg -n "435RTKGJLTX2J1|5G35SPDG3AMRK1|href=\"#\" class=\"btn\">Contáctanos por WhatsApp" . -S` y ya no reportó ocurrencias de los antiguos identificadores; resultado: OK.
- Verificado diferencias y conflictos con `git diff --check` y no se reportaron advertencias de formato; resultado: OK.
- Revisión rápida de fragmentos clave en archivos modificados para confirmar que los `href` fueron reemplazados y que los botones flotantes y CTAs incluyen `target`/`rel` cuando corresponde; resultado: OK.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a25745481ec8332abde62b90305b730)