### PR TITLE
Add RETURN TO HOME button to top navigation

### DIFF
--- a/blog/is-a-xoloitzcuintli-dog-right-for-you.html
+++ b/blog/is-a-xoloitzcuintli-dog-right-for-you.html
@@ -93,12 +93,21 @@
                 <div class="flex items-center space-x-2">
                     <span class="cinzel text-xl font-bold tracking-widest text-bronze">XOLOS RAMIREZ</span>
                 </div>
-                <div class="hidden md:flex space-x-8 text-sm font-semibold tracking-wider">
-                    <a href="#history" class="nav-link">HISTORY</a>
-                    <a href="#biology" class="nav-link">BIOLOGY</a>
-                    <a href="#quiz" class="nav-link">EVALUATION</a>
-                    <a href="#care" class="nav-link">CARE</a>
-                    <a href="#web3" class="nav-link">BLOCKCHAIN</a>
+                <div class="flex items-center gap-4">
+                    <div class="hidden md:flex space-x-8 text-sm font-semibold tracking-wider">
+                        <a href="#history" class="nav-link">HISTORY</a>
+                        <a href="#biology" class="nav-link">BIOLOGY</a>
+                        <a href="#quiz" class="nav-link">EVALUATION</a>
+                        <a href="#care" class="nav-link">CARE</a>
+                        <a href="#web3" class="nav-link">BLOCKCHAIN</a>
+                    </div>
+                    <a
+                        href="https://xolosramirez.com/en/index.html"
+                        aria-label="Return to the Xolos Ramirez homepage"
+                        class="inline-flex items-center justify-center bg-obsidian text-white px-5 py-2 rounded-full text-xs font-bold tracking-wider hover:bg-bronze transition-all duration-300 whitespace-nowrap"
+                    >
+                        RETURN TO HOME
+                    </a>
                 </div>
             </div>
         </div>


### PR DESCRIPTION
### Motivation
- Add a clearly visible, accessible navigation button that redirects users to the English Xolos Ramirez homepage from the fixed top navigation bar so visitors can return to the main site quickly.

### Description
- Inserted an anchor in `blog/is-a-xoloitzcuintli-dog-right-for-you.html` inside the `<!-- Navigation -->` fixed `<nav>` (immediately after the existing section links) using the exact `href="https://xolosramirez.com/en/index.html"` and `aria-label="Return to the Xolos Ramirez homepage"`, and styled it with the requested Tailwind classes `inline-flex items-center justify-center bg-obsidian text-white px-5 py-2 rounded-full text-xs font-bold tracking-wider hover:bg-bronze transition-all duration-300 whitespace-nowrap` so it matches the visual identity and remains visible on mobile.

### Testing
- Ran an automated Python presence check to verify the required `href`, `aria-label`, button text, and class snippet are present, and executed `git diff --check`; both checks passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4e72ddd6c083328e407f120d3ec3cc)