### PR TITLE
Normalize canonical domain and replace sitemap with non-www URLs

### DIFF
--- a/blog/guia-tallas-xoloitzcuintle.html
+++ b/blog/guia-tallas-xoloitzcuintle.html
@@ -8,6 +8,7 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
 })(window,document,'script','dataLayer','GTM-MGTMWN7T');</script>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <link rel="canonical" href="https://xolosramirez.com/blog/guia-tallas-xoloitzcuintle.html" />
     <title>Guía de Tallas del Xoloitzcuintle</title>
     <!-- Tailwind CSS -->
     <script src="https://cdn.tailwindcss.com"></script>

--- a/blog/precio-xoloitzcuintle.html
+++ b/blog/precio-xoloitzcuintle.html
@@ -17,6 +17,7 @@
     <!-- End Google Tag Manager -->
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <link rel="canonical" href="https://xolosramirez.com/blog/precio-xoloitzcuintle.html" />
     <title>Precio de un Xoloitzcuintle: ¿Cuánto Cuesta y Qué Incluye? | Venta</title>
     <meta name="description" content="Descubre el precio real de un perro xoloitzcuintle (miniatura, intermedio y estándar). Conoce los factores que definen su valor, linaje y cachorros disponibles en nuestro criadero.">
     <link rel="preconnect" href="https://fonts.googleapis.com" />

--- a/blog/xoloitzcuintle-miniatura.html
+++ b/blog/xoloitzcuintle-miniatura.html
@@ -3,6 +3,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <link rel="canonical" href="https://xolosramirez.com/blog/xoloitzcuintle-miniatura.html" />
     <title>3 Razones para elegir un Xoloitzcuintle Miniatura | Xolos Ramirez</title>
     <meta name="description" content="Descubre por qué el Xoloitzcuintle miniatura es el compañero ideal. Inteligencia, salud y misticismo en un tamaño compacto. ¡Conoce más en Xolos Ramirez!">
     <style>

--- a/blog/xoloitzcuintle-temperamento.html
+++ b/blog/xoloitzcuintle-temperamento.html
@@ -3,6 +3,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <link rel="canonical" href="https://xolosramirez.com/blog/xoloitzcuintle-temperamento.html" />
     <title>Xoloitzcuintle: Temperamento y Personalidad</title>
     <script src="https://cdn.tailwindcss.com"></script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/Chart.js/3.9.1/chart.min.js"></script>

--- a/contacto.html
+++ b/contacto.html
@@ -10,6 +10,7 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
     <!-- End Google Tag Manager -->
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <link rel="canonical" href="https://xolosramirez.com/contacto.html" />
     <title>Contacto: Criadero y Venta de Xoloitzcuintles | Xolos Ramírez</title>
     <meta
       name="description"
@@ -24,7 +25,7 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
       property="og:description"
       content="Solicita información de adopciones, colaboraciones y eventos del xoloitzcuintle con el equipo especializado de Xolos Ramírez."
     />
-    <meta property="og:image" content="https://www.xolosramirez.com/img/hero/site-hero.jpg" />
+    <meta property="og:image" content="https://xolosramirez.com/img/hero/site-hero.jpg" />
     <meta property="og:type" content="website" />
     <meta name="twitter:card" content="summary_large_image" />
     <meta name="twitter:title" content="Contacto y asesoría sobre xoloitzcuintles | Xolos Ramírez" />
@@ -32,10 +33,10 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
       name="twitter:description"
       content="Solicita información de adopciones, colaboraciones y eventos del xoloitzcuintle con el equipo especializado de Xolos Ramírez."
     />
-    <meta name="twitter:image" content="https://www.xolosramirez.com/img/hero/site-hero.jpg" />
-    <link rel="alternate" hreflang="es" href="https://www.xolosramirez.com/contacto.html" />
-    <link rel="alternate" hreflang="en" href="https://www.xolosramirez.com/en/contact.html" />
-    <link rel="alternate" hreflang="x-default" href="https://www.xolosramirez.com/index.html" />
+    <meta name="twitter:image" content="https://xolosramirez.com/img/hero/site-hero.jpg" />
+    <link rel="alternate" hreflang="es" href="https://xolosramirez.com/contacto.html" />
+    <link rel="alternate" hreflang="en" href="https://xolosramirez.com/en/contact.html" />
+    <link rel="alternate" hreflang="x-default" href="https://xolosramirez.com/" />
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
     <link

--- a/en/available-xolos.html
+++ b/en/available-xolos.html
@@ -11,7 +11,7 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
   <title>Available Xoloitzcuintli Puppies for Sale | Xolos Ramírez</title>
   <meta name="description" content="Meet our available Xoloitzcuintli puppies. Standard, intermediate, and miniature sizes available. Health certified, NFT lineage, and safe shipping to the US & Canada.">
 
-  <link rel="canonical" href="https://xolosramirez.com/en/available-xolos.html">
+  <link rel="canonical" href="https://xolosramirez.com/en/available-xolos.html" />
   <link rel="alternate" hreflang="en" href="https://xolosramirez.com/en/available-xolos.html">
   <link rel="alternate" hreflang="es" href="https://xolosramirez.com/xolos-disponibles.html">
   <link rel="alternate" hreflang="x-default" href="https://xolosramirez.com/xolos-disponibles.html">

--- a/en/index.html
+++ b/en/index.html
@@ -8,6 +8,7 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
 })(window,document,'script','dataLayer','GTM-MGTMWN7T');</script>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <link rel="canonical" href="https://xolosramirez.com/en/index.html" />
     <title>Xoloitzcuintli Kennel: Sale and Adoption | Xolos Ramírez CDMX</title>
     <meta
       name="description"
@@ -22,7 +23,7 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
       property="og:description"
       content="Discover the Xolos Ramírez community: history, responsible adoptions, gallery, and stories about the xoloitzcuintle in Mexico."
     />
-    <meta property="og:image" content="https://www.xolosramirez.com/img/hero/site-hero.jpg" />
+    <meta property="og:image" content="https://xolosramirez.com/img/hero/site-hero.jpg" />
     <meta property="og:type" content="website" />
     <meta name="twitter:card" content="summary_large_image" />
     <meta name="twitter:title" content="Xolos Ramírez – Community dedicated to the Xoloitzcuintli" />
@@ -30,10 +31,10 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
       name="twitter:description"
       content="Discover the Xolos Ramírez community: history, responsible adoptions, gallery, and stories about the xoloitzcuintle in Mexico."
     />
-    <meta name="twitter:image" content="https://www.xolosramirez.com/img/hero/site-hero.jpg" />
-    <link rel="alternate" hreflang="es" href="https://www.xolosramirez.com/index.html" />
-    <link rel="alternate" hreflang="en" href="https://www.xolosramirez.com/en/index.html" />
-    <link rel="alternate" hreflang="x-default" href="https://www.xolosramirez.com/index.html" />
+    <meta name="twitter:image" content="https://xolosramirez.com/img/hero/site-hero.jpg" />
+    <link rel="alternate" hreflang="es" href="https://xolosramirez.com/" />
+    <link rel="alternate" hreflang="en" href="https://xolosramirez.com/en/index.html" />
+    <link rel="alternate" hreflang="x-default" href="https://xolosramirez.com/" />
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
     <link

--- a/index.html
+++ b/index.html
@@ -10,6 +10,7 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
     <!-- End Google Tag Manager -->
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <link rel="canonical" href="https://xolosramirez.com/" />
     <title>Criadero de Xoloitzcuintles: Venta y Adopción | Xolos Ramírez CDMX</title>
     <meta
       name="description"
@@ -24,7 +25,7 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
       property="og:description"
       content="Descubre la comunidad Xolos Ramírez: historia, adopciones responsables, galería y testimonios sobre el xoloitzcuintle en México."
     />
-    <meta property="og:image" content="https://www.xolosramirez.com/img/hero/site-hero.jpg" />
+    <meta property="og:image" content="https://xolosramirez.com/img/hero/site-hero.jpg" />
     <meta property="og:type" content="website" />
     <meta name="twitter:card" content="summary_large_image" />
     <meta name="twitter:title" content="Xolos Ramírez – Comunidad dedicada al xoloitzcuintle" />
@@ -32,10 +33,10 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
       name="twitter:description"
       content="Descubre la comunidad Xolos Ramírez: historia, adopciones responsables, galería y testimonios sobre el xoloitzcuintle en México."
     />
-    <meta name="twitter:image" content="https://www.xolosramirez.com/img/hero/site-hero.jpg" />
-    <link rel="alternate" hreflang="es" href="https://www.xolosramirez.com/index.html" />
-    <link rel="alternate" hreflang="en" href="https://www.xolosramirez.com/en/index.html" />
-    <link rel="alternate" hreflang="x-default" href="https://www.xolosramirez.com/index.html" />
+    <meta name="twitter:image" content="https://xolosramirez.com/img/hero/site-hero.jpg" />
+    <link rel="alternate" hreflang="es" href="https://xolosramirez.com/" />
+    <link rel="alternate" hreflang="en" href="https://xolosramirez.com/en/index.html" />
+    <link rel="alternate" hreflang="x-default" href="https://xolosramirez.com/" />
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
     <link
@@ -372,7 +373,7 @@ NFTs de Linaje Xoloitzcuintle</a></li>
       <section class="cta-section">
         <div class="container">
           <h2>¿Listo para recibir a un compañero ancestral?</h2>
-          <a href="http://xolosramirez.com/xolos-disponibles.html" class="btn">Ver Xolos Ramirez disponibles</a>
+          <a href="https://xolosramirez.com/xolos-disponibles.html" class="btn">Ver Xolos Ramirez disponibles</a>
         </div>
       </section>
 

--- a/sitemap.xml
+++ b/sitemap.xml
@@ -1,70 +1,76 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9" xmlns:xhtml="http://www.w3.org/1999/xhtml">
+
+  <!-- Home (Español e Inglés) -->
   <url>
-    <loc>https://www.xolosramirez.com/index.html</loc>
-    <priority>1.00</priority>
+    <loc>https://xolosramirez.com/</loc>
+    <lastmod>2026-06-07</lastmod>
+    <changefreq>weekly</changefreq>
+    <priority>1.0</priority>
+    <xhtml:link rel="alternate" hreflang="en" href="https://xolosramirez.com/en/index.html" />
+    <xhtml:link rel="alternate" hreflang="es" href="https://xolosramirez.com/" />
   </url>
   <url>
-    <loc>https://www.xolosramirez.com/xolos-disponibles.html</loc>
-    <priority>0.90</priority>
-  </url>
-  <url>
-    <loc>https://www.xolosramirez.com/galeria.html</loc>
-    <priority>0.80</priority>
-  </url>
-  <url>
-    <loc>https://www.xolosramirez.com/testimonios.html</loc>
-    <priority>0.70</priority>
-  </url>
-  <url>
-    <loc>https://www.xolosramirez.com/contacto.html</loc>
-    <priority>0.70</priority>
+    <loc>https://xolosramirez.com/en/index.html</loc>
+    <lastmod>2026-06-07</lastmod>
+    <changefreq>weekly</changefreq>
+    <priority>0.9</priority>
   </url>
 
+  <!-- Páginas Comerciales Principales -->
   <url>
-    <loc>https://www.xolosramirez.com/blog/index.html</loc>
-    <priority>0.85</priority>
+    <loc>https://xolosramirez.com/xolos-disponibles.html</loc>
+    <lastmod>2026-06-07</lastmod>
+    <changefreq>daily</changefreq>
+    <priority>0.9</priority>
+    <xhtml:link rel="alternate" hreflang="en" href="https://xolosramirez.com/en/available-xolos.html" />
+    <xhtml:link rel="alternate" hreflang="es" href="https://xolosramirez.com/xolos-disponibles.html" />
   </url>
   <url>
-    <loc>https://www.xolosramirez.com/blog/historia-xoloitzcuintle.html</loc>
-    <priority>0.75</priority>
-  </url>
-  <url>
-    <loc>https://www.xolosramirez.com/blog/alergias-en-el-xoloitzcuintle.html</loc>
-    <priority>0.75</priority>
-  </url>
-  <url>
-    <loc>https://www.xolosramirez.com/blog/cuidados-basicos.html</loc>
-    <priority>0.75</priority>
-  </url>
-  <url>
-    <loc>https://www.xolosramirez.com/blog/cultura-mexicana.html</loc>
-    <priority>0.75</priority>
+    <loc>https://xolosramirez.com/en/available-xolos.html</loc>
+    <lastmod>2026-06-07</lastmod>
+    <changefreq>daily</changefreq>
+    <priority>0.9</priority>
   </url>
 
+  <!-- Páginas de Apoyo y Conversión -->
   <url>
-    <loc>https://www.xolosramirez.com/en/index.html</loc>
-    <priority>0.80</priority>
+    <loc>https://xolosramirez.com/testimonios.html</loc>
+    <lastmod>2026-06-07</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.8</priority>
   </url>
   <url>
-    <loc>https://www.xolosramirez.com/en/available-xolos.html</loc>
-    <priority>0.75</priority>
+    <loc>https://xolosramirez.com/contacto.html</loc>
+    <lastmod>2026-06-07</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.8</priority>
+  </url>
+
+  <!-- Clúster Educativo / Intención Media -->
+  <url>
+    <loc>https://xolosramirez.com/blog/precio-xoloitzcuintle.html</loc>
+    <lastmod>2026-06-07</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.8</priority>
   </url>
   <url>
-    <loc>https://www.xolosramirez.com/en/gallery.html</loc>
-    <priority>0.60</priority>
+    <loc>https://xolosramirez.com/blog/guia-tallas-xoloitzcuintle.html</loc>
+    <lastmod>2026-06-07</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.7</priority>
   </url>
   <url>
-    <loc>https://www.xolosramirez.com/en/testimonials.html</loc>
-    <priority>0.60</priority>
+    <loc>https://xolosramirez.com/blog/xoloitzcuintle-temperamento.html</loc>
+    <lastmod>2026-06-07</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.7</priority>
   </url>
   <url>
-    <loc>https://www.xolosramirez.com/en/contact.html</loc>
-    <priority>0.60</priority>
+    <loc>https://xolosramirez.com/blog/xoloitzcuintle-miniatura.html</loc>
+    <lastmod>2026-06-07</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.7</priority>
   </url>
-  <url>
-    <loc>https://www.xolosramirez.com/en/blog/index.html</loc>
-    <priority>0.65</priority>
-  </url>
+
 </urlset>
-

--- a/testimonios.html
+++ b/testimonios.html
@@ -10,6 +10,7 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
     <!-- End Google Tag Manager -->
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <link rel="canonical" href="https://xolosramirez.com/testimonios.html" />
     <title>Testimonios de Familias con Xoloitzcuintles | Xolos Ramírez</title>
     <meta
       name="description"
@@ -24,7 +25,7 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
       property="og:description"
       content="Lee testimonios auténticos de adoptantes, especialistas y aliados que respaldan la misión de Xolos Ramírez."
     />
-    <meta property="og:image" content="https://www.xolosramirez.com/img/hero/site-hero.jpg" />
+    <meta property="og:image" content="https://xolosramirez.com/img/hero/site-hero.jpg" />
     <meta property="og:type" content="website" />
     <meta name="twitter:card" content="summary_large_image" />
     <meta name="twitter:title" content="Testimonios de familias y expertos | Xolos Ramírez" />
@@ -32,10 +33,10 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
       name="twitter:description"
       content="Lee testimonios auténticos de adoptantes, especialistas y aliados que respaldan la misión de Xolos Ramírez."
     />
-    <meta name="twitter:image" content="https://www.xolosramirez.com/img/hero/site-hero.jpg" />
-    <link rel="alternate" hreflang="es" href="https://www.xolosramirez.com/testimonios.html" />
-    <link rel="alternate" hreflang="en" href="https://www.xolosramirez.com/en/testimonials.html" />
-    <link rel="alternate" hreflang="x-default" href="https://www.xolosramirez.com/index.html" />
+    <meta name="twitter:image" content="https://xolosramirez.com/img/hero/site-hero.jpg" />
+    <link rel="alternate" hreflang="es" href="https://xolosramirez.com/testimonios.html" />
+    <link rel="alternate" hreflang="en" href="https://xolosramirez.com/en/testimonials.html" />
+    <link rel="alternate" hreflang="x-default" href="https://xolosramirez.com/" />
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
     <link

--- a/xolos-disponibles.html
+++ b/xolos-disponibles.html
@@ -21,11 +21,11 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
       property="og:description"
        content="Consulta xoloitzcuintle precio, disponibilidad actual y compra segura con nuestro criadero en Ciudad de México."
     />
-    <meta property="og:image" content="https://www.xolosramirez.com/img/hero/site-hero.jpg" />
+    <meta property="og:image" content="https://xolosramirez.com/img/hero/site-hero.jpg" />
     <meta property="og:type" content="website" />
     <meta name="twitter:card" content="summary_large_image" />
     <meta name="twitter:title" content="Xoloitzcuintles disponibles | Xolos Ramírez" />
-    <link rel="canonical" href="https://xolosramirez.com/xolos-disponibles.html">
+    <link rel="canonical" href="https://xolosramirez.com/xolos-disponibles.html" />
     <link rel="alternate" hreflang="es" href="https://xolosramirez.com/xolos-disponibles.html">
     <link rel="alternate" hreflang="en" href="https://xolosramirez.com/en/available-xolos.html">
     <link rel="alternate" hreflang="x-default" href="https://xolosramirez.com/xolos-disponibles.html">
@@ -33,7 +33,7 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
       name="twitter:description"
       content="Explora fichas completas de xoloitzcuintles listos para adopción responsable, con detalles de salud, personalidad y requisitos."
     />
-    <meta name="twitter:image" content="https://www.xolosramirez.com/img/hero/site-hero.jpg" />
+    <meta name="twitter:image" content="https://xolosramirez.com/img/hero/site-hero.jpg" />
 
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
@@ -50,7 +50,7 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
         "@context": "https://schema.org",
         "@type": "DogBreeder",
         "name": "Xolos Ramírez",
-        "url": "https://www.xolosramirez.com/xolos-disponibles.html",
+        "url": "https://xolosramirez.com/xolos-disponibles.html",
         "description": "Criadero de xoloitzcuintle en CDMX especializado en venta responsable con control veterinario y seguimiento.",
         "areaServed": "Ciudad de México",
         "breed": "Xoloitzcuintle",


### PR DESCRIPTION
### Motivation
- Ensure the site uses a single canonical domain (`https://xolosramirez.com`) to avoid www/http duplicates and improve Search Console/analytics consistency.
- Provide a minimal, business-focused `sitemap.xml` that only exposes the money pages, conversion/support pages and key blog cluster specified for indexing.

### Description
- Replaced the root `sitemap.xml` with a focused, non‑www sitemap containing Home ES/EN, `xolos-disponibles`, support pages and four key blog posts, adding `lastmod`, `changefreq` and `priority` values.
- Added or normalized `<link rel="canonical">` tags to the homepage and targeted pages: `index.html`, `en/index.html`, `xolos-disponibles.html`, `en/available-xolos.html`, `testimonios.html`, `contacto.html` and the blog articles `precio-xoloitzcuintle.html`, `guia-tallas-xoloitzcuintle.html`, `xoloitzcuintle-temperamento.html`, `xoloitzcuintle-miniatura.html` pointing at `https://xolosramirez.com/...`.
- Removed remaining `www` references and normalized social/og/twitter image URLs and hreflang alternates to the non‑www domain, and updated an internal CTA to `https://xolosramirez.com/xolos-disponibles.html`.
- Minor whitespace/format fixes in `sitemap.xml` and small consistency fixes (self-closing canonical links where appropriate) across the modified HTML files.

### Testing
- Verified the generated `sitemap.xml` parses as XML with `python3` and `xml.etree.ElementTree` (returned OK).
- Ran a Python check that each target file contains the exact canonical tag (script checked presence of `<link rel="canonical" href="..." />`) and it succeeded.
- Scanned for leftover `www` or `http` references in the updated SEO files with `rg` and confirmed none remain.
- Ran `git diff --check` to validate whitespace issues and ensured no trailing/parse problems remained (all checks passed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a259d8fca0483328e4733a41371bcbc)