### PR TITLE
Replace WhatsApp CTAs with email contact links

### DIFF
--- a/blog/2026-01-24-entrega-ceniza-ramirez.html
+++ b/blog/2026-01-24-entrega-ceniza-ramirez.html
@@ -212,7 +212,7 @@
         <section class="cta">
             <h3>¿Buscas un compañero ancestral?</h3>
             <p>En Criadero Xolos Ramírez contamos con ejemplares únicos y asesoría completa para entregas nacionales e internacionales.</p>
-            <a href="https://wa.me/qr/R2F5PRQYZSJOA1" class="btn" target="_blank" rel="noopener noreferrer">Contáctanos por WhatsApp</a>
+            <a href="mailto:fernando@xolosramirez.com?subject=Informes%20Xoloitzcuintle&body=Hola%20Fernando%2C%20estoy%20interesado%20en%20un%20xoloitzcuintle%2C%20quiero%20m%C3%A1s%20informes." class="btn" target="_blank" rel="noopener noreferrer">Contáctanos por correo</a>
         </section>
     </main>
 

--- a/contacto.html
+++ b/contacto.html
@@ -211,13 +211,13 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
 
     <a
       class="wa-float"
-      href="https://wa.me/qr/R2F5PRQYZSJOA1"
+      href="mailto:fernando@xolosramirez.com?subject=Informes%20Xoloitzcuintle&body=Hola%20Fernando%2C%20estoy%20interesado%20en%20un%20xoloitzcuintle%2C%20quiero%20m%C3%A1s%20informes."
       target="_blank"
       rel="noopener noreferrer"
-      data-gtm="whatsapp-floating"
-      onclick="dataLayer.push({ event: 'click_whatsapp', source: 'floating_button' })"
+      data-gtm="email-floating"
+      onclick="dataLayer.push({ event: 'click_email', source: 'floating_button' })"
     >
-      <span>📲 Hablanos por WhatsApp</span>
+      <span>📲 Correo directo ✉️</span>
     </a>
   </body>
 </html>

--- a/css/styles.css
+++ b/css/styles.css
@@ -1537,13 +1537,13 @@ form textarea:focus {
   }
 }
 
-/* Botón Flotante de WhatsApp - Premium */
+/* Botón Flotante de Correo - Premium */
 .wa-float {
   position: fixed;
   right: 1.5rem;
   bottom: 1.5rem;
   background-color: #2c2c2c; /* Fondo oscuro para mantener la elegancia */
-  color: #25D366; /* Verde oficial de WhatsApp */
+  color: #25D366; /* Verde oficial de Correo */
   padding: 0.85rem 1.5rem;
   border: 1px solid #25D366;
   border-radius: 999px;
@@ -1636,3 +1636,9 @@ form textarea:focus {
   }
 }
 
+
+/* Mejora de contraste para botones verdes de correo directo en productos disponibles */
+.email-direct-button {
+  color: #1a1a1a;
+  font-weight: 700;
+}

--- a/en/available-xolos.html
+++ b/en/available-xolos.html
@@ -715,7 +715,7 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
       </div>
       <div>
         <h4>Social</h4>
-        <a href="https://wa.me/qr/R2F5PRQYZSJOA1">WhatsApp</a><br>
+        <a href="mailto:fernando@xolosramirez.com?subject=Informes%20Xoloitzcuintle&body=Hola%20Fernando%2C%20estoy%20interesado%20en%20un%20xoloitzcuintle%2C%20quiero%20m%C3%A1s%20informes.">Correo</a><br>
         <a href="https://x.com/xolosArmy">Twitter/X</a>
       </div>
     </div>

--- a/en/index.html
+++ b/en/index.html
@@ -416,13 +416,13 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
     </script>
     <a
       class="wa-float"
-      href="https://wa.me/qr/R2F5PRQYZSJOA1"
+      href="mailto:fernando@xolosramirez.com?subject=Informes%20Xoloitzcuintle&body=Hola%20Fernando%2C%20estoy%20interesado%20en%20un%20xoloitzcuintle%2C%20quiero%20m%C3%A1s%20informes."
       target="_blank"
       rel="noopener noreferrer"
-      data-gtm="whatsapp-floating"
-      onclick="dataLayer.push({ event: 'click_whatsapp', source: 'floating_button' })"
+      data-gtm="email-floating"
+      onclick="dataLayer.push({ event: 'click_email', source: 'floating_button' })"
     >
-      <span>📲 Chat with us on WhatsApp</span>
+      <span>📲 Direct email ✉️</span>
     </a>
   </body>
 </html>

--- a/import/jimdo-sitemap.html
+++ b/import/jimdo-sitemap.html
@@ -277,8 +277,8 @@ Xoloitzcuintle en nuestra Historia mexicana | Xolos Ramirez</a></li><li><a href=
             <!-- TikTok -->
             <a href="https://www.tiktok.com/@xolosramirezoficial" target="_blank" style="margin:0 10px;display:inline-block;"><img src="jimdo-sitemap_files/3046121.png" alt="TikTok" width="30" height="30"></a> <!-- X / Twitter -->
              <a href="https://x.com/xolosramirez1" target="_blank" style="margin:0 10px;display:inline-block;"><img src="jimdo-sitemap_files/3670151.png" alt="X (Twitter)" width="30" height="30"></a> <!-- YouTube -->
-             <a href="https://www.youtube.com/c/XolosRamirez" target="_blank" style="margin:0 10px;display:inline-block;"><img src="jimdo-sitemap_files/1384060.png" alt="YouTube" width="30" height="30"></a> <!-- WhatsApp -->
-             <a href="https://wa.me/qr/R2F5PRQYZSJOA1" target="_blank" style="margin:0 10px;display:inline-block;"><img src="jimdo-sitemap_files/733585.png" alt="WhatsApp" width="30" height="30"></a> <!-- Snapchat (fantasmita blanco sobre amarillo) -->
+             <a href="https://www.youtube.com/c/XolosRamirez" target="_blank" style="margin:0 10px;display:inline-block;"><img src="jimdo-sitemap_files/1384060.png" alt="YouTube" width="30" height="30"></a> <!-- Correo -->
+             <a href="mailto:fernando@xolosramirez.com?subject=Informes%20Xoloitzcuintle&body=Hola%20Fernando%2C%20estoy%20interesado%20en%20un%20xoloitzcuintle%2C%20quiero%20m%C3%A1s%20informes." target="_blank" style="margin:0 10px;display:inline-block;"><img src="jimdo-sitemap_files/733585.png" alt="Correo" width="30" height="30"></a> <!-- Snapchat (fantasmita blanco sobre amarillo) -->
              <a href="https://www.snapchat.com/add/xolos_ramirez?share_id=hsgphr8jjdg&amp;locale=es-MX" target="_blank" style="margin:0 10px;display:inline-block;"><img src="jimdo-sitemap_files/Rk3Vks0.png" alt="Snapchat" width="30" height="30"></a> <!-- Pixelfed -->
              <a href="https://xolosramirez.club/xolosramirez" target="_blank" rel="me" style="margin:0 10px;display:inline-block;"><img src="jimdo-sitemap_files/Instagram_icon.png" alt="Pixelfed" width="30" height="30"></a>
         </div>

--- a/index.html
+++ b/index.html
@@ -437,13 +437,13 @@ NFTs de Linaje Xoloitzcuintle</a></li>
     </script>
     <a
       class="wa-float"
-      href="https://wa.me/qr/R2F5PRQYZSJOA1"
+      href="mailto:fernando@xolosramirez.com?subject=Informes%20Xoloitzcuintle&body=Hola%20Fernando%2C%20estoy%20interesado%20en%20un%20xoloitzcuintle%2C%20quiero%20m%C3%A1s%20informes."
       target="_blank"
       rel="noopener noreferrer"
-      data-gtm="whatsapp-floating"
-      onclick="dataLayer.push({ event: 'click_whatsapp', source: 'floating_button' })"
+      data-gtm="email-floating"
+      onclick="dataLayer.push({ event: 'click_email', source: 'floating_button' })"
     >
-      <span>📲 Hablanos por WhatsApp</span>
+      <span>📲 Correo directo ✉️</span>
     </a>
   </body>
 </html>

--- a/public/xolos-disponibles.html
+++ b/public/xolos-disponibles.html
@@ -118,14 +118,14 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
           <p><strong>Estado:</strong> <span class="estado disponible">Disponible</span></p>
           <a
             class="btn-whatsapp"
-            href="https://wa.me/qr/R2F5PRQYZSJOA1"
+            href="mailto:fernando@xolosramirez.com?subject=Informes%20Xoloitzcuintle&body=Hola%20Fernando%2C%20estoy%20interesado%20en%20un%20xoloitzcuintle%2C%20quiero%20m%C3%A1s%20informes."
             target="_blank"
             rel="noopener"
-            data-gtm="whatsapp"
+            data-gtm="email"
             data-cachorro="Tliltic"
-            onclick="dataLayer.push({ event: 'click_whatsapp', cachorro: 'Tliltic', source: 'xolos_disponibles_public' })"
+            onclick="dataLayer.push({ event: 'click_email', cachorro: 'Tliltic', source: 'xolos_disponibles_public' })"
           >
-            📲 Reservar vía WhatsApp
+            📲 Reservar por correo
           </a>
         </article>
 
@@ -145,14 +145,14 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
           <p><strong>Estado:</strong> <span class="estado reservado">Reservado</span></p>
           <a
             class="btn-whatsapp"
-            href="https://wa.me/qr/R2F5PRQYZSJOA1"
+            href="mailto:fernando@xolosramirez.com?subject=Informes%20Xoloitzcuintle&body=Hola%20Fernando%2C%20estoy%20interesado%20en%20un%20xoloitzcuintle%2C%20quiero%20m%C3%A1s%20informes."
             target="_blank"
             rel="noopener"
-            data-gtm="whatsapp"
+            data-gtm="email"
             data-cachorro="Nikté"
-            onclick="dataLayer.push({ event: 'click_whatsapp', cachorro: 'Nikté', source: 'xolos_disponibles_public' })"
+            onclick="dataLayer.push({ event: 'click_email', cachorro: 'Nikté', source: 'xolos_disponibles_public' })"
           >
-            📲 Consultar vía WhatsApp
+            📲 Consultar por correo
           </a>
         </article>
 
@@ -172,14 +172,14 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
           <p><strong>Estado:</strong> <span class="estado lista-espera">Lista de espera</span></p>
           <a
             class="btn-whatsapp"
-            href="https://wa.me/qr/R2F5PRQYZSJOA1"
+            href="mailto:fernando@xolosramirez.com?subject=Informes%20Xoloitzcuintle&body=Hola%20Fernando%2C%20estoy%20interesado%20en%20un%20xoloitzcuintle%2C%20quiero%20m%C3%A1s%20informes."
             target="_blank"
             rel="noopener"
-            data-gtm="whatsapp"
+            data-gtm="email"
             data-cachorro="Xólotl"
-            onclick="dataLayer.push({ event: 'click_whatsapp', cachorro: 'Xólotl', source: 'xolos_disponibles_public' })"
+            onclick="dataLayer.push({ event: 'click_email', cachorro: 'Xólotl', source: 'xolos_disponibles_public' })"
           >
-            📲 Enviar mensaje WhatsApp
+            📲 Enviar mensaje Correo
           </a>
         </article>
 
@@ -215,7 +215,7 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
         </div>
         <div class="paso">
           <img src="img/icono-contacto.svg" alt="" width="50" height="50">
-          <p><strong>2. Escríbenos:</strong> Haz clic en el botón de WhatsApp o envíanos un correo para iniciar la reserva.</p>
+          <p><strong>2. Escríbenos:</strong> Haz clic en el botón de correo o envíanos un correo para iniciar la reserva.</p>
         </div>
         <div class="paso">
           <img src="img/icono-reserva.svg" alt="" width="50" height="50">
@@ -272,7 +272,7 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
           <a href="https://www.youtube.com/channel/UCKtNKCavbBmxtcdHSDd9BsA" target="_blank">YouTube</a><br>
           <a href="https://x.com/xolosArmy" target="_blank">Twitter</a><br>
           <a href="https://t.me/xolosramirez" target="_blank">Telegram</a><br>
-          <a href="https://wa.me/qr/R2F5PRQYZSJOA1" target="_blank">WhatsApp</a>
+          <a href="mailto:fernando@xolosramirez.com?subject=Informes%20Xoloitzcuintle&body=Hola%20Fernando%2C%20estoy%20interesado%20en%20un%20xoloitzcuintle%2C%20quiero%20m%C3%A1s%20informes." target="_blank">Correo</a>
         </p>
       </div>
     </div>

--- a/teyolias-guardiania.html
+++ b/teyolias-guardiania.html
@@ -687,13 +687,13 @@
     </script>
 <a
       class="wa-float"
-      href="https://wa.me/qr/R2F5PRQYZSJOA1"
+      href="mailto:fernando@xolosramirez.com?subject=Informes%20Xoloitzcuintle&body=Hola%20Fernando%2C%20estoy%20interesado%20en%20un%20xoloitzcuintle%2C%20quiero%20m%C3%A1s%20informes."
       target="_blank"
       rel="noopener noreferrer"
-      data-gtm="whatsapp-floating"
-      onclick="dataLayer.push({ event: 'click_whatsapp', source: 'floating_button' })"
+      data-gtm="email-floating"
+      onclick="dataLayer.push({ event: 'click_email', source: 'floating_button' })"
     >
-      <span>📲 Hablanos por WhatsApp</span>
+      <span>📲 Correo directo ✉️</span>
     </a>
 
     <a href="mailto:fernando@xolosramirez.com" class="floating-email-btn" aria-label="Enviar correo a Fernando" title="Contacta a Fernando">

--- a/xolo-skin-care/index.html
+++ b/xolo-skin-care/index.html
@@ -1347,7 +1347,7 @@
     }
 
     .sticky-buy__actions {
-      grid-template-columns: 1.2fr 0.8fr;     /* XEC un poco más ancho que WhatsApp */
+      grid-template-columns: 1.2fr 0.8fr;     /* XEC un poco más ancho que Correo */
       align-items: stretch;
     }
 
@@ -1672,12 +1672,12 @@
           ¿Dónde comprar RMZ?
         </button>
 
-        <a href="https://wa.me/qr/R2F5PRQYZSJOA1"
+        <a href="mailto:fernando@xolosramirez.com?subject=Informes%20Xoloitzcuintle&body=Hola%20Fernando%2C%20estoy%20interesado%20en%20un%20xoloitzcuintle%2C%20quiero%20m%C3%A1s%20informes."
            class="whatsapp-buy" target="_blank" rel="noopener noreferrer"
-           data-ga-event="whatsapp_lead"
+           data-ga-event="email_lead"
            data-item="Ungüento Solar del Guardián Xólotl">
           <span aria-hidden="true">🟢</span>
-          <span>Comprar por WhatsApp</span>
+          <span>Correo directo ✉️</span>
         </a>
 
         <button class="txid-toggle" type="button" style="width: 100%;">Ya compré, pegar TXID manual</button>
@@ -1716,12 +1716,12 @@
           ¿Dónde comprar RMZ?
         </button>
 
-        <a href="https://wa.me/qr/R2F5PRQYZSJOA1"
+        <a href="mailto:fernando@xolosramirez.com?subject=Informes%20Xoloitzcuintle&body=Hola%20Fernando%2C%20estoy%20interesado%20en%20un%20xoloitzcuintle%2C%20quiero%20m%C3%A1s%20informes."
            class="whatsapp-buy" target="_blank" rel="noopener noreferrer"
-           data-ga-event="whatsapp_lead"
+           data-ga-event="email_lead"
            data-item="Néctar Onírico de Tlazōlteōtl">
           <span aria-hidden="true">🟢</span>
-          <span>Comprar por WhatsApp</span>
+          <span>Correo directo ✉️</span>
         </a>
 
         <button class="txid-toggle" type="button" style="width: 100%;">Ya compré, pegar TXID manual</button>
@@ -1755,12 +1755,12 @@
           ¿Dónde comprar RMZ?
         </button>
 
-        <a href="https://wa.me/qr/R2F5PRQYZSJOA1"
+        <a href="mailto:fernando@xolosramirez.com?subject=Informes%20Xoloitzcuintle&body=Hola%20Fernando%2C%20estoy%20interesado%20en%20un%20xoloitzcuintle%2C%20quiero%20m%C3%A1s%20informes."
            class="whatsapp-buy" target="_blank" rel="noopener noreferrer"
-           data-ga-event="whatsapp_lead"
+           data-ga-event="email_lead"
            data-item="Bálsamo Protector Solar">
           <span aria-hidden="true">🟢</span>
-          <span>Comprar por WhatsApp</span>
+          <span>Correo directo ✉️</span>
         </a>
 
         <button class="txid-toggle" type="button" style="width: 100%;">Ya compré, pegar TXID manual</button>
@@ -1799,12 +1799,12 @@
           ¿Dónde comprar RMZ?
         </button>
 
-        <a href="https://wa.me/qr/R2F5PRQYZSJOA1"
+        <a href="mailto:fernando@xolosramirez.com?subject=Informes%20Xoloitzcuintle&body=Hola%20Fernando%2C%20estoy%20interesado%20en%20un%20xoloitzcuintle%2C%20quiero%20m%C3%A1s%20informes."
            class="whatsapp-buy" target="_blank" rel="noopener noreferrer"
-           data-ga-event="whatsapp_lead"
+           data-ga-event="email_lead"
            data-item="Esencia Citlalinahuatl del Amanecer">
           <span aria-hidden="true">🟢</span>
-          <span>Comprar por WhatsApp</span>
+          <span>Correo directo ✉️</span>
         </a>
 
         <button class="txid-toggle" type="button" style="width: 100%;">Ya compré, pegar TXID manual</button>
@@ -1843,12 +1843,12 @@
           ¿Dónde comprar RMZ?
         </button>
 
-        <a href="https://wa.me/qr/R2F5PRQYZSJOA1"
+        <a href="mailto:fernando@xolosramirez.com?subject=Informes%20Xoloitzcuintle&body=Hola%20Fernando%2C%20estoy%20interesado%20en%20un%20xoloitzcuintle%2C%20quiero%20m%C3%A1s%20informes."
            class="whatsapp-buy" target="_blank" rel="noopener noreferrer"
-           data-ga-event="whatsapp_lead"
+           data-ga-event="email_lead"
            data-item="Escudo de Bruma de Quetzalcóatl">
           <span aria-hidden="true">🟢</span>
-          <span>Comprar por WhatsApp</span>
+          <span>Correo directo ✉️</span>
         </a>
 
         <button class="txid-toggle" type="button" style="width: 100%;">Ya compré, pegar TXID manual</button>
@@ -1892,12 +1892,12 @@
           ¿Dónde comprar RMZ?
         </button>
 
-        <a href="https://wa.me/qr/R2F5PRQYZSJOA1"
+        <a href="mailto:fernando@xolosramirez.com?subject=Informes%20Xoloitzcuintle&body=Hola%20Fernando%2C%20estoy%20interesado%20en%20un%20xoloitzcuintle%2C%20quiero%20m%C3%A1s%20informes."
            class="whatsapp-buy" target="_blank" rel="noopener noreferrer"
-           data-ga-event="whatsapp_lead"
+           data-ga-event="email_lead"
            data-item="Dúo Ritual de Espuma del Mictlán">
           <span aria-hidden="true">🟢</span>
-          <span>Comprar por WhatsApp</span>
+          <span>Correo directo ✉️</span>
         </a>
 
         <button class="txid-toggle" type="button" style="width: 100%;">Ya compré, pegar TXID manual</button>
@@ -1945,12 +1945,12 @@
           ¿Dónde comprar RMZ?
         </button>
 
-        <a href="https://wa.me/qr/R2F5PRQYZSJOA1"
+        <a href="mailto:fernando@xolosramirez.com?subject=Informes%20Xoloitzcuintle&body=Hola%20Fernando%2C%20estoy%20interesado%20en%20un%20xoloitzcuintle%2C%20quiero%20m%C3%A1s%20informes."
            class="whatsapp-buy" target="_blank" rel="noopener noreferrer"
-           data-ga-event="whatsapp_lead"
+           data-ga-event="email_lead"
            data-item="Paquete Bienestar Integral Xoloitzcuintle">
           <span aria-hidden="true">🟢</span>
-          <span>Comprar por WhatsApp</span>
+          <span>Correo directo ✉️</span>
         </a>
 
         <button class="txid-toggle" type="button" style="width: 100%;">Ya compré, pegar TXID manual</button>
@@ -1997,15 +1997,15 @@
 
       <a
         class="sticky-buy__action sticky-buy__action--whatsapp"
-        href="https://wa.me/qr/R2F5PRQYZSJOA1"
+        href="mailto:fernando@xolosramirez.com?subject=Informes%20Xoloitzcuintle&body=Hola%20Fernando%2C%20estoy%20interesado%20en%20un%20xoloitzcuintle%2C%20quiero%20m%C3%A1s%20informes."
         target="_blank"
         rel="noopener noreferrer"
-        data-ga-event="whatsapp_lead"
-        data-item="Compra rápida WhatsApp"
-        aria-label="Abrir WhatsApp para una compra rápida por transferencia"
+        data-ga-event="email_lead"
+        data-item="Compra rápida correo"
+        aria-label="Abrir correo para una compra rápida por transferencia"
       >
-        <i class="fa-brands fa-whatsapp" aria-hidden="true"></i>
-        WhatsApp
+        <i class="fa-brands fa-envelope" aria-hidden="true"></i>
+        Correo
       </a>
     </div>
   </aside>

--- a/xolos-disponibles.html
+++ b/xolos-disponibles.html
@@ -322,7 +322,7 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
     <iframe width="100%" height="100%" src="https://www.youtube.com/embed/BmeHIF8FKTM" title="Ozomatli Ramirez" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen loading="lazy"></iframe>
   </div>
   <div class="puppy-card__actions">
-    <a href="https://wa.me/qr/R2F5PRQYZSJOA1" class="btn-small btn-primary-small" style="background-color: #25D366; border-color: #25D366; width: 100%; justify-content: center;">WhatsApp Directo 📲</a>
+    <a href="mailto:fernando@xolosramirez.com?subject=Informes%20Xoloitzcuintle&body=Hola%20Fernando%2C%20estoy%20interesado%20en%20un%20xoloitzcuintle%2C%20quiero%20m%C3%A1s%20informes." class="btn-small btn-primary-small email-direct-button" style="background-color: #25D366; border-color: #25D366; width: 100%; justify-content: center;">Correo directo ✉️</a>
   </div>
 </div>
   </article>
@@ -383,7 +383,7 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
     <iframe width="100%" height="100%" src="https://www.youtube.com/embed/YkpF5WeRydo" title="Nox Ramirez" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen loading="lazy"></iframe>
   </div>
   <div class="puppy-card__actions">
-    <a href="https://wa.me/qr/R2F5PRQYZSJOA1" class="btn-small btn-primary-small" style="background-color: #25D366; border-color: #25D366; width: 100%; justify-content: center;">WhatsApp Directo 📲</a>
+    <a href="mailto:fernando@xolosramirez.com?subject=Informes%20Xoloitzcuintle&body=Hola%20Fernando%2C%20estoy%20interesado%20en%20un%20xoloitzcuintle%2C%20quiero%20m%C3%A1s%20informes." class="btn-small btn-primary-small email-direct-button" style="background-color: #25D366; border-color: #25D366; width: 100%; justify-content: center;">Correo directo ✉️</a>
   </div>
     </div>
   </article>
@@ -453,7 +453,7 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
     <iframe width="100%" height="100%" src="https://www.youtube.com/embed/Y6m1tm2dv-A" title="Teyolia Ramirez" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen loading="lazy"></iframe>
   </div>
   <div class="puppy-card__actions">
-    <a href="https://wa.me/qr/R2F5PRQYZSJOA1" class="btn-small btn-primary-small" style="background-color: #25D366; border-color: #25D366; width: 100%; justify-content: center;">WhatsApp Directo 📲</a>
+    <a href="mailto:fernando@xolosramirez.com?subject=Informes%20Xoloitzcuintle&body=Hola%20Fernando%2C%20estoy%20interesado%20en%20un%20xoloitzcuintle%2C%20quiero%20m%C3%A1s%20informes." class="btn-small btn-primary-small email-direct-button" style="background-color: #25D366; border-color: #25D366; width: 100%; justify-content: center;">Correo directo ✉️</a>
   </div>
     </div>
   </article>
@@ -514,7 +514,7 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
     <iframe width="100%" height="100%" src="https://www.youtube.com/embed/_2EGfG77VhE" title="Onix Ramirez" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen loading="lazy"></iframe>
   </div>
   <div class="puppy-card__actions">
-    <a href="https://wa.me/qr/R2F5PRQYZSJOA1" class="btn-small btn-primary-small" style="background-color: #25D366; border-color: #25D366; width: 100%; justify-content: center;">WhatsApp Directo 📲</a>
+    <a href="mailto:fernando@xolosramirez.com?subject=Informes%20Xoloitzcuintle&body=Hola%20Fernando%2C%20estoy%20interesado%20en%20un%20xoloitzcuintle%2C%20quiero%20m%C3%A1s%20informes." class="btn-small btn-primary-small email-direct-button" style="background-color: #25D366; border-color: #25D366; width: 100%; justify-content: center;">Correo directo ✉️</a>
   </div>
     </div>
   </article>
@@ -569,7 +569,7 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
     <iframe width="100%" height="100%" src="https://www.youtube.com/embed/0qcQvELxVpU" title="Chimalma Ramirez" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen loading="lazy"></iframe>
   </div>
   <div class="puppy-card__actions">
-    <a href="https://wa.me/qr/R2F5PRQYZSJOA1" class="btn-small btn-primary-small" style="background-color: #25D366; border-color: #25D366; width: 100%; justify-content: center;">WhatsApp Directo 📲</a>
+    <a href="mailto:fernando@xolosramirez.com?subject=Informes%20Xoloitzcuintle&body=Hola%20Fernando%2C%20estoy%20interesado%20en%20un%20xoloitzcuintle%2C%20quiero%20m%C3%A1s%20informes." class="btn-small btn-primary-small email-direct-button" style="background-color: #25D366; border-color: #25D366; width: 100%; justify-content: center;">Correo directo ✉️</a>
   </div>
     </div>
   </article> 
@@ -614,7 +614,7 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
     <iframe width="100%" height="100%" src="https://www.youtube.com/embed/swT_Xkc7Kco" title="Mixa Ramirez" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen loading="lazy"></iframe>
   </div>
   <div class="puppy-card__actions">
-         <a href="https://wa.me/qr/R2F5PRQYZSJOA1" class="btn-small btn-primary-small" style="background-color: #25D366; border-color: #25D366; width: 100%; justify-content: center;">WhatsApp Directo 📲</a>
+         <a href="mailto:fernando@xolosramirez.com?subject=Informes%20Xoloitzcuintle&body=Hola%20Fernando%2C%20estoy%20interesado%20en%20un%20xoloitzcuintle%2C%20quiero%20m%C3%A1s%20informes." class="btn-small btn-primary-small email-direct-button" style="background-color: #25D366; border-color: #25D366; width: 100%; justify-content: center;">Correo directo ✉️</a>
   
     </div>
     </div>
@@ -661,7 +661,7 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
         <li><strong>Color</strong> Negro</li>
       </ul>
       <div class="puppy-card__actions">
-        <a href="https://wa.me/qr/R2F5PRQYZSJOA1" class="btn-small btn-outline-small" target="_blank" rel="noopener">Ver video Personalidad Xolo 🎥</a>
+        <a href="mailto:fernando@xolosramirez.com?subject=Informes%20Xoloitzcuintle&body=Hola%20Fernando%2C%20estoy%20interesado%20en%20un%20xoloitzcuintle%2C%20quiero%20m%C3%A1s%20informes." class="btn-small btn-outline-small" target="_blank" rel="noopener">Ver video Personalidad Xolo 🎥</a>
         
       </div>
     </div>
@@ -844,7 +844,7 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
           <a href="https://www.youtube.com/channel/UCKtNKCavbBmxtcdHSDd9BsA">YouTube</a><br>
           <a href="https://x.com/xolosArmy">Twitter</a><br>
           <a href="https://t.me/xolosramirez">Telegram</a><br>
-          <a href="https://wa.me/qr/R2F5PRQYZSJOA1">WhatsApp</a>
+          <a href="mailto:fernando@xolosramirez.com?subject=Informes%20Xoloitzcuintle&body=Hola%20Fernando%2C%20estoy%20interesado%20en%20un%20xoloitzcuintle%2C%20quiero%20m%C3%A1s%20informes.">Correo</a>
         </div>
       </div>
       <p class="copyright">© 2025 Xolos Ramírez. Todos los derechos reservados.</p>
@@ -863,13 +863,13 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
 
  <a
       class="wa-float"
-      href="https://wa.me/qr/R2F5PRQYZSJOA1"
+      href="mailto:fernando@xolosramirez.com?subject=Informes%20Xoloitzcuintle&body=Hola%20Fernando%2C%20estoy%20interesado%20en%20un%20xoloitzcuintle%2C%20quiero%20m%C3%A1s%20informes."
       target="_blank"
       rel="noopener noreferrer"
-      data-gtm="whatsapp-floating"
-      onclick="dataLayer.push({ event: 'click_whatsapp', source: 'floating_button' })"
+      data-gtm="email-floating"
+      onclick="dataLayer.push({ event: 'click_email', source: 'floating_button' })"
     >
-      <span>📲 Hablanos por WhatsApp</span>
+      <span>📲 Correo directo ✉️</span>
     </a>
 
     <script src="js/main.js" defer></script>


### PR DESCRIPTION
### Motivation
- Sustituir todos los puntos de contacto y CTAs que enlazaban a WhatsApp por un canal de correo con asunto y cuerpo precargados para centralizar consultas en `fernando@xolosramirez.com`.
- Actualizar el tracking y etiquetas de eventos asociados a acciones de contacto para reportar `email` en lugar de `whatsapp`.
- Asegurar accesibilidad y contrastes en los botones verdes de contacto de productos para mejorar legibilidad.

### Description
- Reemplacé todas las `href` a WhatsApp (`wa.me`, `api.whatsapp`, etc.) por el `mailto:` prellenado a `fernando@xolosramirez.com` con asunto y body URL-encoded: `subject=Informes%20Xoloitzcuintle` y `body=Hola%20Fernando%2C%20estoy%20interesado%20en%20un%20xoloitzcuintle%2C%20quiero%20m%C3%A1s%20informes.`
- Actualicé los textos visibles de CTAs y enlaces a "Correo", "Correo directo ✉️" o similares y eliminé invitaciones a usar WhatsApp en instrucciones y pasos de contacto.
- Cambié eventos/atributos de tracking: `click_whatsapp` → `click_email`, `whatsapp-floating` → `email-floating`, `data-ga-event="whatsapp_lead"` → `data-ga-event="email_lead"`, `data-gtm="whatsapp"` → `data-gtm="email"`, y `data-item` y `aria-label` relevantes para indicar correo donde aplica.
- Actualicé todos los CTAs de productos y botones de "compra rápida" dentro de `xolo-skin-care` para apuntar al `mailto:` (incluyendo el sticky quick-purchase), y remplacé el icono/etiqueta de WhatsApp por icono/etiqueta de correo y accesibilidad orientada a email.
- Añadí la clase `email-direct-button` a los botones verdes de productos disponibles (Ozomatli, Nox, Teyolia, Onix, Chimalma, Mixa y otros cards) y añadí reglas CSS que aplican `color: #1a1a1a;` y `font-weight: 700;` para mejorar contraste sin cambiar el fondo verde.
- Cambios principales en archivos: `xolo-skin-care/index.html`, `xolos-disponibles.html`, `index.html`, `contacto.html`, `en/available-xolos.html`, `en/index.html`, `public/xolos-disponibles.html`, `teyolias-guardiania.html`, `import/jimdo-sitemap.html`, `css/styles.css` y algunos demás HTML menores.
- Commits realizados: `Replace WhatsApp links with email CTAs` y `Mejora contraste de botones de correo`.

### Testing
- Ejecuté búsquedas `rg` para detectar referencias a WhatsApp y confirmé que no quedan `href` a `wa.me`/APIs de WhatsApp ni eventos `click_whatsapp` o `data-gtm="whatsapp"` (resultado: OK).
- Verifiqué la presencia de la clase `email-direct-button` y las reglas CSS `color: #1a1a1a;` y `font-weight: 700;` en `css/styles.css` (resultado: OK).
- Realicé los commits locales con los mensajes solicitados y confirmación de cambios (ambos commits creados exitosamente).
- Nota: se actualizaron textos, atributos aria y data-* para reflejar el cambio a correo; recomiendo revisión visual en entorno de staging para comprobar vínculos `mailto:` y pruebas de tracking en el sistema analítico en producción.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a32b4b1b77c833293e5a41ee0e58d96)