### PR TITLE
Replace floating email button with WhatsApp floating CTA on available-xolos pages

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -1565,6 +1565,39 @@ form textarea:focus {
   text-decoration: none;
 }
 
+.wa-float__icon {
+  line-height: 1;
+}
+
+.wa-float__text {
+  white-space: nowrap;
+}
+
+@media (max-width: 640px) {
+  .wa-float {
+    right: 1rem;
+    bottom: 1rem;
+    width: 3.5rem;
+    height: 3.5rem;
+    justify-content: center;
+    padding: 0;
+    border-radius: 50%;
+    font-size: 1.35rem;
+  }
+
+  .wa-float__text {
+    position: absolute;
+    width: 1px;
+    height: 1px;
+    padding: 0;
+    margin: -1px;
+    overflow: hidden;
+    clip: rect(0, 0, 0, 0);
+    white-space: nowrap;
+    border: 0;
+  }
+}
+
 /* Corrección de contraste para tarjetas destacadas */
 .featured-card-fix {
   background-color: #1a1a1a !important; /* Fondo oscuro sólido */

--- a/en/available-xolos.html
+++ b/en/available-xolos.html
@@ -708,12 +708,15 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
   </footer>
 
   <a
-    class="email-float"
-    href="mailto:fernando@xolosramirez.com?subject=%5BXOLOS%5D%20event%3Dgeneral%20puppy%3Dgeneral&body=context_event%3Dgeneral%0Acontext_puppy%3Dgeneral%0Acontext_name%3Dgeneral%0A%0AHello%20Fernando%2C%20I%20have%20a%20general%20question%20about%20Xolos%20Ramirez."
-    data-gtm="email-floating-en"
-    onclick="dataLayer.push({ event: 'click_email', cachorro: 'general', cachorro_slug: 'general', source: 'available_xolos_floating_en' })"
-   data-cta="email" data-lead-type="generate_lead" data-profile="general" data-page-type="available-xolos" data-lang="en" aria-label="Contact Xolos Ramírez by email">
-    <span>📧 Contact via Email</span>
+    class="wa-float cta-lead cta-whatsapp"
+    href="https://wa.me/message/435RTKGJLTX2J1"
+    target="_blank"
+    rel="noopener noreferrer"
+    data-gtm="whatsapp-floating-en"
+    onclick="dataLayer.push({ event: 'click_whatsapp', source: 'floating_button_en' })"
+    data-cta="whatsapp" data-lead-type="generate_lead" data-profile="general" data-page-type="available-xolos" data-lang="en" aria-label="Talk to Xolos Ramírez on WhatsApp">
+    <span class="wa-float__icon" aria-hidden="true">💬</span>
+    <span class="wa-float__text">Talk to us</span>
   </a>
 
   <script src="https://unpkg.com/aos@2.3.1/dist/aos.js"></script>

--- a/xolos-disponibles.html
+++ b/xolos-disponibles.html
@@ -831,26 +831,16 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
       <p class="copyright">© 2025 Xolos Ramírez. Todos los derechos reservados.</p>
     </footer>
 
-    <!--
-<a
-    class="email-float"
-    href="mailto:fernando@xolosramirez.com?subject=%5BXOLOS%5D%20event%3Dgeneral%20puppy%3Dgeneral&body=context_event%3Dgeneral%0Acontext_puppy%3Dgeneral%0Acontext_name%3Dgeneral%0A%0AHola%20Fernando%2C%20tengo%20una%20consulta%20general%20sobre%20Xolos%20Ram%C3%ADrez."
-    data-gtm="email-floating-en"
-    onclick="dataLayer.push({ event: 'click_email', cachorro: 'general', cachorro_slug: 'general', source: 'available_xolos_floating_en' })"
-   data-cta="email" data-lead-type="generate_lead" data-profile="general" data-page-type="available-xolos" data-lang="es" aria-label="Escribir por correo a Xolos Ramírez">
-    <span>📧 Contact via Email</span>
-  </a>
-     -->
-
- <a
-      class="wa-float"
-      href="mailto:fernando@xolosramirez.com?subject=Informes%20sobre%20xoloitzcuintle&body=Hola%20Fernando%2C%20estoy%20interesado%20en%20un%20xoloitzcuintle%2C%20quiero%20m%C3%A1s%20informes."
+    <a
+      class="wa-float cta-lead cta-whatsapp"
+      href="https://wa.me/message/435RTKGJLTX2J1"
       target="_blank"
       rel="noopener noreferrer"
-      data-gtm="email-floating"
-      onclick="dataLayer.push({ event: 'click_email', source: 'floating_button' })"
-     data-cta="email" data-lead-type="generate_lead" data-profile="general" data-page-type="available-xolos" data-lang="es" aria-label="Escribir por correo a Xolos Ramírez">
-      <span>✉️ Escríbenos por correo</span>
+      data-gtm="whatsapp-floating"
+      onclick="dataLayer.push({ event: 'click_whatsapp', source: 'floating_button' })"
+      data-cta="whatsapp" data-lead-type="generate_lead" data-profile="general" data-page-type="available-xolos" data-lang="es" aria-label="Hablar con Xolos Ramírez por WhatsApp">
+      <span class="wa-float__icon" aria-hidden="true">💬</span>
+      <span class="wa-float__text">Hablar con nosotros</span>
     </a>
 
     <script src="js/main.js" defer></script>


### PR DESCRIPTION
### Motivation
- Replace the existing floating email/contact button on the Spanish and English available-xolos pages with a dedicated WhatsApp CTA per the design brief. 
- Ensure analytics/tracking attributes remain present and that the CTA behaves responsively (text on desktop, icon-only on mobile).

### Description
- Replaced the floating email anchor in `xolos-disponibles.html` with a WhatsApp anchor pointing to `https://wa.me/message/435RTKGJLTX2J1` and added `class="wa-float cta-lead cta-whatsapp"`, `data-cta="whatsapp"`, `data-lead-type="generate_lead"`, `data-gtm="whatsapp-floating"`, and an `onclick` that pushes a `click_whatsapp` event to `dataLayer` and Spanish desktop text `Hablar con nosotros`.
- Replaced the floating email anchor in `en/available-xolos.html` with the same WhatsApp anchor (English copy `Talk to us`) and corresponding `data-gtm="whatsapp-floating-en"` and `onclick` for English tracking.
- Added CSS in `css/styles.css` for `.wa-float__icon` and `.wa-float__text` plus an `@media (max-width: 640px)` rule that makes the floating button a circular icon-only button on mobile while keeping text visible on desktop.

### Testing
- Ran a Python assertion script verifying both pages include `href="https://wa.me/message/435RTKGJLTX2J1"`, `data-cta="whatsapp"`, `data-lead-type="generate_lead"`, and `class="wa-float cta-lead cta-whatsapp"`, and the script passed successfully.
- Verified the modified files appear with the new HTML and CSS changes via a local diff inspection, and the content checks passed.
- Attempted headless browser capture but no browser/Playwright binary is available in the environment, so no visual screenshot was produced.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4bc52c95808332975e9b5efcf9b8a4)