### PR TITLE
Replace floating email buttons with WhatsApp link

### DIFF
--- a/contacto.html
+++ b/contacto.html
@@ -211,13 +211,13 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
 
     <a
       class="wa-float"
-      href="mailto:fernando@xolosramirez.com?subject=%5BXOLOS%5D%20event%3Dgeneral%20puppy%3Dgeneral&body=context_event%3Dgeneral%0Acontext_puppy%3Dgeneral%0Acontext_name%3Dgeneral%0A%0AHola%20Fernando%2C%20tengo%20una%20consulta%20general%20sobre%20Xolos%20Ram%C3%ADrez."
+      href="https://wa.me/message/435RTKGJLTX2J1"
       target="_blank"
       rel="noopener noreferrer"
-      data-gtm="email-floating"
-      onclick="dataLayer.push({ event: 'click_email', cachorro_slug: 'general', source: 'floating_button' })"
+      data-gtm="whatsapp-floating"
+      onclick="dataLayer.push({ event: 'click_whatsapp', cachorro_slug: 'general', source: 'floating_button' })"
     >
-      <span>📲 Correo directo ✉️</span>
+      <span>📲 WhatsApp directo</span>
     </a>
   </body>
 </html>

--- a/en/available-xolos.html
+++ b/en/available-xolos.html
@@ -723,11 +723,11 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
 
   <a
     class="email-float"
-    href="mailto:fernando@xolosramirez.com?subject=%5BXOLOS%5D%20event%3Dgeneral%20puppy%3Dgeneral&body=context_event%3Dgeneral%0Acontext_puppy%3Dgeneral%0Acontext_name%3Dgeneral%0A%0AHello%20Fernando%2C%20I%20have%20a%20general%20question%20about%20Xolos%20Ram%C3%ADrez."
-    data-gtm="email-floating-en"
-    onclick="dataLayer.push({ event: 'click_email', cachorro: 'general', cachorro_slug: 'general', source: 'available_xolos_floating_en' })"
+    href="https://wa.me/message/435RTKGJLTX2J1" target="_blank" rel="noopener noreferrer"
+    data-gtm="whatsapp-floating-en"
+    onclick="dataLayer.push({ event: 'click_whatsapp', cachorro: 'general', cachorro_slug: 'general', source: 'available_xolos_floating_en' })"
   >
-    <span>📧 Contact via Email</span>
+    <span>📲 Contact via WhatsApp</span>
   </a>
 
   <script src="https://unpkg.com/aos@2.3.1/dist/aos.js"></script>

--- a/en/index.html
+++ b/en/index.html
@@ -416,13 +416,13 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
     </script>
     <a
       class="wa-float"
-      href="mailto:fernando@xolosramirez.com?subject=%5BXOLOS%5D%20event%3Dgeneral%20puppy%3Dgeneral&body=context_event%3Dgeneral%0Acontext_puppy%3Dgeneral%0Acontext_name%3Dgeneral%0A%0AHello%20Fernando%2C%20I%20have%20a%20general%20question%20about%20Xolos%20Ram%C3%ADrez."
+      href="https://wa.me/message/435RTKGJLTX2J1"
       target="_blank"
       rel="noopener noreferrer"
-      data-gtm="email-floating"
-      onclick="dataLayer.push({ event: 'click_email', cachorro_slug: 'general', source: 'floating_button' })"
+      data-gtm="whatsapp-floating"
+      onclick="dataLayer.push({ event: 'click_whatsapp', cachorro_slug: 'general', source: 'floating_button' })"
     >
-      <span>📲 Direct email ✉️</span>
+      <span>📲 WhatsApp direct</span>
     </a>
   </body>
 </html>

--- a/en/teyolias-guardianship.html
+++ b/en/teyolias-guardianship.html
@@ -583,11 +583,8 @@
         });
     </script>
 
-    <a href="mailto:fernando@xolosramirez.com?subject=%5BXOLOS%5D%20event%3Dgeneral%20puppy%3Dgeneral&body=context_event%3Dgeneral%0Acontext_puppy%3Dgeneral%0Acontext_name%3Dgeneral%0A%0AHello%20Fernando%2C%20I%20have%20a%20general%20question%20about%20Xolos%20Ram%C3%ADrez." class="floating-email-btn" aria-label="Send email to Fernando" title="Contact Fernando">
-        <svg viewBox="0 0 24 24" width="24" height="24" stroke="currentColor" stroke-width="2" fill="none" stroke-linecap="round" stroke-linejoin="round" class="icon-mail" aria-hidden="true" focusable="false">
-            <path d="M4 4h16c1.1 0 2 .9 2 2v12c0 1.1-.9 2-2 2H4c-1.1 0-2-.9-2-2V6c0-1.1.9-2 2-2z"></path>
-            <polyline points="22,6 12,13 2,6"></polyline>
-        </svg>
+    <a href="https://wa.me/message/435RTKGJLTX2J1" target="_blank" rel="noopener noreferrer" class="floating-email-btn" aria-label="Send WhatsApp to Fernando" title="Contact Fernando on WhatsApp">
+        <span aria-hidden="true">💬</span>
     </a>
 </body>
 </html>

--- a/index.html
+++ b/index.html
@@ -437,13 +437,13 @@ NFTs de Linaje Xoloitzcuintle</a></li>
     </script>
     <a
       class="wa-float"
-      href="mailto:fernando@xolosramirez.com?subject=%5BXOLOS%5D%20event%3Dgeneral%20puppy%3Dgeneral&body=context_event%3Dgeneral%0Acontext_puppy%3Dgeneral%0Acontext_name%3Dgeneral%0A%0AHola%20Fernando%2C%20tengo%20una%20consulta%20general%20sobre%20Xolos%20Ram%C3%ADrez."
+      href="https://wa.me/message/435RTKGJLTX2J1"
       target="_blank"
       rel="noopener noreferrer"
-      data-gtm="email-floating"
-      onclick="dataLayer.push({ event: 'click_email', cachorro_slug: 'general', source: 'floating_button' })"
+      data-gtm="whatsapp-floating"
+      onclick="dataLayer.push({ event: 'click_whatsapp', cachorro_slug: 'general', source: 'floating_button' })"
     >
-      <span>📲 Correo directo ✉️</span>
+      <span>📲 WhatsApp directo</span>
     </a>
   </body>
 </html>

--- a/public/xolos-disponibles.html
+++ b/public/xolos-disponibles.html
@@ -281,11 +281,11 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
 
     <a
     class="email-float"
-    href="mailto:fernando@xolosramirez.com?subject=%5BXOLOS%5D%20event%3Dgeneral%20puppy%3Dgeneral&body=context_event%3Dgeneral%0Acontext_puppy%3Dgeneral%0Acontext_name%3Dgeneral%0A%0AHola%20Fernando%2C%20tengo%20una%20consulta%20general%20sobre%20Xolos%20Ram%C3%ADrez."
-    data-gtm="email-floating"
-    onclick="dataLayer.push({ event: 'click_email', cachorro: 'general', cachorro_slug: 'general', source: 'xolos_disponibles_floating' })"
+    href="https://wa.me/message/435RTKGJLTX2J1" target="_blank" rel="noopener noreferrer"
+    data-gtm="whatsapp-floating"
+    onclick="dataLayer.push({ event: 'click_whatsapp', cachorro: 'general', cachorro_slug: 'general', source: 'xolos_disponibles_floating' })"
   >
-    <span>📧 Contactar por Email</span>
+    <span>📲 Contactar por WhatsApp</span>
   </a>
 
   <!-- Script de filtrado -->

--- a/teyolias-guardiania.html
+++ b/teyolias-guardiania.html
@@ -687,20 +687,17 @@
     </script>
 <a
       class="wa-float"
-      href="mailto:fernando@xolosramirez.com?subject=%5BXOLOS%5D%20event%3Dgeneral%20puppy%3Dgeneral&body=context_event%3Dgeneral%0Acontext_puppy%3Dgeneral%0Acontext_name%3Dgeneral%0A%0AHola%20Fernando%2C%20tengo%20una%20consulta%20general%20sobre%20Xolos%20Ram%C3%ADrez."
+      href="https://wa.me/message/435RTKGJLTX2J1"
       target="_blank"
       rel="noopener noreferrer"
-      data-gtm="email-floating"
-      onclick="dataLayer.push({ event: 'click_email', cachorro_slug: 'general', source: 'floating_button' })"
+      data-gtm="whatsapp-floating"
+      onclick="dataLayer.push({ event: 'click_whatsapp', cachorro_slug: 'general', source: 'floating_button' })"
     >
-      <span>📲 Correo directo ✉️</span>
+      <span>📲 WhatsApp directo</span>
     </a>
 
-    <a href="mailto:fernando@xolosramirez.com?subject=%5BXOLOS%5D%20event%3Dgeneral%20puppy%3Dgeneral&body=context_event%3Dgeneral%0Acontext_puppy%3Dgeneral%0Acontext_name%3Dgeneral%0A%0AHola%20Fernando%2C%20tengo%20una%20consulta%20general%20sobre%20Xolos%20Ram%C3%ADrez." class="floating-email-btn" aria-label="Enviar correo a Fernando" title="Contacta a Fernando">
-        <svg viewBox="0 0 24 24" width="24" height="24" stroke="currentColor" stroke-width="2" fill="none" stroke-linecap="round" stroke-linejoin="round" class="icon-mail" aria-hidden="true" focusable="false">
-            <path d="M4 4h16c1.1 0 2 .9 2 2v12c0 1.1-.9 2-2 2H4c-1.1 0-2-.9-2-2V6c0-1.1.9-2 2-2z"></path>
-            <polyline points="22,6 12,13 2,6"></polyline>
-        </svg>
+    <a href="https://wa.me/message/435RTKGJLTX2J1" target="_blank" rel="noopener noreferrer" class="floating-email-btn" aria-label="Enviar WhatsApp a Fernando" title="Contacta a Fernando por WhatsApp">
+        <span aria-hidden="true">💬</span>
     </a>
 </body>
 </html>

--- a/xolo-skin-care/index.html
+++ b/xolo-skin-care/index.html
@@ -1997,15 +1997,15 @@
 
       <a
         class="sticky-buy__action sticky-buy__action--whatsapp"
-        href="mailto:fernando@xolosramirez.com?subject=%5BXOLOS%5D%20event%3Dgeneral%20puppy%3Dgeneral&body=context_event%3Dgeneral%0Acontext_puppy%3Dgeneral%0Acontext_name%3Dgeneral%0A%0AHola%20Fernando%2C%20tengo%20una%20consulta%20general%20sobre%20Xolos%20Ram%C3%ADrez."
+        href="https://wa.me/message/435RTKGJLTX2J1"
         target="_blank"
         rel="noopener noreferrer"
-        data-ga-event="email_lead"
-        data-item="Compra rápida correo"
-        aria-label="Abrir correo para una compra rápida por transferencia"
+        data-ga-event="whatsapp_lead"
+        data-item="Compra rápida WhatsApp"
+        aria-label="Abrir WhatsApp para una compra rápida por transferencia"
       >
-        <i class="fa-brands fa-envelope" aria-hidden="true"></i>
-        Correo
+        <i class="fa-brands fa-whatsapp" aria-hidden="true"></i>
+        WhatsApp
       </a>
     </div>
   </aside>

--- a/xolos-disponibles.html
+++ b/xolos-disponibles.html
@@ -853,23 +853,23 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
     <!--
 <a
     class="email-float"
-    href="mailto:fernando@xolosramirez.com?subject=%5BXOLOS%5D%20event%3Dgeneral%20puppy%3Dgeneral&body=context_event%3Dgeneral%0Acontext_puppy%3Dgeneral%0Acontext_name%3Dgeneral%0A%0AHola%20Fernando%2C%20tengo%20una%20consulta%20general%20sobre%20Xolos%20Ram%C3%ADrez."
-    data-gtm="email-floating-en"
-    onclick="dataLayer.push({ event: 'click_email', cachorro: 'general', cachorro_slug: 'general', source: 'available_xolos_floating_en' })"
+    href="https://wa.me/message/435RTKGJLTX2J1" target="_blank" rel="noopener noreferrer"
+    data-gtm="whatsapp-floating-en"
+    onclick="dataLayer.push({ event: 'click_whatsapp', cachorro: 'general', cachorro_slug: 'general', source: 'available_xolos_floating_en' })"
   >
-    <span>📧 Contact via Email</span>
+    <span>📲 Contact via WhatsApp</span>
   </a>
      -->
 
  <a
       class="wa-float"
-      href="mailto:fernando@xolosramirez.com?subject=%5BXOLOS%5D%20event%3Dgeneral%20puppy%3Dgeneral&body=context_event%3Dgeneral%0Acontext_puppy%3Dgeneral%0Acontext_name%3Dgeneral%0A%0AHola%20Fernando%2C%20tengo%20una%20consulta%20general%20sobre%20Xolos%20Ram%C3%ADrez."
+      href="https://wa.me/message/435RTKGJLTX2J1"
       target="_blank"
       rel="noopener noreferrer"
-      data-gtm="email-floating"
-      onclick="dataLayer.push({ event: 'click_email', cachorro_slug: 'general', source: 'floating_button' })"
+      data-gtm="whatsapp-floating"
+      onclick="dataLayer.push({ event: 'click_whatsapp', cachorro_slug: 'general', source: 'floating_button' })"
     >
-      <span>📲 Correo directo ✉️</span>
+      <span>📲 WhatsApp directo</span>
     </a>
 
     <script src="js/main.js" defer></script>


### PR DESCRIPTION
### Motivation
- Cambiar los botones flotantes que abrían un `mailto:` para que dirijan a un chat de WhatsApp (`https://wa.me/message/435RTKGJLTX2J1`) y unificar el canal de contacto en todo el sitio.

### Description
- Reemplacé todos los enlaces `mailto:` usados por botones flotantes y la acción sticky de compra rápida por `https://wa.me/message/435RTKGJLTX2J1` en las páginas principales y versiones EN/PU, incluyendo `contacto.html`, `index.html`, `xolos-disponibles.html`, `public/xolos-disponibles.html`, `teyolias-guardiania.html`, `en/index.html`, `en/available-xolos.html`, `en/teyolias-guardianship.html` y `xolo-skin-care/index.html`.
- Actualicé texto visible (por ejemplo `Correo directo ✉️` → `WhatsApp directo` / `Contact via WhatsApp`), los iconos (`fa-envelope` → `fa-whatsapp` o emoji `💬` para botones pequeños) y etiquetas accesibles (`aria-label` / `title`) para mencionar WhatsApp.
- Cambié los atributos de tracking y eventos: `data-gtm`/`data-ga-event` y `data-item` de valores relacionados con email a `whatsapp-floating`, `whatsapp-floating-en`, `click_whatsapp`, `whatsapp_lead`, etc., para mantener analítica coherente.

### Testing
- Ejecuté `git diff --check` y no se reportaron warnings; resultado: success. 
- Ejecuté un script de validación en `python3` que busca anclas flotantes y confirmó que ya no contienen `mailto:`, `click_email` ni `email-floating`; resultado: success. 
- Intenté capturar una captura de pantalla con Playwright para validación visual pero `playwright` no está instalado en el entorno; resultado: failed (tooling missing).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a32c858eb58833295ded4044f600e17)