### PR TITLE
Fix home floating email button

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -1598,6 +1598,68 @@ form textarea:focus {
   }
 }
 
+/* Correo flotante exclusivo de las páginas principales */
+.home-email-float {
+  position: fixed;
+  right: 1.5rem;
+  bottom: 1.5rem;
+  display: inline-flex;
+  align-items: center;
+  gap: 0.75rem;
+  padding: 0.85rem 1.5rem;
+  border: 1px solid #25d366;
+  border-radius: 999px;
+  background-color: #2c2c2c;
+  color: #25d366;
+  font-weight: 700;
+  text-decoration: none;
+  box-shadow: 0 8px 25px rgba(0, 0, 0, 0.5);
+  transition: all 0.3s ease;
+  z-index: 9999;
+}
+
+.home-email-float:hover,
+.home-email-float:focus-visible {
+  background-color: #25d366;
+  color: #111;
+  transform: translateY(-3px);
+  box-shadow: 0 12px 30px rgba(37, 211, 102, 0.3);
+  text-decoration: none;
+}
+
+.home-email-float__icon {
+  line-height: 1;
+}
+
+.home-email-float__text {
+  white-space: nowrap;
+}
+
+@media (max-width: 640px) {
+  .home-email-float {
+    right: 1rem;
+    bottom: 1rem;
+    width: 3.5rem;
+    height: 3.5rem;
+    padding: 0;
+    justify-content: center;
+    border-radius: 50%;
+    font-size: 1.35rem;
+  }
+
+  .home-email-float__text {
+    position: absolute;
+    width: 1px;
+    height: 1px;
+    padding: 0;
+    margin: -1px;
+    overflow: hidden;
+    clip-path: inset(50%);
+    white-space: nowrap;
+    border: 0;
+  }
+}
+
 /* Corrección de contraste para tarjetas destacadas */
 .featured-card-fix {
   background-color: #1a1a1a !important; /* Fondo oscuro sólido */

--- a/en/index.html
+++ b/en/index.html
@@ -438,14 +438,19 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
       AOS.init({ once: true, duration: 700, offset: 60, easing: 'ease-out' });
     </script>
     <a
-      class="wa-float"
-      href="mailto:fernando@xolosramirez.com?subject=Informes%20sobre%20xoloitzcuintle&body=Hola%20Fernando%2C%20estoy%20interesado%20en%20un%20xoloitzcuintle%2C%20quiero%20m%C3%A1s%20informes."
+      class="home-email-float cta-lead cta-email"
+      href="mailto:fernando@xolosramirez.com?subject=Information%20about%20Xoloitzcuintles&body=Hello%2C%20I%20am%20interested%20in%20learning%20more%20about%20your%20Xoloitzcuintles%20and%20your%20family%20matching%20process."
       target="_blank"
       rel="noopener noreferrer"
       data-gtm="email-floating"
-      onclick="dataLayer.push({ event: 'click_email', source: 'floating_button' })"
-     data-cta="email" data-lead-type="generate_lead" data-profile="general" data-page-type="home" data-lang="en" aria-label="Contact Xolos Ramírez by email">
-      <span>✉️ Email us</span>
+      data-cta="email"
+      data-lead-type="generate_lead"
+      data-profile="general"
+      data-page-type="home"
+      data-lang="en"
+      aria-label="Contact Xolos Ramírez by email">
+      <span class="home-email-float__icon" aria-hidden="true">✉️</span>
+      <span class="home-email-float__text">Email us</span>
     </a>
   </body>
 </html>

--- a/index.html
+++ b/index.html
@@ -461,14 +461,19 @@ NFTs de Linaje Xoloitzcuintle</a></li>
       AOS.init({ once: true, duration: 700, offset: 60, easing: 'ease-out' });
     </script>
     <a
-      class="wa-float"
-      href="mailto:fernando@xolosramirez.com?subject=Informes%20sobre%20xoloitzcuintle&body=Hola%20Fernando%2C%20estoy%20interesado%20en%20un%20xoloitzcuintle%2C%20quiero%20m%C3%A1s%20informes."
+      class="home-email-float cta-lead cta-email"
+      href="mailto:fernando@xolosramirez.com?subject=Informes%20sobre%20xoloitzcuintle&body=Hola%2C%20me%20interesa%20conocer%20m%C3%A1s%20sobre%20sus%20xoloitzcuintles%20y%20el%20proceso%20de%20acompa%C3%B1amiento%20para%20las%20familias."
       target="_blank"
       rel="noopener noreferrer"
       data-gtm="email-floating"
-      onclick="dataLayer.push({ event: 'click_email', source: 'floating_button' })"
-     data-cta="email" data-lead-type="generate_lead" data-profile="general" data-page-type="home" data-lang="es" aria-label="Escribir por correo a Xolos Ramírez">
-      <span>✉️ Escríbenos por correo</span>
+      data-cta="email"
+      data-lead-type="generate_lead"
+      data-profile="general"
+      data-page-type="home"
+      data-lang="es"
+      aria-label="Escribir por correo a Xolos Ramírez">
+      <span class="home-email-float__icon" aria-hidden="true">✉️</span>
+      <span class="home-email-float__text">Escríbenos por correo</span>
     </a>
   </body>
 </html>


### PR DESCRIPTION
### Motivation
- The global `.wa-float` responsive rule intended for WhatsApp buttons caused the home-page email float text to overflow and display poorly on mobile, so the home email needs an isolated style and markup. 

### Description
- Replace the home-page floating anchor in `index.html` and `en/index.html` to use `home-email-float cta-lead cta-email` and split the visible content into `home-email-float__icon` and `home-email-float__text` while keeping declarative tracking attributes and the `mailto:` recipient. 
- Update the English home `mailto:` subject/body to English and make the Spanish body neutral as requested. 
- Add dedicated CSS in `css/styles.css` for `.home-email-float`, `.home-email-float__icon` and `.home-email-float__text` including a mobile rule that renders a 3.5rem circular icon-only button while preserving accessible text.

### Testing
- A Python static markup check validated the presence of the new `home-email-float` classes, the updated `mailto:` contents, and the absence of the legacy `onclick`/`wa-float` markup on the home pages (passed). 
- A fast text search confirmed the WhatsApp pages (`xolos-disponibles.html`, `en/available-xolos.html`) still use `.wa-float` and were not modified (passed). 
- Playwright/browser screenshot could not be run because no browser/Playwright is installed in the environment (skipped).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4bce7bd0448332ad9bde2bb1f2376f)