### PR TITLE
Integrate WalletConnect v2 checkout for RMZ products

### DIFF
--- a/xolo-skin-care/index.html
+++ b/xolo-skin-care/index.html
@@ -1609,8 +1609,8 @@
       <h3>Cómo usar XEC</h3>
       <p>Consulta los pasos completos en el modal “¿Cómo pagar con eCash (XEC)?” y usa el botón <strong>Copiar dirección</strong> antes de enviar.</p>
 
-      <h3>Cómo usar Tonalli Connect (RMZ)</h3>
-      <p>Usa “Comprar con Tonalli Connect” para firmar tu orden Web3 o abre “¿Dónde comprar RMZ?” para ver cómo adquirir RMZ desde Tonalli Wallet.</p>
+      <h3>Cómo usar WalletConnect (RMZ)</h3>
+      <p>Usa “Comprar con WalletConnect” para firmar tu orden Web3 desde Tonalli Wallet o abre “¿Dónde comprar RMZ?” para ver cómo adquirir RMZ desde el DEX.</p>
     </div>
   </section>
 
@@ -1661,11 +1661,11 @@
         <p>Formulado para apoyar el cuidado de pieles sensibles con tendencia a irritación, pequeñas molestias cutáneas o zonas que requieren limpieza botánica. El árbol de té es valorado tradicionalmente por sus propiedades purificantes, antibacterianas y protectoras. Ideal para el cuidado puntual de la piel del Xoloitzcuintle.</p>
       </div>
       <div class="card-actions">
-        <p><strong>Pago Web3 Simplificado:</strong> 1 clic para firmar tu orden con Tonalli Connect y facilitar la validación del pago RMZ.</p>
+        <p><strong>Pago Web3 Simplificado:</strong> Conecta tu Tonalli Wallet vía WalletConnect para firmar y autorizar tu orden.</p>
         <p>Precio: <span class="price-rmz"></span> RMZ</p>
 
-        <button class="btn-primary tonalli-connect-btn" type="button" style="width: 100%; margin-bottom: 8px;">
-          <i class="fa-solid fa-link" aria-hidden="true"></i> Comprar con Tonalli Connect
+        <button class="btn-primary wc-connect-btn" type="button" style="width: 100%; margin-bottom: 8px;">
+          <i class="fa-solid fa-qrcode" aria-hidden="true"></i> Comprar con WalletConnect
         </button>
 
         <button class="tonalli-guide" type="button" data-open-tonalli-modal style="width: 100%; justify-content: center; margin-bottom: 8px;">
@@ -1705,11 +1705,11 @@
         <p>Una fórmula pensada para acompañar momentos de calma, descanso y relajación. La lavanda es utilizada tradicionalmente para favorecer tranquilidad, aliviar tensión nerviosa, apoyar el sueño y cuidar la piel en zonas con pequeñas marcas, cicatrices o resequedad. Ideal para rituales suaves de masaje y bienestar.</p>
       </div>
       <div class="card-actions">
-        <p><strong>Pago Web3 Simplificado:</strong> 1 clic para firmar tu orden con Tonalli Connect y facilitar la validación del pago RMZ.</p>
+        <p><strong>Pago Web3 Simplificado:</strong> Conecta tu Tonalli Wallet vía WalletConnect para firmar y autorizar tu orden.</p>
         <p>Precio: <span class="price-rmz"></span> RMZ</p>
 
-        <button class="btn-primary tonalli-connect-btn" type="button" style="width: 100%; margin-bottom: 8px;">
-          <i class="fa-solid fa-link" aria-hidden="true"></i> Comprar con Tonalli Connect
+        <button class="btn-primary wc-connect-btn" type="button" style="width: 100%; margin-bottom: 8px;">
+          <i class="fa-solid fa-qrcode" aria-hidden="true"></i> Comprar con WalletConnect
         </button>
 
         <button class="tonalli-guide" type="button" data-open-tonalli-modal style="width: 100%; justify-content: center; margin-bottom: 8px;">
@@ -1744,11 +1744,11 @@
         <p>Bálsamo natural creado para proteger la piel del Xoloitzcuintle frente a la exposición solar cotidiana. Ayuda a formar una barrera humectante sobre la piel, especialmente útil en perros sin pelo o con zonas sensibles. Aplicar antes de la exposición al sol y reaplicar cuando sea necesario.</p>
       </div>
       <div class="card-actions">
-        <p><strong>Pago Web3 Simplificado:</strong> 1 clic para firmar tu orden con Tonalli Connect y facilitar la validación del pago RMZ.</p>
+        <p><strong>Pago Web3 Simplificado:</strong> Conecta tu Tonalli Wallet vía WalletConnect para firmar y autorizar tu orden.</p>
         <p>Precio: <span class="price-rmz"></span> RMZ</p>
 
-        <button class="btn-primary tonalli-connect-btn" type="button" style="width: 100%; margin-bottom: 8px;">
-          <i class="fa-solid fa-link" aria-hidden="true"></i> Comprar con Tonalli Connect
+        <button class="btn-primary wc-connect-btn" type="button" style="width: 100%; margin-bottom: 8px;">
+          <i class="fa-solid fa-qrcode" aria-hidden="true"></i> Comprar con WalletConnect
         </button>
 
         <button class="tonalli-guide" type="button" data-open-tonalli-modal style="width: 100%; justify-content: center; margin-bottom: 8px;">
@@ -1788,11 +1788,11 @@
         <p>Fórmula botánica de aroma fresco pensada para pieles con tendencia grasa o con necesidad de limpieza profunda. El limón es valorado tradicionalmente por su efecto purificante, revitalizante y refrescante. Puede apoyar el cuidado de piel con acné, exceso de grasa y también ayudar a repeler insectos de forma aromática. Precaución: evitar la exposición directa al sol inmediatamente después de su aplicación.</p>
       </div>
       <div class="card-actions">
-        <p><strong>Pago Web3 Simplificado:</strong> 1 clic para firmar tu orden con Tonalli Connect y facilitar la validación del pago RMZ.</p>
+        <p><strong>Pago Web3 Simplificado:</strong> Conecta tu Tonalli Wallet vía WalletConnect para firmar y autorizar tu orden.</p>
         <p>Precio: <span class="price-rmz"></span> RMZ</p>
 
-        <button class="btn-primary tonalli-connect-btn" type="button" style="width: 100%; margin-bottom: 8px;">
-          <i class="fa-solid fa-link" aria-hidden="true"></i> Comprar con Tonalli Connect
+        <button class="btn-primary wc-connect-btn" type="button" style="width: 100%; margin-bottom: 8px;">
+          <i class="fa-solid fa-qrcode" aria-hidden="true"></i> Comprar con WalletConnect
         </button>
 
         <button class="tonalli-guide" type="button" data-open-tonalli-modal style="width: 100%; justify-content: center; margin-bottom: 8px;">
@@ -1832,11 +1832,11 @@
         <p>Mezcla botánica diseñada para ayudar a repeler insectos durante paseos, visitas al jardín o actividades al aire libre. Su aroma natural funciona como una barrera suave para acompañar el cuidado diario del Xoloitzcuintle sin recurrir a fragancias agresivas.</p>
       </div>
       <div class="card-actions">
-        <p><strong>Pago Web3 Simplificado:</strong> 1 clic para firmar tu orden con Tonalli Connect y facilitar la validación del pago RMZ.</p>
+        <p><strong>Pago Web3 Simplificado:</strong> Conecta tu Tonalli Wallet vía WalletConnect para firmar y autorizar tu orden.</p>
         <p>Precio: <span class="price-rmz"></span> RMZ</p>
 
-        <button class="btn-primary tonalli-connect-btn" type="button" style="width: 100%; margin-bottom: 8px;">
-          <i class="fa-solid fa-link" aria-hidden="true"></i> Comprar con Tonalli Connect
+        <button class="btn-primary wc-connect-btn" type="button" style="width: 100%; margin-bottom: 8px;">
+          <i class="fa-solid fa-qrcode" aria-hidden="true"></i> Comprar con WalletConnect
         </button>
 
         <button class="tonalli-guide" type="button" data-open-tonalli-modal style="width: 100%; justify-content: center; margin-bottom: 8px;">
@@ -1881,11 +1881,11 @@
         </ul>
       </div>
       <div class="card-actions">
-        <p><strong>Pago Web3 Simplificado:</strong> 1 clic para firmar tu orden con Tonalli Connect y facilitar la validación del pago RMZ.</p>
+        <p><strong>Pago Web3 Simplificado:</strong> Conecta tu Tonalli Wallet vía WalletConnect para firmar y autorizar tu orden.</p>
         <p>Precio: <span class="price-rmz"></span> RMZ</p>
 
-        <button class="btn-primary tonalli-connect-btn" type="button" style="width: 100%; margin-bottom: 8px;">
-          <i class="fa-solid fa-link" aria-hidden="true"></i> Comprar con Tonalli Connect
+        <button class="btn-primary wc-connect-btn" type="button" style="width: 100%; margin-bottom: 8px;">
+          <i class="fa-solid fa-qrcode" aria-hidden="true"></i> Comprar con WalletConnect
         </button>
 
         <button class="tonalli-guide" type="button" data-open-tonalli-modal style="width: 100%; justify-content: center; margin-bottom: 8px;">
@@ -1934,11 +1934,11 @@
         <p class="promo-text">Solución completa para el cuidado natural del Xoloitzcuintle. Incluye tres bálsamos o aceites botánicos, dos jabones artesanales y un repelente natural de insectos. Diseñado para proteger, limpiar, relajar y acompañar el bienestar diario de perros sin pelo o con piel sensible.</p>
       </div>
       <div class="card-actions">
-        <p><strong>Pago Web3 Simplificado:</strong> 1 clic para firmar tu orden con Tonalli Connect y facilitar la validación del pago RMZ.</p>
+        <p><strong>Pago Web3 Simplificado:</strong> Conecta tu Tonalli Wallet vía WalletConnect para firmar y autorizar tu orden.</p>
         <p>Precio: <span class="price-rmz"></span> RMZ</p>
 
-        <button class="btn-primary tonalli-connect-btn" type="button" style="width: 100%; margin-bottom: 8px;">
-          <i class="fa-solid fa-link" aria-hidden="true"></i> Comprar con Tonalli Connect
+        <button class="btn-primary wc-connect-btn" type="button" style="width: 100%; margin-bottom: 8px;">
+          <i class="fa-solid fa-qrcode" aria-hidden="true"></i> Comprar con WalletConnect
         </button>
 
         <button class="tonalli-guide" type="button" data-open-tonalli-modal style="width: 100%; justify-content: center; margin-bottom: 8px;">
@@ -2067,7 +2067,7 @@
       <button class="xec-modal__close" id="closeTonalliModal" type="button" aria-label="Cerrar guía Tonalli DEX">
         <i class="fa-solid fa-xmark" aria-hidden="true"></i>
       </button>
-      <h2 class="xec-modal__title" id="tonalliModalTitle">¿Cómo comprar con Tonalli Connect?</h2>
+      <h2 class="xec-modal__title" id="tonalliModalTitle">¿Dónde comprar RMZ?</h2>
 
       <div class="xec-payment-info" style="margin-bottom: 12px;">
         <h3 style="color: var(--color-highlight-strong); margin-top: 0; margin-bottom: 8px;">Paso 1: ¿Dónde comprar RMZ?</h3>
@@ -2079,15 +2079,6 @@
         </ol>
       </div>
 
-      <div class="xec-payment-info">
-        <h3 style="color: var(--color-highlight-strong); margin-top: 0; margin-bottom: 8px;">Paso 2: Pagar en la tienda</h3>
-        <ol class="xec-modal__list">
-          <li>Haz clic en el botón <strong>Comprar con Tonalli Connect</strong> en el producto deseado.</li>
-          <li>Serás redirigido a tu billetera de forma segura.</li>
-          <li>Revisa y <strong>firma el mensaje</strong> (Challenge) que autoriza la orden.</li>
-          <li>¡Listo! Regresarás automáticamente aquí con tu orden firmada para continuar la validación del pago.</li>
-        </ol>
-      </div>
     </div>
   </div>
 
@@ -2103,109 +2094,159 @@ document.addEventListener('click', function(e){
 });
 </script>
 
-  <script>
+  <script type="module">
+    import UniversalProvider from 'https://esm.sh/@walletconnect/universal-provider@2.11.1';
+    import { WalletConnectModal } from 'https://esm.sh/@walletconnect/modal@2.6.2';
+
+    // Configuración de eCash México y Tonalli Wallet
+    const PROJECT_ID = "d8772b58056b6812d57c181501dd854c";
+    const ECASH_CHAIN = "ecash:1";
+    const WALLETCONNECT_METADATA = {
+      name: "Xolo Skin Care",
+      description: "Cuidado Ancestral para piel de Guerrero",
+      url: window.location.origin,
+      icons: ["https://xolosramirez.com/assets/xolosramirez.ico"],
+    };
+
+    const ECASH_NAMESPACE = {
+      ecash: {
+        chains: [ECASH_CHAIN],
+        methods: ["ecash_getAddresses", "ecash_signMessage"],
+        events: ["accountsChanged", "chainChanged"],
+      },
+    };
+
+    const PRODUCT_OFFERS = {
+      'xolo-unguento': { rmz: 5752.32, offerId: '44d97441db8e02e045181bf2f213d1f782af81b9e1c4eabab28e641c8e8b1f01:1' },
+      'xolo-nectar': { rmz: 5752.32, offerId: '34d3107f8d4032adfe87f1d8d32d859118b9f6f2c10ab8989e557c89b83ba3ab:1' },
+      'xolo-amanecer': { rmz: 5752.32, offerId: 'd007f09d6167d1c7a8517cfff7446d59d69b5afe90202d739e463436fa3aa092:1' },
+      'xolo-solar-ancestral': { rmz: 5752.32, offerId: 'e9447b3f72fd79a9a6795328d47f3216e92276d7bb2176f6bef06afb6a4b6ddef:1' },
+      'xolo-escudo': { rmz: 5752.32, offerId: '24c72fd8fe3956c19e76a66d767f594228025d1a8330c45b8b59d5ed7efbff12:1' },
+      'xolo-duo': { rmz: 5752.32, offerId: '6d7bb2176f6bef06afb6a4b6ddef7447b3f72fd79a9a6795328d47f3216e9227:1' },
+      'xolo-bienestar': { rmz: 20707.84, offerId: 'a16e9319ef221abf486a47dd43e1ab2035b2a1e0cabc688ac3462c31261c75e6:1' },
+    };
+
+    let provider;
+    const modal = new WalletConnectModal({ projectId: PROJECT_ID });
+
+    // Inicializa el proveedor de WalletConnect
+    async function initializeProvider() {
+      if (provider) return;
+      provider = await UniversalProvider.init({
+        projectId: PROJECT_ID,
+        metadata: WALLETCONNECT_METADATA,
+      });
+
+      provider.on("display_uri", (uri) => {
+        modal.openModal({ uri });
+      });
+
+      provider.on("session_delete", () => console.log("Sesión finalizada."));
+      provider.on("disconnect", () => console.log("Desconectado de WalletConnect."));
+    }
+
+    // Flujo principal de conexión y firma
+    async function processOrder(sku, config, button) {
+      const originalText = button.innerHTML;
+      button.disabled = true;
+      button.innerHTML = '<i class="fa-solid fa-spinner fa-spin"></i> Conectando...';
+
+      try {
+        await initializeProvider();
+
+        let session = provider.session;
+        if (!session) {
+          session = await provider.connect({ namespaces: ECASH_NAMESPACE });
+          modal.closeModal();
+        }
+
+        if (!session) throw new Error("WalletConnect no devolvió una sesión válida.");
+
+        button.innerHTML = '<i class="fa-solid fa-pen-nib"></i> Firma en tu Wallet...';
+
+        // 1. Obtener la dirección eCash
+        const addressesResponse = await provider.request({
+          method: "ecash_getAddresses",
+          params: {},
+        });
+
+        let address = "";
+        if (Array.isArray(addressesResponse)) address = addressesResponse[0];
+        else if (addressesResponse?.address) address = addressesResponse.address;
+        else if (Array.isArray(addressesResponse?.addresses)) address = addressesResponse.addresses[0];
+
+        if (!address) throw new Error("No se pudo obtener la dirección eCash.");
+
+        // 2. Preparar el Challenge (Al igual que en la Asamblea)
+        const offerId = config.offerId;
+        const challengeId = offerId.split(':')[0].substring(0, 16);
+        const message = `Autorizo la orden del producto SKU: ${sku} por ${config.rmz} RMZ. OfferID: ${offerId}`;
+
+        // 3. Solicitar la firma
+        const signResponse = await provider.request({
+          method: "ecash_signMessage",
+          params: {
+            message: message,
+            challengeId: challengeId,
+            address: address,
+          },
+        });
+
+        const signature = typeof signResponse === 'string'
+          ? signResponse
+          : (signResponse?.signature || signResponse?.sig || signResponse?.base64Signature);
+
+        // 4. Éxito
+        alert(`¡Orden Web3 firmada correctamente!\n\nDirección eCash: ${address}\nFirma: ${signature.substring(0, 15)}...\n\nHemos registrado tu intención de compra vía WalletConnect. Ahora validaremos el pago RMZ.`);
+
+      } catch (error) {
+        modal.closeModal();
+        console.error("[RMZ WalletConnect] Error:", error);
+        alert("La conexión fue cancelada o denegada por Tonalli Wallet.");
+      } finally {
+        button.disabled = false;
+        button.innerHTML = originalText;
+      }
+    }
+
     document.addEventListener('DOMContentLoaded', () => {
       const isMobile = window.matchMedia('(max-width: 768px)').matches;
-      const PRODUCT_OFFERS = {
-        'xolo-unguento': { priceXEC: 1900000, rmz: 5752.32, offerId: '44d97441db8e02e045181bf2f213d1f782af81b9e1c4eabab28e641c8e8b1f01:1' },
-        'xolo-nectar': { priceXEC: 1900000, rmz: 5752.32, offerId: '34d3107f8d4032adfe87f1d8d32d859118b9f6f2c10ab8989e557c89b83ba3ab:1' },
-        'xolo-amanecer': { priceXEC: 1900000, rmz: 5752.32, offerId: 'd007f09d6167d1c7a8517cfff7446d59d69b5afe90202d739e463436fa3aa092:1' },
-        'xolo-solar-ancestral': { priceXEC: 1900000, rmz: 5752.32, offerId: 'e9447b3f72fd79a9a6795328d47f3216e92276d7bb2176f6bef06afb6a4b6ddef:1' },
-        'xolo-escudo': { priceXEC: 1900000, rmz: 5752.32, offerId: '24c72fd8fe3956c19e76a66d767f594228025d1a8330c45b8b59d5ed7efbff12:1' },
-        'xolo-duo': { priceXEC: 1900000, rmz: 5752.32, offerId: '6d7bb2176f6bef06afb6a4b6ddef7447b3f72fd79a9a6795328d47f3216e9227:1' },
-        'xolo-bienestar': { priceXEC: 6900000, rmz: 20707.84, offerId: 'a16e9319ef221abf486a47dd43e1ab2035b2a1e0cabc688ac3462c31261c75e6:1' },
-      };
 
-      const copyTextWithFallback = async (text) => {
-        if (navigator.clipboard?.writeText) {
-          await navigator.clipboard.writeText(text);
-          return true;
+      document.querySelectorAll('.card[data-sku]').forEach((card) => {
+        const sku = card.dataset.sku;
+        const config = PRODUCT_OFFERS[sku];
+
+        const priceEl = card.querySelector('.price-rmz');
+        const connectBtn = card.querySelector('.wc-connect-btn');
+        const txToggle = card.querySelector('.txid-toggle');
+        const txForm = card.querySelector('.txid-form');
+        const txInput = txForm?.querySelector('input[name="txid"]');
+        const txMsg = card.querySelector('.txid-success-msg');
+
+        if (config && priceEl) priceEl.textContent = config.rmz;
+
+        // Evento del botón WalletConnect
+        if (connectBtn && config) {
+          connectBtn.addEventListener('click', () => processOrder(sku, config, connectBtn));
         }
-        const textarea = document.createElement('textarea');
-        textarea.value = text;
-        textarea.setAttribute('readonly', '');
-        textarea.style.position = 'absolute';
-        textarea.style.left = '-9999px';
-        document.body.appendChild(textarea);
-        textarea.select();
-        const success = document.execCommand('copy');
-        document.body.removeChild(textarea);
-        return success;
-      };
 
-      // 1. Manejo del callback de Tonalli Connect al volver a la página
-      if (window.location.hash) {
-        const hashParams = new URLSearchParams(window.location.hash.substring(1));
-        const status = hashParams.get('status');
-
-        if (status === 'success') {
-          const signature = hashParams.get('signature');
-          const address = hashParams.get('address');
-
-          alert(`¡Orden Web3 firmada correctamente!\n\nDirección eCash: ${address}\nFirma generada: ${signature.substring(0, 15)}...\n\nHemos registrado tu intención de compra. Ahora validaremos el pago RMZ correspondiente a esta orden.`);
-
-          // Limpia el hash para no volver a lanzar la alerta al recargar
-          window.history.replaceState(null, null, window.location.pathname);
-        } else if (status === 'error' || status === 'rejected') {
-          alert('La conexión con Tonalli Connect fue cancelada o denegada.');
-          window.history.replaceState(null, null, window.location.pathname);
-        }
-      }
-
-      // 2. Función actualizada para inyectar la lógica de botones
-      const updateOfferBlocks = () => {
-        document.querySelectorAll('.card[data-sku]').forEach((card) => {
-          const sku = card.dataset.sku;
-          const config = PRODUCT_OFFERS[sku];
-          const priceEl = card.querySelector('.price-rmz');
-          const connectBtn = card.querySelector('.tonalli-connect-btn');
-
-          if (config && priceEl) {
-            priceEl.textContent = config.rmz;
-          }
-
-          // Inyectamos el flujo hacia Tonalli Connect
-          if (connectBtn && config) {
-            connectBtn.addEventListener('click', () => {
-              const offerId = config.offerId;
-              const challengeId = offerId.split(':')[0].substring(0, 16); // ID corto referencial
-              // El mensaje refleja intención de orden, NO confirmación de pago
-              const message = `Autorizo la orden del producto SKU: ${sku} por ${config.rmz} RMZ. OfferID: ${offerId}`;
-
-              const callbackUrl = window.location.origin + window.location.pathname;
-
-              const tonalliUrl = new URL('https://cartera.xolosarmy.xyz/connect/sign-message');
-              tonalliUrl.searchParams.append('challenge', message);
-              tonalliUrl.searchParams.append('challengeId', challengeId);
-              tonalliUrl.searchParams.append('callbackUrl', callbackUrl);
-
-              window.location.href = tonalliUrl.toString();
-            });
-          }
-
-          // Mantiene el fallback manual del TXID
-          const txToggle = card.querySelector('.txid-toggle');
-          const txForm = card.querySelector('.txid-form');
-          const txInput = txForm?.querySelector('input[name="txid"]');
-          const txMsg = card.querySelector('.txid-success-msg');
-
-          txToggle?.addEventListener('click', () => {
-            if (!txForm) return;
-            txForm.style.display = txForm.style.display === 'block' ? 'none' : 'block';
-          });
-
-          txForm?.addEventListener('submit', (event) => {
-            event.preventDefault();
-            const txid = txInput?.value.trim();
-            if (txid && txMsg) {
-              txMsg.textContent = `✅ TXID recibido: ${txid.slice(0, 12)}...${txid.slice(-6)}. Validaremos tu pago.`;
-              txMsg.style.display = 'block';
-              txForm.reset();
-              txForm.style.display = 'none';
-            }
-          });
+        // Funcionalidad del TXID manual
+        txToggle?.addEventListener('click', () => {
+          if (!txForm) return;
+          txForm.style.display = txForm.style.display === 'block' ? 'none' : 'block';
         });
-      };
+
+        txForm?.addEventListener('submit', (event) => {
+          event.preventDefault();
+          const txid = txInput?.value.trim();
+          if (txid && txMsg) {
+            txMsg.textContent = `✅ TXID recibido: ${txid.slice(0, 12)}...${txid.slice(-6)}. Validaremos tu pago.`;
+            txMsg.style.display = 'block';
+            txForm.reset();
+            txForm.style.display = 'none';
+          }
+        });
+      });
 
       if (window.AOS) {
         AOS.init({
@@ -2400,8 +2441,6 @@ document.addEventListener('click', function(e){
           closeTonalliModal();
         }
       });
-
-      updateOfferBlocks();
 
       const filterButtons = document.querySelectorAll('.filter-btn');
       const productCards = document.querySelectorAll('.card[data-category]');


### PR DESCRIPTION
### Motivation
- Sustituir el flujo de firma por redirección a Tonalli Connect por un checkout Web3 moderno usando WalletConnect v2 para mejorar la UX y permitir firma desde Tonalli Wallet sin redirecciones.
- Firmar la intención de compra usando los métodos eCash ya usados por la Asamblea (`ecash_getAddresses`, `ecash_signMessage`) para mantener compatibilidad con el ecosistema RMZ/XEC.
- Conservar el fallback manual de `TXID` y la guía sobre dónde adquirir RMZ en el DEX mientras se simplifica la experiencia de pago Web3.

### Description
- Reemplacé las CTAs de las tarjetas de producto: cambié `tonalli-connect-btn` por `wc-connect-btn`, actualicé el copy a “Comprar con WalletConnect” y renombré el modal de ayuda a `¿Dónde comprar RMZ?`.
- Añadí un bloque `script` tipo módulo que importa `UniversalProvider` y `WalletConnectModal` desde `https://esm.sh`, configura `ECASH_NAMESPACE` y `PRODUCT_OFFERS`, inicializa el provider/modal y añade la función `processOrder` que conecta con WalletConnect, obtiene dirección (`ecash_getAddresses`) y solicita firma (`ecash_signMessage`) mostrando estados en la UI.
- Eliminé el flujo de redirección anterior (`updateOfferBlocks`), mantuve la inyección de precios RMZ en las tarjetas y la lógica de formulario/mostrar `TXID` manual como fallback, y dejé el modal DEX sólo con instrucciones para comprar RMZ.

### Testing
- `node --check /tmp/xolo-skin-care-module.mjs` — pasada correctamente.
- Chequeos estáticos: `git diff --check` y las aserciones en `python3` que verificaron la presencia de `wc-connect-btn`, la ausencia del flujo de redirección y la inclusión de `ecash_getAddresses`/`ecash_signMessage` — todas pasaron.
- Pruebas de render/screenshot con Playwright: se ejecutó `npx playwright install` y `npx playwright install-deps` para obtener navegadores, y luego se generaron capturas con `npx playwright screenshot` contra `http://127.0.0.1:4173/xolo-skin-care/`, las cuales se completaron con éxito tras instalar dependencias del entorno.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a26d5450f5c8332b5b921f680ce2383)