### PR TITLE
Mejora contraste de botones 'Correo directo'

### DIFF
--- a/xolos-disponibles.html
+++ b/xolos-disponibles.html
@@ -321,7 +321,7 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
     <iframe width="100%" height="100%" src="https://www.youtube.com/embed/BmeHIF8FKTM" title="Ozomatli Ramirez" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen loading="lazy"></iframe>
   </div>
   <div class="puppy-card__actions">
-    <a href="mailto:fernando@xolosramirez.com?subject=Informes%20sobre%20xoloitzcuintle&body=Hola%20Fernando%2C%20estoy%20interesado%20en%20un%20xoloitzcuintle%2C%20quiero%20m%C3%A1s%20informes." class="btn-small btn-primary-small" style="background-color: #25D366; border-color: #25D366; width: 100%; justify-content: center;">Correo directo ✉️</a>
+    <a href="mailto:fernando@xolosramirez.com?subject=Informes%20sobre%20xoloitzcuintle&body=Hola%20Fernando%2C%20estoy%20interesado%20en%20un%20xoloitzcuintle%2C%20quiero%20m%C3%A1s%20informes." class="btn-small btn-primary-small" style="background-color: #25D366; border-color: #25D366; color: #1a1a1a; font-weight: 700; width: 100%; justify-content: center;">Correo directo ✉️</a>
   </div>
 </div>
   </article>
@@ -382,7 +382,7 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
     <iframe width="100%" height="100%" src="https://www.youtube.com/embed/YkpF5WeRydo" title="Nox Ramirez" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen loading="lazy"></iframe>
   </div>
   <div class="puppy-card__actions">
-    <a href="mailto:fernando@xolosramirez.com?subject=Informes%20sobre%20xoloitzcuintle&body=Hola%20Fernando%2C%20estoy%20interesado%20en%20un%20xoloitzcuintle%2C%20quiero%20m%C3%A1s%20informes." class="btn-small btn-primary-small" style="background-color: #25D366; border-color: #25D366; width: 100%; justify-content: center;">Correo directo ✉️</a>
+    <a href="mailto:fernando@xolosramirez.com?subject=Informes%20sobre%20xoloitzcuintle&body=Hola%20Fernando%2C%20estoy%20interesado%20en%20un%20xoloitzcuintle%2C%20quiero%20m%C3%A1s%20informes." class="btn-small btn-primary-small" style="background-color: #25D366; border-color: #25D366; color: #1a1a1a; font-weight: 700; width: 100%; justify-content: center;">Correo directo ✉️</a>
   </div>
     </div>
   </article>
@@ -452,7 +452,7 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
     <iframe width="100%" height="100%" src="https://www.youtube.com/embed/Y6m1tm2dv-A" title="Teyolia Ramirez" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen loading="lazy"></iframe>
   </div>
   <div class="puppy-card__actions">
-    <a href="mailto:fernando@xolosramirez.com?subject=Informes%20sobre%20xoloitzcuintle&body=Hola%20Fernando%2C%20estoy%20interesado%20en%20un%20xoloitzcuintle%2C%20quiero%20m%C3%A1s%20informes." class="btn-small btn-primary-small" style="background-color: #25D366; border-color: #25D366; width: 100%; justify-content: center;">Correo directo ✉️</a>
+    <a href="mailto:fernando@xolosramirez.com?subject=Informes%20sobre%20xoloitzcuintle&body=Hola%20Fernando%2C%20estoy%20interesado%20en%20un%20xoloitzcuintle%2C%20quiero%20m%C3%A1s%20informes." class="btn-small btn-primary-small" style="background-color: #25D366; border-color: #25D366; color: #1a1a1a; font-weight: 700; width: 100%; justify-content: center;">Correo directo ✉️</a>
   </div>
     </div>
   </article>
@@ -513,7 +513,7 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
     <iframe width="100%" height="100%" src="https://www.youtube.com/embed/_2EGfG77VhE" title="Onix Ramirez" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen loading="lazy"></iframe>
   </div>
   <div class="puppy-card__actions">
-    <a href="mailto:fernando@xolosramirez.com?subject=Informes%20sobre%20xoloitzcuintle&body=Hola%20Fernando%2C%20estoy%20interesado%20en%20un%20xoloitzcuintle%2C%20quiero%20m%C3%A1s%20informes." class="btn-small btn-primary-small" style="background-color: #25D366; border-color: #25D366; width: 100%; justify-content: center;">Correo directo ✉️</a>
+    <a href="mailto:fernando@xolosramirez.com?subject=Informes%20sobre%20xoloitzcuintle&body=Hola%20Fernando%2C%20estoy%20interesado%20en%20un%20xoloitzcuintle%2C%20quiero%20m%C3%A1s%20informes." class="btn-small btn-primary-small" style="background-color: #25D366; border-color: #25D366; color: #1a1a1a; font-weight: 700; width: 100%; justify-content: center;">Correo directo ✉️</a>
   </div>
     </div>
   </article>
@@ -568,7 +568,7 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
     <iframe width="100%" height="100%" src="https://www.youtube.com/embed/0qcQvELxVpU" title="Chimalma Ramirez" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen loading="lazy"></iframe>
   </div>
   <div class="puppy-card__actions">
-    <a href="mailto:fernando@xolosramirez.com?subject=Informes%20sobre%20xoloitzcuintle&body=Hola%20Fernando%2C%20estoy%20interesado%20en%20un%20xoloitzcuintle%2C%20quiero%20m%C3%A1s%20informes." class="btn-small btn-primary-small" style="background-color: #25D366; border-color: #25D366; width: 100%; justify-content: center;">Correo directo ✉️</a>
+    <a href="mailto:fernando@xolosramirez.com?subject=Informes%20sobre%20xoloitzcuintle&body=Hola%20Fernando%2C%20estoy%20interesado%20en%20un%20xoloitzcuintle%2C%20quiero%20m%C3%A1s%20informes." class="btn-small btn-primary-small" style="background-color: #25D366; border-color: #25D366; color: #1a1a1a; font-weight: 700; width: 100%; justify-content: center;">Correo directo ✉️</a>
   </div>
     </div>
   </article> 
@@ -613,7 +613,7 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
     <iframe width="100%" height="100%" src="https://www.youtube.com/embed/swT_Xkc7Kco" title="Mixa Ramirez" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen loading="lazy"></iframe>
   </div>
   <div class="puppy-card__actions">
-         <a href="mailto:fernando@xolosramirez.com?subject=Informes%20sobre%20xoloitzcuintle&body=Hola%20Fernando%2C%20estoy%20interesado%20en%20un%20xoloitzcuintle%2C%20quiero%20m%C3%A1s%20informes." class="btn-small btn-primary-small" style="background-color: #25D366; border-color: #25D366; width: 100%; justify-content: center;">Correo directo ✉️</a>
+         <a href="mailto:fernando@xolosramirez.com?subject=Informes%20sobre%20xoloitzcuintle&body=Hola%20Fernando%2C%20estoy%20interesado%20en%20un%20xoloitzcuintle%2C%20quiero%20m%C3%A1s%20informes." class="btn-small btn-primary-small" style="background-color: #25D366; border-color: #25D366; color: #1a1a1a; font-weight: 700; width: 100%; justify-content: center;">Correo directo ✉️</a>
   
     </div>
     </div>


### PR DESCRIPTION
### Motivation
- Los botones verdes “Correo directo ✉️” usaban texto blanco sobre un verde brillante, lo que producía bajo contraste y problemas de accesibilidad.
- Se buscó igualar la legibilidad con el botón amarillo ya presente sin alterar la paleta visual del sitio.

### Description
- Actualiza el inline `style` de los botones de correo en `xolos-disponibles.html` para añadir `color: #1a1a1a` y `font-weight: 700` manteniendo `background-color: #25D366`.
- La mejora se aplicó de forma consistente a las seis ocurrencias del botón “Correo directo ✉️” en la página.

### Testing
- Se ejecutó un chequeo Python que valida la presencia del nuevo estilo y confirma que hay 6 botones actualizados con la cadena esperada, y pasó (`assert` exitoso).
- Se calculó programáticamente la relación de contraste WCAG para `#25D366` sobre `#1a1a1a`, resultando en `8.78:1` y el test pasó (supera 4.5:1).
- Se intentó usar Playwright / navegador para capturar una vista previa pero la dependencia/navegador no estaba disponible en el entorno, por lo que no se generó screenshot.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3079c0a2888332ab0e19659e346820)