### PR TITLE
Fix Tonalli WalletConnect events

### DIFF
--- a/xolo-skin-care/index.html
+++ b/xolo-skin-care/index.html
@@ -2112,7 +2112,9 @@ document.addEventListener('click', function(e){
       ecash: {
         chains: [ECASH_CHAIN],
         methods: ["ecash_getAddresses", "ecash_signMessage"],
-        events: ["accountsChanged", "chainChanged"],
+        // Tonalli Wallet actualmente declara events: []; mantenerlo vacío evita
+        // que WalletConnect rechace la sesión por exigir eventos no soportados.
+        events: [],
       },
     };
 


### PR DESCRIPTION
### Motivation
- Evitar que WalletConnect v2 rechace la conexión porque la Tonalli Wallet declara `events: []` mientras la dApp exigía `["accountsChanged","chainChanged"]` como requisito obligatorio.

### Description
- Actualiza `xolo-skin-care/index.html` reemplazando `events: ["accountsChanged", "chainChanged"]` por un comentario explicativo y `events: []` para aceptar la sesión sin solicitar eventos no soportados.

### Testing
- Se ejecutaron `rg -n "events: \[\]" xolo-skin-care/index.html`, `git diff --check` y `git status --short`, y las comprobaciones automatizadas finalizaron correctamente.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a26df45bffc83329fbadf74d06150d2)