### PR TITLE
Add Tonalli Connect purchase flow and RMZ UX to xolo-skin-care

### DIFF
--- a/xolo-skin-care/index.html
+++ b/xolo-skin-care/index.html
@@ -1429,7 +1429,7 @@
   </nav>
   <main id="mainContent" role="main">
    <section class="hero" aria-labelledby="heroTitle heroTagline">
-     
+
 <!-- HERO IMAGE -->
 <picture class="hero-media">
   <img
@@ -1609,8 +1609,8 @@
       <h3>Cómo usar XEC</h3>
       <p>Consulta los pasos completos en el modal “¿Cómo pagar con eCash (XEC)?” y usa el botón <strong>Copiar dirección</strong> antes de enviar.</p>
 
-      <h3>Cómo usar Tonalli DEX (RMZ)</h3>
-      <p>Abre la guía desde los botones “Guía Tonalli (paso a paso)” (o la barra de compra rápida), copia el Offer ID del producto y sigue el flujo dentro del modal.</p>
+      <h3>Cómo usar Tonalli Connect (RMZ)</h3>
+      <p>Usa “Comprar con Tonalli Connect” para firmar tu orden Web3 o abre “¿Dónde comprar RMZ?” para ver cómo adquirir RMZ desde Tonalli Wallet.</p>
     </div>
   </section>
 
@@ -1661,26 +1661,26 @@
         <p>Formulado para apoyar el cuidado de pieles sensibles con tendencia a irritación, pequeñas molestias cutáneas o zonas que requieren limpieza botánica. El árbol de té es valorado tradicionalmente por sus propiedades purificantes, antibacterianas y protectoras. Ideal para el cuidado puntual de la piel del Xoloitzcuintle.</p>
       </div>
       <div class="card-actions">
-        <p><strong>Flujo rápido:</strong> 1) Copia Offer ID · 2) Abre wallet · 3) Pega y paga en Tonalli.</p>
-        <p><strong>RMZ = comprobante digital de compra</strong></p>
-        <p>Precio: <span class="price-rmz">5752.32</span> RMZ</p>
-        <div class="offer-id-box">
-          <span class="offer-id">44d97441db8e02e045181bf2f213d1f782af81b9e1c4eabab28e641c8e8b1f01:1</span>
-          <button class="copy-offer-btn" type="button">Copiar Offer ID</button>
-        </div>
-        <a href="https://cartera.xolosarmy.xyz" target="_blank" rel="noopener noreferrer">
-          Abrir wallet Tonalli (paso 2)
-        </a>
-        <button class="tonalli-guide" type="button" data-open-tonalli-modal>Guía Tonalli (paso a paso)</button>
+        <p><strong>Pago Web3 Simplificado:</strong> 1 clic para firmar tu orden con Tonalli Connect y facilitar la validación del pago RMZ.</p>
+        <p>Precio: <span class="price-rmz"></span> RMZ</p>
+
+        <button class="btn-primary tonalli-connect-btn" type="button" style="width: 100%; margin-bottom: 8px;">
+          <i class="fa-solid fa-link" aria-hidden="true"></i> Comprar con Tonalli Connect
+        </button>
+
+        <button class="tonalli-guide" type="button" data-open-tonalli-modal style="width: 100%; justify-content: center; margin-bottom: 8px;">
+          ¿Dónde comprar RMZ?
+        </button>
+
         <a href="https://wa.me/qr/R2F5PRQYZSJOA1"
            class="whatsapp-buy" target="_blank" rel="noopener noreferrer"
            data-ga-event="whatsapp_lead"
-           data-item="Ungüento Solar del Guardián Xólotl"
-           aria-label="Abrir WhatsApp para comprar el Ungüento Solar del Guardián Xólotl mediante transferencia bancaria">
+           data-item="Ungüento Solar del Guardián Xólotl">
           <span aria-hidden="true">🟢</span>
-          <span>Comprar por WhatsApp (Transferencia bancaria)</span>
+          <span>Comprar por WhatsApp</span>
         </a>
-        <button class="txid-toggle" type="button">Ya compré, pegar TXID</button>
+
+        <button class="txid-toggle" type="button" style="width: 100%;">Ya compré, pegar TXID manual</button>
         <form class="txid-form" onsubmit="return false;">
           <input type="text" name="txid" placeholder="Pega tu TXID aquí" required>
           <button type="submit">Confirmar TXID</button>
@@ -1705,25 +1705,26 @@
         <p>Una fórmula pensada para acompañar momentos de calma, descanso y relajación. La lavanda es utilizada tradicionalmente para favorecer tranquilidad, aliviar tensión nerviosa, apoyar el sueño y cuidar la piel en zonas con pequeñas marcas, cicatrices o resequedad. Ideal para rituales suaves de masaje y bienestar.</p>
       </div>
       <div class="card-actions">
-        <p><strong>Flujo rápido:</strong> 1) Copia Offer ID · 2) Abre wallet · 3) Pega y paga en Tonalli.</p>
-        <p><strong>RMZ = comprobante digital de compra</strong></p>
-        <p>Precio: <span class="price-rmz">5752.32</span> RMZ</p>
-        <div class="offer-id-box">
-          <span class="offer-id">REPLACE_WITH_TXID:1</span>
-          <button class="copy-offer-btn" type="button">Copiar Offer ID</button>
-        </div>
-        <a href="https://cartera.xolosarmy.xyz" target="_blank" rel="noopener noreferrer">
-          Abrir wallet Tonalli (paso 2)
-        </a>
-        <button class="tonalli-guide" type="button" data-open-tonalli-modal>Guía Tonalli (paso a paso)</button>
+        <p><strong>Pago Web3 Simplificado:</strong> 1 clic para firmar tu orden con Tonalli Connect y facilitar la validación del pago RMZ.</p>
+        <p>Precio: <span class="price-rmz"></span> RMZ</p>
+
+        <button class="btn-primary tonalli-connect-btn" type="button" style="width: 100%; margin-bottom: 8px;">
+          <i class="fa-solid fa-link" aria-hidden="true"></i> Comprar con Tonalli Connect
+        </button>
+
+        <button class="tonalli-guide" type="button" data-open-tonalli-modal style="width: 100%; justify-content: center; margin-bottom: 8px;">
+          ¿Dónde comprar RMZ?
+        </button>
+
         <a href="https://wa.me/qr/R2F5PRQYZSJOA1"
-           class="whatsapp-buy" target="_blank" rel="noopener noreferrer" data-ga-event="whatsapp_lead"
-           data-item="Néctar Onírico de Tlazōlteōtl"
-           aria-label="Abrir WhatsApp para comprar el Néctar Onírico de Tlazōlteōtl mediante transferencia bancaria">
+           class="whatsapp-buy" target="_blank" rel="noopener noreferrer"
+           data-ga-event="whatsapp_lead"
+           data-item="Néctar Onírico de Tlazōlteōtl">
           <span aria-hidden="true">🟢</span>
-          <span>Comprar por WhatsApp (Transferencia bancaria)</span>
+          <span>Comprar por WhatsApp</span>
         </a>
-        <button class="txid-toggle" type="button">Ya compré, pegar TXID</button>
+
+        <button class="txid-toggle" type="button" style="width: 100%;">Ya compré, pegar TXID manual</button>
         <form class="txid-form" onsubmit="return false;">
           <input type="text" name="txid" placeholder="Pega tu TXID aquí" required>
           <button type="submit">Confirmar TXID</button>
@@ -1743,19 +1744,31 @@
         <p>Bálsamo natural creado para proteger la piel del Xoloitzcuintle frente a la exposición solar cotidiana. Ayuda a formar una barrera humectante sobre la piel, especialmente útil en perros sin pelo o con zonas sensibles. Aplicar antes de la exposición al sol y reaplicar cuando sea necesario.</p>
       </div>
       <div class="card-actions">
-        <p><strong>RMZ = comprobante digital de compra</strong></p>
-        <div class="offer-id-box">
-          <span class="offer-id">e9447b3f72fd79a9a6795328d47f3216e92276d7bb2176f6bef06afb6a4b6ddef:1</span>
-          <button class="copy-offer-btn" type="button">Copiar Offer ID</button>
-        </div>
-        <a href="https://cartera.xolosarmy.xyz" target="_blank" rel="noopener noreferrer">Abrir wallet Tonalli (paso 2)</a>
+        <p><strong>Pago Web3 Simplificado:</strong> 1 clic para firmar tu orden con Tonalli Connect y facilitar la validación del pago RMZ.</p>
+        <p>Precio: <span class="price-rmz"></span> RMZ</p>
+
+        <button class="btn-primary tonalli-connect-btn" type="button" style="width: 100%; margin-bottom: 8px;">
+          <i class="fa-solid fa-link" aria-hidden="true"></i> Comprar con Tonalli Connect
+        </button>
+
+        <button class="tonalli-guide" type="button" data-open-tonalli-modal style="width: 100%; justify-content: center; margin-bottom: 8px;">
+          ¿Dónde comprar RMZ?
+        </button>
+
         <a href="https://wa.me/qr/R2F5PRQYZSJOA1"
            class="whatsapp-buy" target="_blank" rel="noopener noreferrer"
-           aria-label="Comprar por WhatsApp">
+           data-ga-event="whatsapp_lead"
+           data-item="Bálsamo Protector Solar">
           <span aria-hidden="true">🟢</span>
           <span>Comprar por WhatsApp</span>
         </a>
-        <button class="txid-toggle" type="button">Ya compré, pegar TXID</button>
+
+        <button class="txid-toggle" type="button" style="width: 100%;">Ya compré, pegar TXID manual</button>
+        <form class="txid-form" onsubmit="return false;">
+          <input type="text" name="txid" placeholder="Pega tu TXID aquí" required>
+          <button type="submit">Confirmar TXID</button>
+        </form>
+        <p class="txid-success-msg" role="status" aria-live="polite"></p>
       </div>
     </div>
 
@@ -1775,25 +1788,26 @@
         <p>Fórmula botánica de aroma fresco pensada para pieles con tendencia grasa o con necesidad de limpieza profunda. El limón es valorado tradicionalmente por su efecto purificante, revitalizante y refrescante. Puede apoyar el cuidado de piel con acné, exceso de grasa y también ayudar a repeler insectos de forma aromática. Precaución: evitar la exposición directa al sol inmediatamente después de su aplicación.</p>
       </div>
       <div class="card-actions">
-        <p><strong>Flujo rápido:</strong> 1) Copia Offer ID · 2) Abre wallet · 3) Pega y paga en Tonalli.</p>
-        <p><strong>RMZ = comprobante digital de compra</strong></p>
-        <p>Precio: <span class="price-rmz">5752.32</span> RMZ</p>
-        <div class="offer-id-box">
-          <span class="offer-id">d007f09d6167d1c7a8517cfff7446d59d69b5afe90202d739e463436fa3aa092:1</span>
-          <button class="copy-offer-btn" type="button">Copiar Offer ID</button>
-        </div>
-        <a href="https://cartera.xolosarmy.xyz" target="_blank" rel="noopener noreferrer">
-          Abrir wallet Tonalli (paso 2)
-        </a>
-        <button class="tonalli-guide" type="button" data-open-tonalli-modal>Guía Tonalli (paso a paso)</button>
+        <p><strong>Pago Web3 Simplificado:</strong> 1 clic para firmar tu orden con Tonalli Connect y facilitar la validación del pago RMZ.</p>
+        <p>Precio: <span class="price-rmz"></span> RMZ</p>
+
+        <button class="btn-primary tonalli-connect-btn" type="button" style="width: 100%; margin-bottom: 8px;">
+          <i class="fa-solid fa-link" aria-hidden="true"></i> Comprar con Tonalli Connect
+        </button>
+
+        <button class="tonalli-guide" type="button" data-open-tonalli-modal style="width: 100%; justify-content: center; margin-bottom: 8px;">
+          ¿Dónde comprar RMZ?
+        </button>
+
         <a href="https://wa.me/qr/R2F5PRQYZSJOA1"
-           class="whatsapp-buy" target="_blank" rel="noopener noreferrer" data-ga-event="whatsapp_lead"
-           data-item="Esencia Citlalinahuatl del Amanecer"
-           aria-label="Abrir WhatsApp para comprar la Esencia Citlalinahuatl del Amanecer mediante transferencia bancaria">
+           class="whatsapp-buy" target="_blank" rel="noopener noreferrer"
+           data-ga-event="whatsapp_lead"
+           data-item="Esencia Citlalinahuatl del Amanecer">
           <span aria-hidden="true">🟢</span>
-          <span>Comprar por WhatsApp (Transferencia bancaria)</span>
+          <span>Comprar por WhatsApp</span>
         </a>
-        <button class="txid-toggle" type="button">Ya compré, pegar TXID</button>
+
+        <button class="txid-toggle" type="button" style="width: 100%;">Ya compré, pegar TXID manual</button>
         <form class="txid-form" onsubmit="return false;">
           <input type="text" name="txid" placeholder="Pega tu TXID aquí" required>
           <button type="submit">Confirmar TXID</button>
@@ -1818,25 +1832,26 @@
         <p>Mezcla botánica diseñada para ayudar a repeler insectos durante paseos, visitas al jardín o actividades al aire libre. Su aroma natural funciona como una barrera suave para acompañar el cuidado diario del Xoloitzcuintle sin recurrir a fragancias agresivas.</p>
       </div>
       <div class="card-actions">
-        <p><strong>Flujo rápido:</strong> 1) Copia Offer ID · 2) Abre wallet · 3) Pega y paga en Tonalli.</p>
-        <p><strong>RMZ = comprobante digital de compra</strong></p>
-        <p>Precio: <span class="price-rmz">5752.32</span> RMZ</p>
-        <div class="offer-id-box">
-          <span class="offer-id">24c72fd8fe3956c19e76a66d767f594228025d1a8330c45b8b59d5ed7efbff12:1</span>
-          <button class="copy-offer-btn" type="button">Copiar Offer ID</button>
-        </div>
-        <a href="https://cartera.xolosarmy.xyz" target="_blank" rel="noopener noreferrer">
-          Abrir wallet Tonalli (paso 2)
-        </a>
-        <button class="tonalli-guide" type="button" data-open-tonalli-modal>Guía Tonalli (paso a paso)</button>
+        <p><strong>Pago Web3 Simplificado:</strong> 1 clic para firmar tu orden con Tonalli Connect y facilitar la validación del pago RMZ.</p>
+        <p>Precio: <span class="price-rmz"></span> RMZ</p>
+
+        <button class="btn-primary tonalli-connect-btn" type="button" style="width: 100%; margin-bottom: 8px;">
+          <i class="fa-solid fa-link" aria-hidden="true"></i> Comprar con Tonalli Connect
+        </button>
+
+        <button class="tonalli-guide" type="button" data-open-tonalli-modal style="width: 100%; justify-content: center; margin-bottom: 8px;">
+          ¿Dónde comprar RMZ?
+        </button>
+
         <a href="https://wa.me/qr/R2F5PRQYZSJOA1"
-           class="whatsapp-buy" target="_blank" rel="noopener noreferrer" data-ga-event="whatsapp_lead"
-           data-item="Escudo de Bruma de Quetzalcóatl"
-           aria-label="Abrir WhatsApp para comprar el Escudo de Bruma de Quetzalcóatl mediante transferencia bancaria">
+           class="whatsapp-buy" target="_blank" rel="noopener noreferrer"
+           data-ga-event="whatsapp_lead"
+           data-item="Escudo de Bruma de Quetzalcóatl">
           <span aria-hidden="true">🟢</span>
-          <span>Comprar por WhatsApp (Transferencia bancaria)</span>
+          <span>Comprar por WhatsApp</span>
         </a>
-        <button class="txid-toggle" type="button">Ya compré, pegar TXID</button>
+
+        <button class="txid-toggle" type="button" style="width: 100%;">Ya compré, pegar TXID manual</button>
         <form class="txid-form" onsubmit="return false;">
           <input type="text" name="txid" placeholder="Pega tu TXID aquí" required>
           <button type="submit">Confirmar TXID</button>
@@ -1866,25 +1881,26 @@
         </ul>
       </div>
       <div class="card-actions">
-        <p><strong>Flujo rápido:</strong> 1) Copia Offer ID · 2) Abre wallet · 3) Pega y paga en Tonalli.</p>
-        <p><strong>RMZ = comprobante digital de compra</strong></p>
-        <p>Precio: <span class="price-rmz">5752.32</span> RMZ</p>
-        <div class="offer-id-box">
-          <span class="offer-id">6d7bb2176f6bef06afb6a4b6ddef7447b3f72fd79a9a6795328d47f3216e9227:1</span>
-          <button class="copy-offer-btn" type="button">Copiar Offer ID</button>
-        </div>
-        <a href="https://cartera.xolosarmy.xyz" target="_blank" rel="noopener noreferrer">
-          Abrir wallet Tonalli (paso 2)
-        </a>
-        <button class="tonalli-guide" type="button" data-open-tonalli-modal>Guía Tonalli (paso a paso)</button>
+        <p><strong>Pago Web3 Simplificado:</strong> 1 clic para firmar tu orden con Tonalli Connect y facilitar la validación del pago RMZ.</p>
+        <p>Precio: <span class="price-rmz"></span> RMZ</p>
+
+        <button class="btn-primary tonalli-connect-btn" type="button" style="width: 100%; margin-bottom: 8px;">
+          <i class="fa-solid fa-link" aria-hidden="true"></i> Comprar con Tonalli Connect
+        </button>
+
+        <button class="tonalli-guide" type="button" data-open-tonalli-modal style="width: 100%; justify-content: center; margin-bottom: 8px;">
+          ¿Dónde comprar RMZ?
+        </button>
+
         <a href="https://wa.me/qr/R2F5PRQYZSJOA1"
-           class="whatsapp-buy" target="_blank" rel="noopener noreferrer" data-ga-event="whatsapp_lead"
-           data-item="Dúo Ritual de Espuma del Mictlán"
-           aria-label="Abrir WhatsApp para comprar el Dúo Ritual de Espuma del Mictlán mediante transferencia bancaria">
+           class="whatsapp-buy" target="_blank" rel="noopener noreferrer"
+           data-ga-event="whatsapp_lead"
+           data-item="Dúo Ritual de Espuma del Mictlán">
           <span aria-hidden="true">🟢</span>
-          <span>Comprar por WhatsApp (Transferencia bancaria)</span>
+          <span>Comprar por WhatsApp</span>
         </a>
-        <button class="txid-toggle" type="button">Ya compré, pegar TXID</button>
+
+        <button class="txid-toggle" type="button" style="width: 100%;">Ya compré, pegar TXID manual</button>
         <form class="txid-form" onsubmit="return false;">
           <input type="text" name="txid" placeholder="Pega tu TXID aquí" required>
           <button type="submit">Confirmar TXID</button>
@@ -1893,7 +1909,7 @@
       </div>
     </div>
 
-    
+
     <!-- Producto 6 -->
     <div class="card animate-on-scroll" data-sku="xolo-bienestar" data-category="kit">
       <div class="product-media">
@@ -1918,25 +1934,26 @@
         <p class="promo-text">Solución completa para el cuidado natural del Xoloitzcuintle. Incluye tres bálsamos o aceites botánicos, dos jabones artesanales y un repelente natural de insectos. Diseñado para proteger, limpiar, relajar y acompañar el bienestar diario de perros sin pelo o con piel sensible.</p>
       </div>
       <div class="card-actions">
-        <p><strong>Flujo rápido:</strong> 1) Copia Offer ID · 2) Abre wallet · 3) Pega y paga en Tonalli.</p>
-        <p><strong>RMZ = comprobante digital de compra</strong></p>
-        <p>Precio: <span class="price-rmz">20707.84</span> RMZ</p>
-        <div class="offer-id-box">
-          <span class="offer-id">a16e9319ef221abf486a47dd43e1ab2035b2a1e0cabc688ac3462c31261c75e6:1</span>
-          <button class="copy-offer-btn" type="button">Copiar Offer ID</button>
-        </div>
-        <a href="https://cartera.xolosarmy.xyz" target="_blank" rel="noopener noreferrer">
-          Abrir wallet Tonalli (paso 2)
-        </a>
-        <a href="https://wa.me/qr/R2F5PRQYZSJOA1" class="btn-highlight" target="_blank" rel="noopener noreferrer">Personalizar mi Paquete</a>
+        <p><strong>Pago Web3 Simplificado:</strong> 1 clic para firmar tu orden con Tonalli Connect y facilitar la validación del pago RMZ.</p>
+        <p>Precio: <span class="price-rmz"></span> RMZ</p>
+
+        <button class="btn-primary tonalli-connect-btn" type="button" style="width: 100%; margin-bottom: 8px;">
+          <i class="fa-solid fa-link" aria-hidden="true"></i> Comprar con Tonalli Connect
+        </button>
+
+        <button class="tonalli-guide" type="button" data-open-tonalli-modal style="width: 100%; justify-content: center; margin-bottom: 8px;">
+          ¿Dónde comprar RMZ?
+        </button>
+
         <a href="https://wa.me/qr/R2F5PRQYZSJOA1"
-           class="whatsapp-buy" target="_blank" rel="noopener noreferrer" data-ga-event="whatsapp_lead"
-           data-item="Paquete Bienestar Integral Xoloitzcuintle"
-           aria-label="Abrir WhatsApp para comprar el Paquete Bienestar Integral Xoloitzcuintle mediante transferencia bancaria">
+           class="whatsapp-buy" target="_blank" rel="noopener noreferrer"
+           data-ga-event="whatsapp_lead"
+           data-item="Paquete Bienestar Integral Xoloitzcuintle">
           <span aria-hidden="true">🟢</span>
-          <span>Comprar por WhatsApp (Transferencia bancaria)</span>
+          <span>Comprar por WhatsApp</span>
         </a>
-        <button class="txid-toggle" type="button">Ya compré, pegar TXID</button>
+
+        <button class="txid-toggle" type="button" style="width: 100%;">Ya compré, pegar TXID manual</button>
         <form class="txid-form" onsubmit="return false;">
           <input type="text" name="txid" placeholder="Pega tu TXID aquí" required>
           <button type="submit">Confirmar TXID</button>
@@ -1975,7 +1992,7 @@
         aria-haspopup="dialog"
         aria-expanded="false">
         <i class="fa-solid fa-coins" aria-hidden="true"></i>
-        Pagar con RMZ (Tonalli DEX)
+        ¿Dónde comprar RMZ?
       </button>
 
       <a
@@ -2050,16 +2067,26 @@
       <button class="xec-modal__close" id="closeTonalliModal" type="button" aria-label="Cerrar guía Tonalli DEX">
         <i class="fa-solid fa-xmark" aria-hidden="true"></i>
       </button>
-      <h2 class="xec-modal__title" id="tonalliModalTitle">¿Cómo pagar con Tonalli (Offer ID)?</h2>
-      <ol class="xec-modal__list">
-        <li>Abre tu cartera Tonalli y ve a la sección DEX.</li>
-        <li>Selecciona la opción para pagar con Offer ID.</li>
-        <li>Pega el Offer ID que copiaste en el campo correspondiente.</li>
-        <li>Ingresa el monto exacto de <strong>RMZ</strong> y confirma la transacción.</li>
-        <li>Espera la confirmación y copia tu TXID de la transacción.</li>
-      </ol>
+      <h2 class="xec-modal__title" id="tonalliModalTitle">¿Cómo comprar con Tonalli Connect?</h2>
+
+      <div class="xec-payment-info" style="margin-bottom: 12px;">
+        <h3 style="color: var(--color-highlight-strong); margin-top: 0; margin-bottom: 8px;">Paso 1: ¿Dónde comprar RMZ?</h3>
+        <ol class="xec-modal__list">
+          <li>Abre tu <a href="https://cartera.xolosarmy.xyz" target="_blank" style="color:var(--color-highlight-strong)">Tonalli Wallet</a>.</li>
+          <li>Dirígete a la pestaña <strong>DEX</strong> (Intercambio descentralizado).</li>
+          <li>Busca el par de intercambio <strong>XEC / RMZ</strong>.</li>
+          <li>Ingresa la cantidad de eCash (XEC) que deseas cambiar y confirma la operación para obtener tus RMZ.</li>
+        </ol>
+      </div>
+
       <div class="xec-payment-info">
-        <p>⚠️ Recuerda verificar siempre la dirección y la red antes de enviar.</p>
+        <h3 style="color: var(--color-highlight-strong); margin-top: 0; margin-bottom: 8px;">Paso 2: Pagar en la tienda</h3>
+        <ol class="xec-modal__list">
+          <li>Haz clic en el botón <strong>Comprar con Tonalli Connect</strong> en el producto deseado.</li>
+          <li>Serás redirigido a tu billetera de forma segura.</li>
+          <li>Revisa y <strong>firma el mensaje</strong> (Challenge) que autoriza la orden.</li>
+          <li>¡Listo! Regresarás automáticamente aquí con tu orden firmada para continuar la validación del pago.</li>
+        </ol>
       </div>
     </div>
   </div>
@@ -2106,47 +2133,73 @@ document.addEventListener('click', function(e){
         return success;
       };
 
+      // 1. Manejo del callback de Tonalli Connect al volver a la página
+      if (window.location.hash) {
+        const hashParams = new URLSearchParams(window.location.hash.substring(1));
+        const status = hashParams.get('status');
+
+        if (status === 'success') {
+          const signature = hashParams.get('signature');
+          const address = hashParams.get('address');
+
+          alert(`¡Orden Web3 firmada correctamente!\n\nDirección eCash: ${address}\nFirma generada: ${signature.substring(0, 15)}...\n\nHemos registrado tu intención de compra. Ahora validaremos el pago RMZ correspondiente a esta orden.`);
+
+          // Limpia el hash para no volver a lanzar la alerta al recargar
+          window.history.replaceState(null, null, window.location.pathname);
+        } else if (status === 'error' || status === 'rejected') {
+          alert('La conexión con Tonalli Connect fue cancelada o denegada.');
+          window.history.replaceState(null, null, window.location.pathname);
+        }
+      }
+
+      // 2. Función actualizada para inyectar la lógica de botones
       const updateOfferBlocks = () => {
         document.querySelectorAll('.card[data-sku]').forEach((card) => {
           const sku = card.dataset.sku;
           const config = PRODUCT_OFFERS[sku];
           const priceEl = card.querySelector('.price-rmz');
-          const offerEl = card.querySelector('.offer-id');
-          const copyBtn = card.querySelector('.copy-offer-btn');
+          const connectBtn = card.querySelector('.tonalli-connect-btn');
+
+          if (config && priceEl) {
+            priceEl.textContent = config.rmz;
+          }
+
+          // Inyectamos el flujo hacia Tonalli Connect
+          if (connectBtn && config) {
+            connectBtn.addEventListener('click', () => {
+              const offerId = config.offerId;
+              const challengeId = offerId.split(':')[0].substring(0, 16); // ID corto referencial
+              // El mensaje refleja intención de orden, NO confirmación de pago
+              const message = `Autorizo la orden del producto SKU: ${sku} por ${config.rmz} RMZ. OfferID: ${offerId}`;
+
+              const callbackUrl = window.location.origin + window.location.pathname;
+
+              const tonalliUrl = new URL('https://cartera.xolosarmy.xyz/connect/sign-message');
+              tonalliUrl.searchParams.append('challenge', message);
+              tonalliUrl.searchParams.append('challengeId', challengeId);
+              tonalliUrl.searchParams.append('callbackUrl', callbackUrl);
+
+              window.location.href = tonalliUrl.toString();
+            });
+          }
+
+          // Mantiene el fallback manual del TXID
           const txToggle = card.querySelector('.txid-toggle');
           const txForm = card.querySelector('.txid-form');
           const txInput = txForm?.querySelector('input[name="txid"]');
-
-          if (config) {
-            if (priceEl) priceEl.textContent = config.rmz;
-            if (offerEl) offerEl.textContent = config.offerId;
-          }
-
-          copyBtn?.addEventListener('click', async () => {
-            const toCopy = config?.offerId || offerEl?.textContent || '';
-            if (!toCopy) return;
-            await copyTextWithFallback(toCopy);
-            copyBtn.textContent = '¡Copiado!';
-            setTimeout(() => {
-              copyBtn.textContent = 'Copiar Offer ID';
-            }, 1500);
-          });
+          const txMsg = card.querySelector('.txid-success-msg');
 
           txToggle?.addEventListener('click', () => {
             if (!txForm) return;
             txForm.style.display = txForm.style.display === 'block' ? 'none' : 'block';
           });
 
-          const txMsg = card.querySelector('.txid-success-msg');
-
           txForm?.addEventListener('submit', (event) => {
             event.preventDefault();
             const txid = txInput?.value.trim();
-            if (txid) {
-              if (txMsg) {
-                txMsg.textContent = `✅ TXID recibido: ${txid.slice(0, 12)}...${txid.slice(-6)}. Validaremos tu compra.`;
-                txMsg.style.display = 'block';
-              }
+            if (txid && txMsg) {
+              txMsg.textContent = `✅ TXID recibido: ${txid.slice(0, 12)}...${txid.slice(-6)}. Validaremos tu pago.`;
+              txMsg.style.display = 'block';
               txForm.reset();
               txForm.style.display = 'none';
             }


### PR DESCRIPTION
### Motivation
- Modernize the product purchase experience to use a Web3 signing flow (Tonalli Connect) while keeping a WhatsApp fallback and manual TXID submission for verification.
- Make RMZ pricing and OfferID-driven flows clearer and programmatically injected so content remains maintainable from the `PRODUCT_OFFERS` data.

### Description
- Updated `xolo-skin-care/index.html` to replace each product's `.card-actions` block with a new UI that includes a `Comprar con Tonalli Connect` button, a `¿Dónde comprar RMZ?` guide button, a WhatsApp fallback anchor with `data-ga-event` tracking, and a manual TXID toggle/form with success message area.
- Replaced the `tonalliDexHowToModal` content with a two-step guide that explains where to buy RMZ in Tonalli Wallet (DEX) and how to sign the order via Tonalli Connect.
- Added client-side callback handling that reads `window.location.hash` for Tonalli Connect statuses (`success`, `error`, `rejected`) and shows contextual alerts while cleaning the hash afterwards.
- Rewrote `updateOfferBlocks` JavaScript to populate RMZ prices from `PRODUCT_OFFERS`, wire `tonalli-connect-btn` to build a challenge message and redirect to `https://cartera.xolosarmy.xyz/connect/sign-message` with `challenge`, `challengeId` and `callbackUrl`, and preserve the manual TXID fallback UI behavior.

### Testing
- Ran `git diff --check` to validate whitespace and basic diff issues and fixed trailing whitespace warnings, which passed after cleanup.
- Performed static HTML checks with a custom `HTMLParser` script that asserted there are 7 `card-actions`, 7 `tonalli-connect-btn` elements and one modal, and verified `data-ga-event=

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a26cf8182648332a1cbb5814b9ba337)