### PR TITLE
Add HOME link to Xoloitzcuintli facts nav

### DIFF
--- a/blog/ten-fascinating-facts-about-the-xoloitzcuintli-dog.html
+++ b/blog/ten-fascinating-facts-about-the-xoloitzcuintli-dog.html
@@ -114,11 +114,35 @@
 <nav class="sticky top-0 z-50 glass-panel py-4 px-6 border-b border-stone-200">
     <div class="max-w-7xl mx-auto flex justify-between items-center">
         <div class="text-2xl font-bold tracking-widest uppercase text-clay" style="color: #b05b3b;">XOLOS RAMIREZ</div>
-        <div class="hidden md:flex space-x-8 text-sm font-semibold">
-            <button onclick="scrollToSection('hero')" class="nav-link">ORIGIN</button>
-            <button onclick="scrollToSection('facts')" class="nav-link">10 FACTS</button>
-            <button onclick="scrollToSection('sizes')" class="nav-link">SIZES</button>
-            <button onclick="scrollToSection('myth')" class="nav-link">MYTHOLOGY</button>
+        <div class="flex items-center gap-4 md:gap-8">
+
+            <div class="hidden md:flex space-x-8 text-sm font-semibold">
+                <button onclick="scrollToSection('hero')" class="nav-link">
+                    ORIGIN
+                </button>
+
+                <button onclick="scrollToSection('facts')" class="nav-link">
+                    10 FACTS
+                </button>
+
+                <button onclick="scrollToSection('sizes')" class="nav-link">
+                    SIZES
+                </button>
+
+                <button onclick="scrollToSection('myth')" class="nav-link">
+                    MYTHOLOGY
+                </button>
+            </div>
+
+            <a
+                href="https://xolosramirez.com/en/index.html"
+                class="inline-flex items-center gap-2 rounded-full bg-stone-800 px-4 py-2 text-xs md:text-sm font-semibold text-white transition hover:bg-stone-700 focus:outline-none focus:ring-2 focus:ring-[#b05b3b] focus:ring-offset-2"
+                aria-label="Return to the Xolos Ramirez home page"
+            >
+                <span aria-hidden="true">←</span>
+                <span>HOME</span>
+            </a>
+
         </div>
     </div>
 </nav>


### PR DESCRIPTION
### Motivation
- Añadir un botón "HOME" que enlace a la página principal en inglés y permitir su colocación junto a la navegación de secciones sin romper el diseño responsive.
- Insertar el nuevo bloque inmediatamente después del logotipo `XOLOS RAMIREZ` dentro del `<nav>` para mantener la jerarquía visual.

### Description
- Modifiqué `blog/ten-fascinating-facts-about-the-xoloitzcuintli-dog.html` reemplazando el bloque de navegación de escritorio por un contenedor `div` con `flex items-center gap-4 md:gap-8`.
- Conservé los botones existentes `ORIGIN`, `10 FACTS`, `SIZES`, `MYTHOLOGY` y los reformaté a multilínea según lo solicitado.
- Añadí un enlace `a` estilizado con clases de Tailwind que apunta a `https://xolosramirez.com/en/index.html` y utiliza `aria-label="Return to the Xolos Ramirez home page"`.
- No se agregaron hojas de estilo nuevas; el botón reutiliza las clases de Tailwind ya presentes en la página.

### Testing
- Ejecuté `git diff --check` y no se reportaron errores (éxito).
- Ejecuté `git status --short` para verificar el archivo modificado y la salida fue la esperada (éxito).
- Ejecuté `git log -1 --oneline` para inspeccionar el último cambio registrado y confirmó la actualización (éxito).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4d11d6894883328cd784926edd4926)