### PR TITLE
Add NFT blockchain section to FCM blog post

### DIFF
--- a/blog/2026-07-02-registro-fcm-xoloitzcuintle-xolos-ramirez.html
+++ b/blog/2026-07-02-registro-fcm-xoloitzcuintle-xolos-ramirez.html
@@ -97,6 +97,34 @@
             border: none;
         }
 
+        /* Estilos para la sección del NFT Conmemorativo */
+        .nft-container {
+            background-color: #f3f4f6;
+            border: 1px solid #e5e7eb;
+            border-left: 4px solid #2c3e50;
+            padding: 20px;
+            border-radius: 0 8px 8px 0;
+            margin: 30px 0;
+        }
+
+        .nft-container h3 {
+            margin-top: 0;
+            color: #2c3e50;
+            font-size: 1.2em;
+        }
+
+        .txid-box {
+            background-color: #111827;
+            color: #10b981; /* Verde tipo terminal/explorer */
+            padding: 12px;
+            border-radius: 6px;
+            font-family: 'Courier New', Courier, monospace;
+            font-size: 0.9em;
+            word-break: break-all;
+            margin-top: 10px;
+            border: 1px solid #374151;
+        }
+
         /* Llamado a la acción (Footer del post) */
         .cta-section {
             margin-top: 40px;
@@ -175,6 +203,21 @@
         <h2>Nuestro Compromiso Continúa</h2>
         <p>Ver a <strong>Chimalma, Mixa, Luna y Teyolia</strong> certificadas nos llena de orgullo. Este proceso de registro ante la FCM es nuestra forma de asegurar a las futuras familias que cada cachorro que nace en Xolos Ramírez cumple con los más altos estándares de crianza responsable.</p>
         <p>Fue una mañana de risas, un poco de caos perruno y mucha satisfacción. Seguiremos trabajando con el mismo amor y dedicación para poner en alto el nombre del perro azteca.</p>
+
+        <h2>Un Hito Digital: Registro Inmortalizado en la Blockchain</h2>
+        <p>En <strong>Xolos Ramírez</strong>, creemos firmemente en conectar nuestras raíces milenarias con las tecnologías del futuro. Por ello, hemos llevado este acontecimiento un paso más allá: el registro oficial de nuestras cachorras ha sido inmortalizado de forma inmutable en la blockchain.</p>
+        
+        <p>A través de la <strong>Tonalli Wallet</strong> y utilizando la red de <strong>eCash (XEC)</strong>, minteamos un NFT conmemorativo que servirá como un registro histórico, transparente y permanente del linaje de Chimalma, Mixa, Luna y Teyolia.</p>
+
+        <div class="nft-container">
+            <h3>Certificado de Minteo Digital</h3>
+            <p style="margin: 5px 0;"><strong>Red:</strong> eCash Network (XEC)</p>
+            <p style="margin: 5px 0;"><strong>Categoría:</strong> Registro de Camada Oficial FCM</p>
+            <p style="margin: 15px 0 5px 0;"><strong>Transaction ID (TXID) / Token ID:</strong></p>
+            <div class="txid-box">
+                e498efa3118069e3a0d0243c98af94b4beb3a0e819dc7690438aad7617d85a06
+            </div>
+        </div>
 
         <div class="cta-section">
             <p><strong>¿Te gustaría conocer más sobre nuestras cachorras o el proceso de crianza?</strong></p>


### PR DESCRIPTION
### Motivation
- Integrar en la crónica un bloque que documente y destaque el minteo del certificado NFT como registro inmutable en la blockchain. 
- Presentar el TXID/token de forma clara y con un estilo visual consistente con el diseño del blog.

### Description
- Se añadieron estilos CSS para el bloque del NFT y la caja del TXID (`.nft-container` y `.txid-box`) dentro de la etiqueta `<style>` del archivo HTML. 
- Se insertó la sección HTML titulada “Un Hito Digital: Registro Inmortalizado en la Blockchain” justo antes del bloque de llamada a la acción (`<div class="cta-section">`).
- El bloque incluye metadatos de minteo (red, categoría) y el `Transaction ID (TXID)` provisto: `e498efa3118069e3a0d0243c98af94b4beb3a0e819dc7690438aad7617d85a06`.

### Testing
- Ejecuté un script de verificación que confirmó la presencia de `.nft-container` en el CSS, del TXID en el HTML y del bloque `<div class="cta-section">`, y la comprobación automatizada pasó correctamente.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a496121cd5083329f9fae14e6659c29)