### PR TITLE
Estandarizar contexto estructurado en mailto: para orquestador

### DIFF
--- a/blog/2026-01-24-entrega-ceniza-ramirez.html
+++ b/blog/2026-01-24-entrega-ceniza-ramirez.html
@@ -212,7 +212,7 @@
         <section class="cta">
             <h3>¿Buscas un compañero ancestral?</h3>
             <p>En Criadero Xolos Ramírez contamos con ejemplares únicos y asesoría completa para entregas nacionales e internacionales.</p>
-            <a href="mailto:fernando@xolosramirez.com?subject=Informes%20sobre%20xoloitzcuintle&body=Hola%20Fernando%2C%20estoy%20interesado%20en%20un%20xoloitzcuintle%2C%20quiero%20m%C3%A1s%20informes." class="btn" target="_blank" rel="noopener noreferrer">Contáctanos por correo</a>
+            <a href="mailto:fernando@xolosramirez.com?subject=%5BXOLOS%5D%20event%3Dgeneral%20puppy%3Dgeneral&body=context_event%3Dgeneral%0Acontext_puppy%3Dgeneral%0Acontext_name%3Dgeneral%0A%0AHola%20Fernando%2C%20tengo%20una%20consulta%20general%20sobre%20Xolos%20Ram%C3%ADrez." class="btn" target="_blank" rel="noopener noreferrer">Contáctanos por correo</a>
         </section>
     </main>
 

--- a/contacto.html
+++ b/contacto.html
@@ -211,7 +211,7 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
 
     <a
       class="wa-float"
-      href="mailto:fernando@xolosramirez.com?subject=Informes%20sobre%20xoloitzcuintle&body=Hola%20Fernando%2C%20estoy%20interesado%20en%20un%20xoloitzcuintle%2C%20quiero%20m%C3%A1s%20informes."
+      href="mailto:fernando@xolosramirez.com?subject=%5BXOLOS%5D%20event%3Dgeneral%20puppy%3Dgeneral&body=context_event%3Dgeneral%0Acontext_puppy%3Dgeneral%0Acontext_name%3Dgeneral%0A%0AHola%20Fernando%2C%20tengo%20una%20consulta%20general%20sobre%20Xolos%20Ram%C3%ADrez."
       target="_blank"
       rel="noopener noreferrer"
       data-gtm="email-floating"

--- a/docs/email-context.md
+++ b/docs/email-context.md
@@ -1,0 +1,46 @@
+# Formato de contexto para correos
+
+Todos los enlaces `mailto:` del sitio deben incluir contexto estructurado en asunto y cuerpo para que el orquestador elija una respuesta desde `cachorros.json`.
+
+## Asunto
+
+```text
+[XOLOS] event=<EVENTO> puppy=<SLUG_O_GENERAL>
+```
+
+## Cuerpo
+
+```text
+context_event=<EVENTO>
+context_puppy=<SLUG_O_GENERAL>
+context_name=<NOMBRE_VISIBLE>
+
+<Texto amable para la persona usuaria>
+```
+
+## Valores controlados
+
+`event` debe ser uno de: `info`, `reserve`, `adoption`, `visit`, `waitlist`, `general`.
+
+`puppy` debe ser el slug canónico del cachorro cuando aplique, o `general` para consultas sin cachorro específico. El slug es el identificador principal para mapear contra `cachorros.json`; `context_name` solo es apoyo humano.
+
+## Parsing recomendado para el orquestador
+
+1. Decodificar URL/quoted-printable del asunto y cuerpo si aplica.
+2. Intentar extraer del asunto con:
+
+```regex
+\[XOLOS\]\s+event=(info|reserve|adoption|visit|waitlist|general)\s+puppy=([a-z0-9-]+|general)
+```
+
+3. Si falta contexto, buscar en el cuerpo con:
+
+```regex
+^context_event=(info|reserve|adoption|visit|waitlist|general)$
+^context_puppy=([a-z0-9-]+|general)$
+^context_name=(.+)$
+```
+
+usando modo multilínea.
+
+4. Si todavía falta contexto, usar `event=general` y `puppy=general`.

--- a/en/available-xolos.html
+++ b/en/available-xolos.html
@@ -243,7 +243,7 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
     <iframe width="100%" height="100%" src="https://www.youtube.com/embed/BmeHIF8FKTM" title="Ozomatli Ramirez" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen loading="lazy"></iframe>
   </div>
   <div class="puppy-card__actions">
-              <a href="mailto:fernando@xolosramirez.com?subject=Interest in Ozomatli Ramirez&body=Hello, I would like to receive information on how to reserve Ozomatli Ramirez." class="btn-small btn-primary-small" onclick="dataLayer.push({ event: 'click_email', cachorro: 'Ozomatli Ramirez', source: 'available_xolos_contact_en' })">Contact via Email</a>
+              <a href="mailto:fernando@xolosramirez.com?subject=%5BXOLOS%5D%20event%3Dinfo%20puppy%3Dozomatli&body=context_event%3Dinfo%0Acontext_puppy%3Dozomatli%0Acontext_name%3DOzomatli%20Ramirez%0A%0AHello%20Fernando%2C%20I%20would%20like%20to%20receive%20information%20about%20Ozomatli%20Ramirez." class="btn-small btn-primary-small" onclick="dataLayer.push({ event: 'click_email', cachorro: 'Ozomatli Ramirez', cachorro_slug: 'ozomatli', source: 'available_xolos_contact_en' })">Contact via Email</a>
             </div>
           </div>
         </article>
@@ -290,7 +290,7 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
     <iframe width="100%" height="100%" src="https://www.youtube.com/embed/YkpF5WeRydo" title="Nox Ramirez" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen loading="lazy"></iframe>
   </div>
   <div class="puppy-card__actions">
-              <a href="mailto:fernando@xolosramirez.com?subject=Interest in Nox Ramirez&body=Hello, I would like to receive information on how to reserve Nox Ramirez." class="btn-small btn-primary-small" onclick="dataLayer.push({ event: 'click_email', cachorro: 'Nox Ramirez', source: 'available_xolos_contact_en' })">Contact via Email</a>
+              <a href="mailto:fernando@xolosramirez.com?subject=%5BXOLOS%5D%20event%3Dinfo%20puppy%3Dnox&body=context_event%3Dinfo%0Acontext_puppy%3Dnox%0Acontext_name%3DNox%20Ramirez%0A%0AHello%20Fernando%2C%20I%20would%20like%20to%20receive%20information%20about%20Nox%20Ramirez." class="btn-small btn-primary-small" onclick="dataLayer.push({ event: 'click_email', cachorro: 'Nox Ramirez', cachorro_slug: 'nox', source: 'available_xolos_contact_en' })">Contact via Email</a>
             </div>
           </div>
         </article>
@@ -351,7 +351,7 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
     <iframe width="100%" height="100%" src="https://www.youtube.com/embed/Y6m1tm2dv-A" title="Teyolia Ramirez" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen loading="lazy"></iframe>
   </div>
   <div class="puppy-card__actions">
-              <a href="mailto:fernando@xolosramirez.com?subject=Interest in Teyolia Ramirez&body=Hello, I would like to receive information on how to reserve Teyolia Ramirez." class="btn-small btn-primary-small" onclick="dataLayer.push({ event: 'click_email', cachorro: 'Teyolia Ramirez', source: 'available_xolos_contact_en' })">Contact via Email</a>
+              <a href="mailto:fernando@xolosramirez.com?subject=%5BXOLOS%5D%20event%3Dreserve%20puppy%3Dteyolia&body=context_event%3Dreserve%0Acontext_puppy%3Dteyolia%0Acontext_name%3DTeyolia%20Ramirez%0A%0AHello%20Fernando%2C%20I%20am%20interested%20in%20reserving%20Teyolia%20Ramirez." class="btn-small btn-primary-small" onclick="dataLayer.push({ event: 'click_email', cachorro: 'Teyolia Ramirez', cachorro_slug: 'teyolia', source: 'available_xolos_contact_en' })">Contact via Email</a>
             </div>
           </div>
         </article>
@@ -407,7 +407,7 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
     <iframe width="100%" height="100%" src="https://www.youtube.com/embed/_2EGfG77VhE" title="Onix Ramirez" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen loading="lazy"></iframe>
   </div>
   <div class="puppy-card__actions">
-      <a href="mailto:fernando@xolosramirez.com?subject=Interest in Ónix Ramirez&body=Hello, I would like to receive information about reserving Ónix Ramirez." class="btn-small btn-primary-small" onclick="dataLayer.push({ event: 'click_email', cachorro: 'Ónix Ramirez', source: 'xolos_disponibles_contactar' })">Contact by Email</a>
+      <a href="mailto:fernando@xolosramirez.com?subject=%5BXOLOS%5D%20event%3Dinfo%20puppy%3Donix&body=context_event%3Dinfo%0Acontext_puppy%3Donix%0Acontext_name%3D%C3%93nix%20Ramirez%0A%0AHello%20Fernando%2C%20I%20would%20like%20to%20receive%20information%20about%20%C3%93nix%20Ramirez." class="btn-small btn-primary-small" onclick="dataLayer.push({ event: 'click_email', cachorro: 'Ónix Ramirez', cachorro_slug: 'onix', source: 'xolos_disponibles_contactar' })">Contact by Email</a>
     </div>
   </div>
 </article>
@@ -446,7 +446,7 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
     </ul>
     <div class="puppy-card__actions">
       <a href="https://www.youtube.com/watch?v=rqkZo7nrAWM" class="btn-small btn-outline-small" target="_blank" rel="noopener">Watch Xolo Personality Video 🎥</a>
-      <a href="mailto:fernando@xolosramirez.com?subject=Interest in Luna Ramirez&body=Hello, I would like to receive information about reserving Luna Ramirez." class="btn-small btn-primary-small" onclick="dataLayer.push({ event: 'click_email', cachorro: 'Luna Ramirez', source: 'xolos_disponibles_contactar' })">Contact by Email</a>
+      <a href="mailto:fernando@xolosramirez.com?subject=%5BXOLOS%5D%20event%3Dinfo%20puppy%3Dluna&body=context_event%3Dinfo%0Acontext_puppy%3Dluna%0Acontext_name%3DLuna%20Ramirez%0A%0AHello%20Fernando%2C%20I%20would%20like%20to%20receive%20information%20about%20Luna%20Ramirez." class="btn-small btn-primary-small" onclick="dataLayer.push({ event: 'click_email', cachorro: 'Luna Ramirez', cachorro_slug: 'luna', source: 'xolos_disponibles_contactar' })">Contact by Email</a>
     </div>
   </div>
 </article>
@@ -491,7 +491,7 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
     <iframe width="100%" height="100%" src="https://www.youtube.com/embed/swT_Xkc7Kco" title="Mixa Ramirez" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen loading="lazy"></iframe>
   </div>
   <div class="puppy-card__actions">
-      <a href="mailto:fernando@xolosramirez.com?subject=Interest in Mixa Ramirez&body=Hello, I would like to receive information about reserving Mixa Ramirez." class="btn-small btn-primary-small" onclick="dataLayer.push({ event: 'click_email', cachorro: 'Mixa Ramirez', source: 'available_xolos_contact_en' })">Contact by Email</a>
+      <a href="mailto:fernando@xolosramirez.com?subject=%5BXOLOS%5D%20event%3Dinfo%20puppy%3Dmixa&body=context_event%3Dinfo%0Acontext_puppy%3Dmixa%0Acontext_name%3DMixa%20Ramirez%0A%0AHello%20Fernando%2C%20I%20would%20like%20to%20receive%20information%20about%20Mixa%20Ramirez." class="btn-small btn-primary-small" onclick="dataLayer.push({ event: 'click_email', cachorro: 'Mixa Ramirez', cachorro_slug: 'mixa', source: 'available_xolos_contact_en' })">Contact by Email</a>
     </div>
   </div>
 </article>
@@ -543,7 +543,7 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
     <iframe width="100%" height="100%" src="https://www.youtube.com/embed/0qcQvELxVpU" title="Chimalma Ramirez" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen loading="lazy"></iframe>
   </div>
   <div class="puppy-card__actions">
-      <a href="mailto:fernando@xolosramirez.com?subject=Interest in Chimalma Ramirez&body=Hello, I would like to receive information about reserving Chimalma Ramirez." class="btn-small btn-primary-small" onclick="dataLayer.push({ event: 'click_email', cachorro: 'Chimalma Ramirez', source: 'available_xolos_contact_en' })">Contact by Email</a>
+      <a href="mailto:fernando@xolosramirez.com?subject=%5BXOLOS%5D%20event%3Dinfo%20puppy%3Dchimalma&body=context_event%3Dinfo%0Acontext_puppy%3Dchimalma%0Acontext_name%3DChimalma%20Ramirez%0A%0AHello%20Fernando%2C%20I%20would%20like%20to%20receive%20information%20about%20Chimalma%20Ramirez." class="btn-small btn-primary-small" onclick="dataLayer.push({ event: 'click_email', cachorro: 'Chimalma Ramirez', cachorro_slug: 'chimalma', source: 'available_xolos_contact_en' })">Contact by Email</a>
     </div>
   </div>
 </article>
@@ -715,7 +715,7 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
       </div>
       <div>
         <h4>Social</h4>
-        <a href="mailto:fernando@xolosramirez.com?subject=Informes%20sobre%20xoloitzcuintle&body=Hola%20Fernando%2C%20estoy%20interesado%20en%20un%20xoloitzcuintle%2C%20quiero%20m%C3%A1s%20informes.">Correo</a><br>
+        <a href="mailto:fernando@xolosramirez.com?subject=%5BXOLOS%5D%20event%3Dgeneral%20puppy%3Dgeneral&body=context_event%3Dgeneral%0Acontext_puppy%3Dgeneral%0Acontext_name%3Dgeneral%0A%0AHello%20Fernando%2C%20I%20have%20a%20general%20question%20about%20Xolos%20Ramirez.">Correo</a><br>
         <a href="https://x.com/xolosArmy">Twitter/X</a>
       </div>
     </div>
@@ -723,9 +723,9 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
 
   <a
     class="email-float"
-    href="mailto:fernando@xolosramirez.com?subject=Inquiry about Available Xolos&body=Hello Fernando, I am visiting the Xolos Ramirez website from the US/Canada and would like more information on the available puppies."
+    href="mailto:fernando@xolosramirez.com?subject=%5BXOLOS%5D%20event%3Dgeneral%20puppy%3Dgeneral&body=context_event%3Dgeneral%0Acontext_puppy%3Dgeneral%0Acontext_name%3Dgeneral%0A%0AHello%20Fernando%2C%20I%20have%20a%20general%20question%20about%20Xolos%20Ramirez."
     data-gtm="email-floating-en"
-    onclick="dataLayer.push({ event: 'click_email', cachorro: 'general', source: 'available_xolos_floating_en' })"
+    onclick="dataLayer.push({ event: 'click_email', cachorro: 'general', cachorro_slug: 'general', source: 'available_xolos_floating_en' })"
   >
     <span>📧 Contact via Email</span>
   </a>

--- a/en/index.html
+++ b/en/index.html
@@ -227,7 +227,7 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
           </p>
           <a href="teyolias-guardianship.html" style="font-weight: 600; color: var(--accent-color);">Discover their story and how to participate →</a>
           <p class="callout" style="margin-top: 15px; font-size: 0.9rem;">
-            <a href="mailto:contacto@xolosarmy.xyz?subject=Newsletter Subscription&body=Hello, I would like to subscribe to your mailing list for special adoptions."
+            <a href="mailto:contacto@xolosarmy.xyz?subject=%5BXOLOS%5D%20event%3Dwaitlist%20puppy%3Dgeneral&body=context_event%3Dwaitlist%0Acontext_puppy%3Dgeneral%0Acontext_name%3Dgeneral%0A%0AHello%2C%20I%20would%20like%20to%20join%20the%20Xolos%20Ramirez%20waitlist."
                style="color: #666; text-decoration: underline;">
                Learn about the program and how to participate →
               <p class="callout" style="margin-top: 15px; font-size: 0.9rem;">
@@ -416,7 +416,7 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
     </script>
     <a
       class="wa-float"
-      href="mailto:fernando@xolosramirez.com?subject=Informes%20sobre%20xoloitzcuintle&body=Hola%20Fernando%2C%20estoy%20interesado%20en%20un%20xoloitzcuintle%2C%20quiero%20m%C3%A1s%20informes."
+      href="mailto:fernando@xolosramirez.com?subject=%5BXOLOS%5D%20event%3Dgeneral%20puppy%3Dgeneral&body=context_event%3Dgeneral%0Acontext_puppy%3Dgeneral%0Acontext_name%3Dgeneral%0A%0AHello%20Fernando%2C%20I%20have%20a%20general%20question%20about%20Xolos%20Ramirez."
       target="_blank"
       rel="noopener noreferrer"
       data-gtm="email-floating"

--- a/en/teyolias-guardianship.html
+++ b/en/teyolias-guardianship.html
@@ -583,7 +583,7 @@
         });
     </script>
 
-    <a href="mailto:fernando@xolosramirez.com" class="floating-email-btn" aria-label="Send email to Fernando" title="Contact Fernando">
+    <a href="mailto:fernando@xolosramirez.com?subject=%5BXOLOS%5D%20event%3Dgeneral%20puppy%3Dgeneral&body=context_event%3Dgeneral%0Acontext_puppy%3Dgeneral%0Acontext_name%3Dgeneral%0A%0AHello%20Fernando%2C%20I%20have%20a%20general%20question%20about%20Xolos%20Ramirez." class="floating-email-btn" aria-label="Send email to Fernando" title="Contact Fernando">
         <svg viewBox="0 0 24 24" width="24" height="24" stroke="currentColor" stroke-width="2" fill="none" stroke-linecap="round" stroke-linejoin="round" class="icon-mail" aria-hidden="true" focusable="false">
             <path d="M4 4h16c1.1 0 2 .9 2 2v12c0 1.1-.9 2-2 2H4c-1.1 0-2-.9-2-2V6c0-1.1.9-2 2-2z"></path>
             <polyline points="22,6 12,13 2,6"></polyline>

--- a/index.html
+++ b/index.html
@@ -232,7 +232,7 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
           </p>
           <a href="teyolias-guardiania.html" style="font-weight: 600; color: var(--accent-color);">Descubre su historia y cómo participar →</a>
           <p class="callout" style="margin-top: 15px; font-size: 0.9rem;">
-            <a href="mailto:contacto@xolosarmy.xyz?subject=Suscripción al Boletín&body=Hola, me gustaría suscribirme a su lista de correos para adopciones especiales."
+            <a href="mailto:contacto@xolosarmy.xyz?subject=%5BXOLOS%5D%20event%3Dwaitlist%20puppy%3Dgeneral&body=context_event%3Dwaitlist%0Acontext_puppy%3Dgeneral%0Acontext_name%3Dgeneral%0A%0AHola%2C%20me%20gustar%C3%ADa%20unirme%20a%20la%20lista%20de%20espera%20de%20Xolos%20Ram%C3%ADrez."
                style="color: #666; text-decoration: underline;">
                Conoce el programa y cómo participar →
               <p class="callout" style="margin-top: 15px; font-size: 0.9rem;">
@@ -437,7 +437,7 @@ NFTs de Linaje Xoloitzcuintle</a></li>
     </script>
     <a
       class="wa-float"
-      href="mailto:fernando@xolosramirez.com?subject=Informes%20sobre%20xoloitzcuintle&body=Hola%20Fernando%2C%20estoy%20interesado%20en%20un%20xoloitzcuintle%2C%20quiero%20m%C3%A1s%20informes."
+      href="mailto:fernando@xolosramirez.com?subject=%5BXOLOS%5D%20event%3Dgeneral%20puppy%3Dgeneral&body=context_event%3Dgeneral%0Acontext_puppy%3Dgeneral%0Acontext_name%3Dgeneral%0A%0AHola%20Fernando%2C%20tengo%20una%20consulta%20general%20sobre%20Xolos%20Ram%C3%ADrez."
       target="_blank"
       rel="noopener noreferrer"
       data-gtm="email-floating"

--- a/public/xolos-disponibles.html
+++ b/public/xolos-disponibles.html
@@ -118,12 +118,12 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
           <p><strong>Estado:</strong> <span class="estado disponible">Disponible</span></p>
           <a
             class="btn-whatsapp"
-            href="mailto:fernando@xolosramirez.com?subject=Informes%20sobre%20xoloitzcuintle&body=Hola%20Fernando%2C%20estoy%20interesado%20en%20un%20xoloitzcuintle%2C%20quiero%20m%C3%A1s%20informes."
+            href="mailto:fernando@xolosramirez.com?subject=%5BXOLOS%5D%20event%3Dinfo%20puppy%3Dtliltic&body=context_event%3Dinfo%0Acontext_puppy%3Dtliltic%0Acontext_name%3DTliltic%0A%0AHola%20Fernando%2C%20me%20gustar%C3%ADa%20recibir%20informaci%C3%B3n%20sobre%20Tliltic."
             target="_blank"
             rel="noopener"
             data-gtm="email"
             data-cachorro="Tliltic"
-            onclick="dataLayer.push({ event: 'click_email', cachorro: 'Tliltic', source: 'xolos_disponibles_public' })"
+            onclick="dataLayer.push({ event: 'click_email', cachorro: 'Tliltic', cachorro_slug: 'tliltic', source: 'xolos_disponibles_public' })"
           >
             ✉️ Reservar por correo
           </a>
@@ -145,12 +145,12 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
           <p><strong>Estado:</strong> <span class="estado reservado">Reservado</span></p>
           <a
             class="btn-whatsapp"
-            href="mailto:fernando@xolosramirez.com?subject=Informes%20sobre%20xoloitzcuintle&body=Hola%20Fernando%2C%20estoy%20interesado%20en%20un%20xoloitzcuintle%2C%20quiero%20m%C3%A1s%20informes."
+            href="mailto:fernando@xolosramirez.com?subject=%5BXOLOS%5D%20event%3Dinfo%20puppy%3Dnikte&body=context_event%3Dinfo%0Acontext_puppy%3Dnikte%0Acontext_name%3DNikt%C3%A9%0A%0AHola%20Fernando%2C%20me%20gustar%C3%ADa%20recibir%20informaci%C3%B3n%20sobre%20Nikt%C3%A9."
             target="_blank"
             rel="noopener"
             data-gtm="email"
             data-cachorro="Nikté"
-            onclick="dataLayer.push({ event: 'click_email', cachorro: 'Nikté', source: 'xolos_disponibles_public' })"
+            onclick="dataLayer.push({ event: 'click_email', cachorro: 'Nikté', cachorro_slug: 'nikte', source: 'xolos_disponibles_public' })"
           >
             ✉️ Consultar por correo
           </a>
@@ -172,12 +172,12 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
           <p><strong>Estado:</strong> <span class="estado lista-espera">Lista de espera</span></p>
           <a
             class="btn-whatsapp"
-            href="mailto:fernando@xolosramirez.com?subject=Informes%20sobre%20xoloitzcuintle&body=Hola%20Fernando%2C%20estoy%20interesado%20en%20un%20xoloitzcuintle%2C%20quiero%20m%C3%A1s%20informes."
+            href="mailto:fernando@xolosramirez.com?subject=%5BXOLOS%5D%20event%3Dinfo%20puppy%3Dxolotl&body=context_event%3Dinfo%0Acontext_puppy%3Dxolotl%0Acontext_name%3DX%C3%B3lotl%0A%0AHola%20Fernando%2C%20me%20gustar%C3%ADa%20recibir%20informaci%C3%B3n%20sobre%20X%C3%B3lotl."
             target="_blank"
             rel="noopener"
             data-gtm="email"
             data-cachorro="Xólotl"
-            onclick="dataLayer.push({ event: 'click_email', cachorro: 'Xólotl', source: 'xolos_disponibles_public' })"
+            onclick="dataLayer.push({ event: 'click_email', cachorro: 'Xólotl', cachorro_slug: 'xolotl', source: 'xolos_disponibles_public' })"
           >
             ✉️ Enviar correo
           </a>
@@ -272,7 +272,7 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
           <a href="https://www.youtube.com/channel/UCKtNKCavbBmxtcdHSDd9BsA" target="_blank">YouTube</a><br>
           <a href="https://x.com/xolosArmy" target="_blank">Twitter</a><br>
           <a href="https://t.me/xolosramirez" target="_blank">Telegram</a><br>
-          <a href="mailto:fernando@xolosramirez.com?subject=Informes%20sobre%20xoloitzcuintle&body=Hola%20Fernando%2C%20estoy%20interesado%20en%20un%20xoloitzcuintle%2C%20quiero%20m%C3%A1s%20informes." target="_blank">Correo</a>
+          <a href="mailto:fernando@xolosramirez.com?subject=%5BXOLOS%5D%20event%3Dgeneral%20puppy%3Dgeneral&body=context_event%3Dgeneral%0Acontext_puppy%3Dgeneral%0Acontext_name%3Dgeneral%0A%0AHola%20Fernando%2C%20tengo%20una%20consulta%20general%20sobre%20Xolos%20Ram%C3%ADrez." target="_blank">Correo</a>
         </p>
       </div>
     </div>
@@ -281,9 +281,9 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
 
     <a
     class="email-float"
-    href="mailto:fernando@xolosramirez.com?subject=Consulta sobre Xolos Disponibles&body=Hola Fernando, me interesa obtener más información sobre los ejemplares disponibles en la web."
+    href="mailto:fernando@xolosramirez.com?subject=%5BXOLOS%5D%20event%3Dgeneral%20puppy%3Dgeneral&body=context_event%3Dgeneral%0Acontext_puppy%3Dgeneral%0Acontext_name%3Dgeneral%0A%0AHola%20Fernando%2C%20tengo%20una%20consulta%20general%20sobre%20Xolos%20Ram%C3%ADrez."
     data-gtm="email-floating"
-    onclick="dataLayer.push({ event: 'click_email', cachorro: 'general', source: 'xolos_disponibles_floating' })"
+    onclick="dataLayer.push({ event: 'click_email', cachorro: 'general', cachorro_slug: 'general', source: 'xolos_disponibles_floating' })"
   >
     <span>📧 Contactar por Email</span>
   </a>

--- a/teyolia.html
+++ b/teyolia.html
@@ -277,7 +277,10 @@
               action="https://formspree.io/f/xbdzegwj"
               novalidate
             >
-              <input type="hidden" name="_subject" value="Teyolia | Pre-postulación" />
+              <input type="hidden" name="_subject" value="[XOLOS] event=adoption puppy=teyolia" />
+                <input type="hidden" name="context_event" value="adoption" />
+                <input type="hidden" name="context_puppy" value="teyolia" />
+                <input type="hidden" name="context_name" value="Teyolia Ramírez" />
               <input type="hidden" name="_language" value="es" />
 
               <div class="form-grid">
@@ -341,7 +344,10 @@
               action="https://formspree.io/f/xbdzegwj"
               novalidate
             >
-              <input type="hidden" name="_subject" value="Teyolia | Verificación de depósito" />
+              <input type="hidden" name="_subject" value="[XOLOS] event=reserve puppy=teyolia" />
+                <input type="hidden" name="context_event" value="reserve" />
+                <input type="hidden" name="context_puppy" value="teyolia" />
+                <input type="hidden" name="context_name" value="Teyolia Ramírez" />
               <input type="hidden" name="_language" value="es" />
 
               <div class="form-grid">

--- a/teyolias-guardiania.html
+++ b/teyolias-guardiania.html
@@ -687,7 +687,7 @@
     </script>
 <a
       class="wa-float"
-      href="mailto:fernando@xolosramirez.com?subject=Informes%20sobre%20xoloitzcuintle&body=Hola%20Fernando%2C%20estoy%20interesado%20en%20un%20xoloitzcuintle%2C%20quiero%20m%C3%A1s%20informes."
+      href="mailto:fernando@xolosramirez.com?subject=%5BXOLOS%5D%20event%3Dgeneral%20puppy%3Dgeneral&body=context_event%3Dgeneral%0Acontext_puppy%3Dgeneral%0Acontext_name%3Dgeneral%0A%0AHola%20Fernando%2C%20tengo%20una%20consulta%20general%20sobre%20Xolos%20Ram%C3%ADrez."
       target="_blank"
       rel="noopener noreferrer"
       data-gtm="email-floating"
@@ -696,7 +696,7 @@
       <span>✉️ Escríbenos por correo</span>
     </a>
 
-    <a href="mailto:fernando@xolosramirez.com" class="floating-email-btn" aria-label="Enviar correo a Fernando" title="Contacta a Fernando">
+    <a href="mailto:fernando@xolosramirez.com?subject=%5BXOLOS%5D%20event%3Dgeneral%20puppy%3Dgeneral&body=context_event%3Dgeneral%0Acontext_puppy%3Dgeneral%0Acontext_name%3Dgeneral%0A%0AHola%20Fernando%2C%20tengo%20una%20consulta%20general%20sobre%20Xolos%20Ram%C3%ADrez." class="floating-email-btn" aria-label="Enviar correo a Fernando" title="Contacta a Fernando">
         <svg viewBox="0 0 24 24" width="24" height="24" stroke="currentColor" stroke-width="2" fill="none" stroke-linecap="round" stroke-linejoin="round" class="icon-mail" aria-hidden="true" focusable="false">
             <path d="M4 4h16c1.1 0 2 .9 2 2v12c0 1.1-.9 2-2 2H4c-1.1 0-2-.9-2-2V6c0-1.1.9-2 2-2z"></path>
             <polyline points="22,6 12,13 2,6"></polyline>

--- a/xolo-skin-care/index.html
+++ b/xolo-skin-care/index.html
@@ -1630,7 +1630,7 @@
       </div>
       <a
         class="newsletter-banner__cta"
-        href="mailto:fernando@xolosramirez.com?subject=Suscripci%C3%B3n%20bolet%C3%ADn%20Xolo%20Skin%20Care&body=Hola%2C%20quiero%20suscribirme%20al%20bolet%C3%ADn%20de%20productos%20Xoloitzcuintle."
+        href="mailto:fernando@xolosramirez.com?subject=%5BXOLOS%5D%20event%3Dgeneral%20puppy%3Dgeneral&body=context_event%3Dgeneral%0Acontext_puppy%3Dgeneral%0Acontext_name%3Dgeneral%0A%0AHola%20Fernando%2C%20tengo%20una%20consulta%20general%20sobre%20Xolos%20Ram%C3%ADrez."
       >
         Quiero suscribirme
       </a>
@@ -1672,7 +1672,7 @@
           ¿Dónde comprar RMZ?
         </button>
 
-        <a href="mailto:fernando@xolosramirez.com?subject=Informes%20sobre%20xoloitzcuintle&body=Hola%20Fernando%2C%20estoy%20interesado%20en%20un%20xoloitzcuintle%2C%20quiero%20m%C3%A1s%20informes."
+        <a href="mailto:fernando@xolosramirez.com?subject=%5BXOLOS%5D%20event%3Dgeneral%20puppy%3Dgeneral&body=context_event%3Dgeneral%0Acontext_puppy%3Dgeneral%0Acontext_name%3Dgeneral%0A%0AHola%20Fernando%2C%20tengo%20una%20consulta%20general%20sobre%20Xolos%20Ram%C3%ADrez."
            class="whatsapp-buy" target="_blank" rel="noopener noreferrer"
            data-ga-event="email_lead"
            data-item="Ungüento Solar del Guardián Xólotl">
@@ -1716,7 +1716,7 @@
           ¿Dónde comprar RMZ?
         </button>
 
-        <a href="mailto:fernando@xolosramirez.com?subject=Informes%20sobre%20xoloitzcuintle&body=Hola%20Fernando%2C%20estoy%20interesado%20en%20un%20xoloitzcuintle%2C%20quiero%20m%C3%A1s%20informes."
+        <a href="mailto:fernando@xolosramirez.com?subject=%5BXOLOS%5D%20event%3Dgeneral%20puppy%3Dgeneral&body=context_event%3Dgeneral%0Acontext_puppy%3Dgeneral%0Acontext_name%3Dgeneral%0A%0AHola%20Fernando%2C%20tengo%20una%20consulta%20general%20sobre%20Xolos%20Ram%C3%ADrez."
            class="whatsapp-buy" target="_blank" rel="noopener noreferrer"
            data-ga-event="email_lead"
            data-item="Néctar Onírico de Tlazōlteōtl">
@@ -1755,7 +1755,7 @@
           ¿Dónde comprar RMZ?
         </button>
 
-        <a href="mailto:fernando@xolosramirez.com?subject=Informes%20sobre%20xoloitzcuintle&body=Hola%20Fernando%2C%20estoy%20interesado%20en%20un%20xoloitzcuintle%2C%20quiero%20m%C3%A1s%20informes."
+        <a href="mailto:fernando@xolosramirez.com?subject=%5BXOLOS%5D%20event%3Dgeneral%20puppy%3Dgeneral&body=context_event%3Dgeneral%0Acontext_puppy%3Dgeneral%0Acontext_name%3Dgeneral%0A%0AHola%20Fernando%2C%20tengo%20una%20consulta%20general%20sobre%20Xolos%20Ram%C3%ADrez."
            class="whatsapp-buy" target="_blank" rel="noopener noreferrer"
            data-ga-event="email_lead"
            data-item="Bálsamo Protector Solar">
@@ -1799,7 +1799,7 @@
           ¿Dónde comprar RMZ?
         </button>
 
-        <a href="mailto:fernando@xolosramirez.com?subject=Informes%20sobre%20xoloitzcuintle&body=Hola%20Fernando%2C%20estoy%20interesado%20en%20un%20xoloitzcuintle%2C%20quiero%20m%C3%A1s%20informes."
+        <a href="mailto:fernando@xolosramirez.com?subject=%5BXOLOS%5D%20event%3Dgeneral%20puppy%3Dgeneral&body=context_event%3Dgeneral%0Acontext_puppy%3Dgeneral%0Acontext_name%3Dgeneral%0A%0AHola%20Fernando%2C%20tengo%20una%20consulta%20general%20sobre%20Xolos%20Ram%C3%ADrez."
            class="whatsapp-buy" target="_blank" rel="noopener noreferrer"
            data-ga-event="email_lead"
            data-item="Esencia Citlalinahuatl del Amanecer">
@@ -1843,7 +1843,7 @@
           ¿Dónde comprar RMZ?
         </button>
 
-        <a href="mailto:fernando@xolosramirez.com?subject=Informes%20sobre%20xoloitzcuintle&body=Hola%20Fernando%2C%20estoy%20interesado%20en%20un%20xoloitzcuintle%2C%20quiero%20m%C3%A1s%20informes."
+        <a href="mailto:fernando@xolosramirez.com?subject=%5BXOLOS%5D%20event%3Dgeneral%20puppy%3Dgeneral&body=context_event%3Dgeneral%0Acontext_puppy%3Dgeneral%0Acontext_name%3Dgeneral%0A%0AHola%20Fernando%2C%20tengo%20una%20consulta%20general%20sobre%20Xolos%20Ram%C3%ADrez."
            class="whatsapp-buy" target="_blank" rel="noopener noreferrer"
            data-ga-event="email_lead"
            data-item="Escudo de Bruma de Quetzalcóatl">
@@ -1892,7 +1892,7 @@
           ¿Dónde comprar RMZ?
         </button>
 
-        <a href="mailto:fernando@xolosramirez.com?subject=Informes%20sobre%20xoloitzcuintle&body=Hola%20Fernando%2C%20estoy%20interesado%20en%20un%20xoloitzcuintle%2C%20quiero%20m%C3%A1s%20informes."
+        <a href="mailto:fernando@xolosramirez.com?subject=%5BXOLOS%5D%20event%3Dgeneral%20puppy%3Dgeneral&body=context_event%3Dgeneral%0Acontext_puppy%3Dgeneral%0Acontext_name%3Dgeneral%0A%0AHola%20Fernando%2C%20tengo%20una%20consulta%20general%20sobre%20Xolos%20Ram%C3%ADrez."
            class="whatsapp-buy" target="_blank" rel="noopener noreferrer"
            data-ga-event="email_lead"
            data-item="Dúo Ritual de Espuma del Mictlán">
@@ -1945,7 +1945,7 @@
           ¿Dónde comprar RMZ?
         </button>
 
-        <a href="mailto:fernando@xolosramirez.com?subject=Informes%20sobre%20xoloitzcuintle&body=Hola%20Fernando%2C%20estoy%20interesado%20en%20un%20xoloitzcuintle%2C%20quiero%20m%C3%A1s%20informes."
+        <a href="mailto:fernando@xolosramirez.com?subject=%5BXOLOS%5D%20event%3Dgeneral%20puppy%3Dgeneral&body=context_event%3Dgeneral%0Acontext_puppy%3Dgeneral%0Acontext_name%3Dgeneral%0A%0AHola%20Fernando%2C%20tengo%20una%20consulta%20general%20sobre%20Xolos%20Ram%C3%ADrez."
            class="whatsapp-buy" target="_blank" rel="noopener noreferrer"
            data-ga-event="email_lead"
            data-item="Paquete Bienestar Integral Xoloitzcuintle">
@@ -1997,7 +1997,7 @@
 
       <a
         class="sticky-buy__action sticky-buy__action--whatsapp"
-        href="mailto:fernando@xolosramirez.com?subject=Informes%20sobre%20xoloitzcuintle&body=Hola%20Fernando%2C%20estoy%20interesado%20en%20un%20xoloitzcuintle%2C%20quiero%20m%C3%A1s%20informes."
+        href="mailto:fernando@xolosramirez.com?subject=%5BXOLOS%5D%20event%3Dgeneral%20puppy%3Dgeneral&body=context_event%3Dgeneral%0Acontext_puppy%3Dgeneral%0Acontext_name%3Dgeneral%0A%0AHola%20Fernando%2C%20tengo%20una%20consulta%20general%20sobre%20Xolos%20Ram%C3%ADrez."
         target="_blank"
         rel="noopener noreferrer"
         data-ga-event="email_lead"

--- a/xolos-disponibles.html
+++ b/xolos-disponibles.html
@@ -321,7 +321,7 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
     <iframe width="100%" height="100%" src="https://www.youtube.com/embed/BmeHIF8FKTM" title="Ozomatli Ramirez" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen loading="lazy"></iframe>
   </div>
   <div class="puppy-card__actions">
-    <a href="mailto:fernando@xolosramirez.com?subject=Informes%20sobre%20xoloitzcuintle&body=Hola%20Fernando%2C%20estoy%20interesado%20en%20un%20xoloitzcuintle%2C%20quiero%20m%C3%A1s%20informes." class="btn-small btn-primary-small" style="background-color: #25D366; border-color: #25D366; color: #1a1a1a; font-weight: 700; width: 100%; justify-content: center;">Correo directo ✉️</a>
+    <a href="mailto:fernando@xolosramirez.com?subject=%5BXOLOS%5D%20event%3Dinfo%20puppy%3Dozomatli&body=context_event%3Dinfo%0Acontext_puppy%3Dozomatli%0Acontext_name%3DOzomatli%20Ramirez%0A%0AHola%20Fernando%2C%20me%20gustar%C3%ADa%20recibir%20informaci%C3%B3n%20sobre%20Ozomatli%20Ramirez." class="btn-small btn-primary-small" style="background-color: #25D366; border-color: #25D366; color: #1a1a1a; font-weight: 700; width: 100%; justify-content: center;">Correo directo ✉️</a>
   </div>
 </div>
   </article>
@@ -382,7 +382,7 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
     <iframe width="100%" height="100%" src="https://www.youtube.com/embed/YkpF5WeRydo" title="Nox Ramirez" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen loading="lazy"></iframe>
   </div>
   <div class="puppy-card__actions">
-    <a href="mailto:fernando@xolosramirez.com?subject=Informes%20sobre%20xoloitzcuintle&body=Hola%20Fernando%2C%20estoy%20interesado%20en%20un%20xoloitzcuintle%2C%20quiero%20m%C3%A1s%20informes." class="btn-small btn-primary-small" style="background-color: #25D366; border-color: #25D366; color: #1a1a1a; font-weight: 700; width: 100%; justify-content: center;">Correo directo ✉️</a>
+    <a href="mailto:fernando@xolosramirez.com?subject=%5BXOLOS%5D%20event%3Dinfo%20puppy%3Dnox&body=context_event%3Dinfo%0Acontext_puppy%3Dnox%0Acontext_name%3DNox%20Ramirez%0A%0AHola%20Fernando%2C%20me%20gustar%C3%ADa%20recibir%20informaci%C3%B3n%20sobre%20Nox%20Ramirez." class="btn-small btn-primary-small" style="background-color: #25D366; border-color: #25D366; color: #1a1a1a; font-weight: 700; width: 100%; justify-content: center;">Correo directo ✉️</a>
   </div>
     </div>
   </article>
@@ -452,7 +452,7 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
     <iframe width="100%" height="100%" src="https://www.youtube.com/embed/Y6m1tm2dv-A" title="Teyolia Ramirez" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen loading="lazy"></iframe>
   </div>
   <div class="puppy-card__actions">
-    <a href="mailto:fernando@xolosramirez.com?subject=Informes%20sobre%20xoloitzcuintle&body=Hola%20Fernando%2C%20estoy%20interesado%20en%20un%20xoloitzcuintle%2C%20quiero%20m%C3%A1s%20informes." class="btn-small btn-primary-small" style="background-color: #25D366; border-color: #25D366; color: #1a1a1a; font-weight: 700; width: 100%; justify-content: center;">Correo directo ✉️</a>
+    <a href="mailto:fernando@xolosramirez.com?subject=%5BXOLOS%5D%20event%3Dreserve%20puppy%3Dteyolia&body=context_event%3Dreserve%0Acontext_puppy%3Dteyolia%0Acontext_name%3DTeyolia%20Ramirez%0A%0AHola%20Fernando%2C%20me%20interesa%20reservar%20a%20Teyolia%20Ramirez." class="btn-small btn-primary-small" style="background-color: #25D366; border-color: #25D366; color: #1a1a1a; font-weight: 700; width: 100%; justify-content: center;">Correo directo ✉️</a>
   </div>
     </div>
   </article>
@@ -513,7 +513,7 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
     <iframe width="100%" height="100%" src="https://www.youtube.com/embed/_2EGfG77VhE" title="Onix Ramirez" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen loading="lazy"></iframe>
   </div>
   <div class="puppy-card__actions">
-    <a href="mailto:fernando@xolosramirez.com?subject=Informes%20sobre%20xoloitzcuintle&body=Hola%20Fernando%2C%20estoy%20interesado%20en%20un%20xoloitzcuintle%2C%20quiero%20m%C3%A1s%20informes." class="btn-small btn-primary-small" style="background-color: #25D366; border-color: #25D366; color: #1a1a1a; font-weight: 700; width: 100%; justify-content: center;">Correo directo ✉️</a>
+    <a href="mailto:fernando@xolosramirez.com?subject=%5BXOLOS%5D%20event%3Dinfo%20puppy%3Donix&body=context_event%3Dinfo%0Acontext_puppy%3Donix%0Acontext_name%3D%C3%93nix%20Ramirez%0A%0AHola%20Fernando%2C%20me%20gustar%C3%ADa%20recibir%20informaci%C3%B3n%20sobre%20%C3%93nix%20Ramirez." class="btn-small btn-primary-small" style="background-color: #25D366; border-color: #25D366; color: #1a1a1a; font-weight: 700; width: 100%; justify-content: center;">Correo directo ✉️</a>
   </div>
     </div>
   </article>
@@ -568,7 +568,7 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
     <iframe width="100%" height="100%" src="https://www.youtube.com/embed/0qcQvELxVpU" title="Chimalma Ramirez" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen loading="lazy"></iframe>
   </div>
   <div class="puppy-card__actions">
-    <a href="mailto:fernando@xolosramirez.com?subject=Informes%20sobre%20xoloitzcuintle&body=Hola%20Fernando%2C%20estoy%20interesado%20en%20un%20xoloitzcuintle%2C%20quiero%20m%C3%A1s%20informes." class="btn-small btn-primary-small" style="background-color: #25D366; border-color: #25D366; color: #1a1a1a; font-weight: 700; width: 100%; justify-content: center;">Correo directo ✉️</a>
+    <a href="mailto:fernando@xolosramirez.com?subject=%5BXOLOS%5D%20event%3Dinfo%20puppy%3Dchimalma&body=context_event%3Dinfo%0Acontext_puppy%3Dchimalma%0Acontext_name%3DChimalma%20Ramirez%0A%0AHola%20Fernando%2C%20me%20gustar%C3%ADa%20recibir%20informaci%C3%B3n%20sobre%20Chimalma%20Ramirez." class="btn-small btn-primary-small" style="background-color: #25D366; border-color: #25D366; color: #1a1a1a; font-weight: 700; width: 100%; justify-content: center;">Correo directo ✉️</a>
   </div>
     </div>
   </article> 
@@ -613,7 +613,7 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
     <iframe width="100%" height="100%" src="https://www.youtube.com/embed/swT_Xkc7Kco" title="Mixa Ramirez" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen loading="lazy"></iframe>
   </div>
   <div class="puppy-card__actions">
-         <a href="mailto:fernando@xolosramirez.com?subject=Informes%20sobre%20xoloitzcuintle&body=Hola%20Fernando%2C%20estoy%20interesado%20en%20un%20xoloitzcuintle%2C%20quiero%20m%C3%A1s%20informes." class="btn-small btn-primary-small" style="background-color: #25D366; border-color: #25D366; color: #1a1a1a; font-weight: 700; width: 100%; justify-content: center;">Correo directo ✉️</a>
+         <a href="mailto:fernando@xolosramirez.com?subject=%5BXOLOS%5D%20event%3Dinfo%20puppy%3Dmixa&body=context_event%3Dinfo%0Acontext_puppy%3Dmixa%0Acontext_name%3DMixa%20Ramirez%0A%0AHola%20Fernando%2C%20me%20gustar%C3%ADa%20recibir%20informaci%C3%B3n%20sobre%20Mixa%20Ramirez." class="btn-small btn-primary-small" style="background-color: #25D366; border-color: #25D366; color: #1a1a1a; font-weight: 700; width: 100%; justify-content: center;">Correo directo ✉️</a>
   
     </div>
     </div>
@@ -660,7 +660,7 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
         <li><strong>Color</strong> Negro</li>
       </ul>
       <div class="puppy-card__actions">
-        <a href="mailto:fernando@xolosramirez.com?subject=Informes%20sobre%20xoloitzcuintle&body=Hola%20Fernando%2C%20estoy%20interesado%20en%20un%20xoloitzcuintle%2C%20quiero%20m%C3%A1s%20informes." class="btn-small btn-outline-small" target="_blank" rel="noopener">Solicitar video Personalidad Xolo 🎥</a>
+        <a href="mailto:fernando@xolosramirez.com?subject=%5BXOLOS%5D%20event%3Dinfo%20puppy%3Dluna&body=context_event%3Dinfo%0Acontext_puppy%3Dluna%0Acontext_name%3DLuna%20Ramirez%0A%0AHola%20Fernando%2C%20me%20gustar%C3%ADa%20recibir%20informaci%C3%B3n%20sobre%20Luna%20Ramirez." class="btn-small btn-outline-small" target="_blank" rel="noopener">Solicitar video Personalidad Xolo 🎥</a>
         
       </div>
     </div>
@@ -843,7 +843,7 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
           <a href="https://www.youtube.com/channel/UCKtNKCavbBmxtcdHSDd9BsA">YouTube</a><br>
           <a href="https://x.com/xolosArmy">Twitter</a><br>
           <a href="https://t.me/xolosramirez">Telegram</a><br>
-          <a href="mailto:fernando@xolosramirez.com?subject=Informes%20sobre%20xoloitzcuintle&body=Hola%20Fernando%2C%20estoy%20interesado%20en%20un%20xoloitzcuintle%2C%20quiero%20m%C3%A1s%20informes.">Correo</a>
+          <a href="mailto:fernando@xolosramirez.com?subject=%5BXOLOS%5D%20event%3Dgeneral%20puppy%3Dgeneral&body=context_event%3Dgeneral%0Acontext_puppy%3Dgeneral%0Acontext_name%3Dgeneral%0A%0AHola%20Fernando%2C%20tengo%20una%20consulta%20general%20sobre%20Xolos%20Ram%C3%ADrez.">Correo</a>
         </div>
       </div>
       <p class="copyright">© 2025 Xolos Ramírez. Todos los derechos reservados.</p>
@@ -852,9 +852,9 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
     <!--
 <a
     class="email-float"
-    href="mailto:fernando@xolosramirez.com?subject=Pregunta sobre Xolos Ramirez Disponibles.&body=Hola Fernando, estoy visitando el sitio web de Xolos Ramirez y me gustaría obtener más información sobre los cachorros disponibles."
+    href="mailto:fernando@xolosramirez.com?subject=%5BXOLOS%5D%20event%3Dgeneral%20puppy%3Dgeneral&body=context_event%3Dgeneral%0Acontext_puppy%3Dgeneral%0Acontext_name%3Dgeneral%0A%0AHola%20Fernando%2C%20tengo%20una%20consulta%20general%20sobre%20Xolos%20Ram%C3%ADrez."
     data-gtm="email-floating-en"
-    onclick="dataLayer.push({ event: 'click_email', cachorro: 'general', source: 'available_xolos_floating_en' })"
+    onclick="dataLayer.push({ event: 'click_email', cachorro: 'general', cachorro_slug: 'general', source: 'available_xolos_floating_en' })"
   >
     <span>📧 Contact via Email</span>
   </a>
@@ -862,7 +862,7 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
 
  <a
       class="wa-float"
-      href="mailto:fernando@xolosramirez.com?subject=Informes%20sobre%20xoloitzcuintle&body=Hola%20Fernando%2C%20estoy%20interesado%20en%20un%20xoloitzcuintle%2C%20quiero%20m%C3%A1s%20informes."
+      href="mailto:fernando@xolosramirez.com?subject=%5BXOLOS%5D%20event%3Dgeneral%20puppy%3Dgeneral&body=context_event%3Dgeneral%0Acontext_puppy%3Dgeneral%0Acontext_name%3Dgeneral%0A%0AHola%20Fernando%2C%20tengo%20una%20consulta%20general%20sobre%20Xolos%20Ram%C3%ADrez."
       target="_blank"
       rel="noopener noreferrer"
       data-gtm="email-floating"


### PR DESCRIPTION
### Motivation

- Garantizar que todas las acciones que abren correo (`mailto:` y formularios relacionados) incluyan un asunto y un cuerpo con contexto estructurado para que el orquestador pueda identificar `event` y `puppy` y seleccionar la respuesta correcta desde `cachorros.json`. 
- Minimizar el alcance de los cambios para mantener la UI, estilos y tracking actuales intactos mientras se hace el contenido fácil de parsear. 
- Preparar un contrato legible y consistente para futuras páginas y para el equipo que integra el orquestador. 

### Description

- Actualicé todos los `mailto:` detectados en el sitio para usar el asunto estándar `[XOLOS] event=<EVENTO> puppy=<SLUG_O_GENERAL>` y un cuerpo que comienza con `context_event=...`, `context_puppy=...` y `context_name=...` (ejemplos: Ozomatli -> `event=info puppy=ozomatli`, Nox -> `event=info puppy=nox`, Teyolia -> `event=reserve puppy=teyolia`). 
- Añadí campos ocultos estructurados (`_subject`, `context_event`, `context_puppy`, `context_name`) a los formularios Formspree en `teyolia.html` para que las postulaciónes/confirmaciones también entreguen el mismo contexto. 
- Preservé todos los atributos `target`, `rel`, clases y estilos y añadí `cachorro_slug` a los `dataLayer.push(...)` relevantes para mantener/ayudar la analítica sin romper eventos existentes. 
- Archivos clave modificados: `xolos-disponibles.html`, `en/available-xolos.html`, `public/xolos-disponibles.html`, `contacto.html`, `index.html`, `en/index.html`, `teyolia.html`, `teyolias-guardiania.html`, `en/teyolias-guardianship.html`, `xolo-skin-care/index.html`, `blog/2026-01-24-entrega-ceniza-ramirez.html` y se agregó `docs/email-context.md` con el contrato y regex recomendadas. 

### Testing

- Ejecuté un validador Python que recorrió los `mailto:` del repo y comprobó que el asunto coincide con el patrón `[XOLOS] event=... puppy=...` y que el cuerpo contiene `context_event` y `context_puppy`; la validación local devolvió que todos los `mailto:` (42) cumplen el formato. 
- Busqué por asuntos viejos y frases no estructuradas con `rg` (por ejemplo `Informes sobre xoloitzcuintle`, `Interest in ...`) y confirmé que ya no aparecen en `mailto:` activos fuera de la nueva documentación. 
- Hice comprobaciones puntuales de hrefs codificados para los ejemplos requeridos (Ozomatli, Nox, Teyolia y contacto general) y verifiqué que están correctamente URL-encoded y que el cuerpo contiene las líneas `context_event`/`context_puppy`/`context_name` según el contrato (éxito).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a30a55337908332aadfe02336f93941)