### PR TITLE
Add English language switch to home nav

### DIFF
--- a/index.html
+++ b/index.html
@@ -76,6 +76,7 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
 
         <nav id="menu" class="nav-menu" data-visible="false">
           <ul>
+            <li><a href="en/index.html" class="lang-switch">English</a></li>
             <li><a href="index.html">Inicio</a></li>
             <li><a href="xolos-disponibles.html">Xolos disponibles</a></li>
             <li><a href="teyolias-guardiania.html">Teyolias</a></li>


### PR DESCRIPTION
### Motivation
- Agregar el botón de idioma English al menú principal de la página de inicio para ofrecer la versión en inglés con el mismo estilo y comportamiento que ya existe en otras páginas.

### Description
- Inserté en `index.html` como primer elemento del menú una línea `<li><a href="en/index.html" class="lang-switch">English</a></li>` para reutilizar la clase `lang-switch` y mantener el mismo diseño/efecto.

### Testing
- Ejecuté una comprobación automática con `python3` que verifica la presencia del enlace en `index.html` y `git diff --check`, y ambas pruebas pasaron correctamente.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a259a56dce88332b2005d512dae1d90)