### PR TITLE
Capture “precio xoloitzcuintle” intent in Available Xolos and fix home email float

### DIFF
--- a/en/available-xolos.html
+++ b/en/available-xolos.html
@@ -84,10 +84,10 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
     </section>
 
     <section class="container card" aria-labelledby="commercial-info-en" data-aos="fade-up" style="margin-top: 2rem; margin-bottom: 2rem; border-left: 4px solid #d4af37;">
-      <h2 id="commercial-info-en">Pricing, reservation, and what is included</h2>
+      <h2 id="commercial-info-en">Xoloitzcuintle price guidance and support</h2>
       <ul>
-        <li>Reference price depends on each puppy and size.</li>
-        <li>Reservation through an initial deposit.</li>
+        <li>Personal guidance based on each puppy, size, and family compatibility.</li>
+        <li>Current availability confirmed directly by our team.</li>
         <li>Includes health record, microchip, follow-up, and guidance.</li>
         <li>Delivery available in Mexico City, Mexico, and abroad.</li>
       </ul>
@@ -138,9 +138,9 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
         </article>
         <article class="card trust-card">
           <span class="trust-icon" aria-hidden="true">🔒💳</span>
-          <h4>Secure Payment</h4>
+          <h4>Clear, personalized guidance</h4>
           <p>
-            We accept bank transfers, cash, and international digital payment options. We provide clarity and professional guidance so your process is secure and reliable.
+            We explain the specific conditions personally after confirming availability, family compatibility, and location, with professional guidance from beginning to end.
           </p>
         </article>
         <article class="card trust-card">
@@ -265,7 +265,7 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
     </div>
 
     <div class="puppy-card__actions">
-      <a href="mailto:fernando@xolosramirez.com?subject=%5BXOLOS%5D%20event%3Dinfo%20puppy%3Dyaretzi&body=context_event%3Dinfo%0Acontext_puppy%3Dyaretzi%0Acontext_name%3DYaretzi%20Ramirez%0A%0AHello%20Fernando%2C%20I%20would%20like%20to%20receive%20information%20about%20Yaretzi%20Ramirez." class="btn-small btn-primary-small cta-lead cta-email" onclick="dataLayer.push({ event: 'click_email', cachorro: 'Yaretzi Ramirez', cachorro_slug: 'yaretzi', source: 'available_xolos_contact_en' })" data-cta="email" data-lead-type="generate_lead" data-profile="yaretzi" data-page-type="available-xolos" data-lang="en" aria-label="Contact by email about Yaretzi">Contact via Email</a>
+      <a href="mailto:fernando@xolosramirez.com?subject=%5BXOLOS%5D%20event%3Dprofile_inquiry%20puppy%3Dyaretzi&body=context_event%3Dprofile_inquiry%0Acontext_puppy%3Dyaretzi%0Acontext_name%3DYaretzi%20Ramirez%0Acontext_status%3Davailable%0Acontext_lang%3Den%0A%0AHello%2C%0A%0AI%20saw%20Yaretzi%20Ramirez%27s%20profile%20on%20the%20Xolos%20Ram%C3%ADrez%20website%20and%20I%20am%20interested%20in%20learning%20more.%0A%0AI%20would%20like%20to%20know%20whether%20this%20Xoloitzcuintle%20could%20be%20a%20good%20fit%20for%20our%20family%20and%20receive%20information%20about%3A%0A%0A-%20personality%20and%20temperament%3B%0A-%20current%20availability%3B%0A-%20documentation%20and%20care%3B%0A-%20price%20and%20process%20conditions%3B%0A-%20delivery%20options%20for%20our%20location.%0A%0ACity%20or%20country%3A%0AType%20of%20home%3A%0APrevious%20experience%20with%20dogs%3A%0AContact%20number%3A%0A%0AThank%20you." class="btn-small btn-primary-small cta-lead cta-email" data-cta="email" data-lead-type="generate_lead" data-profile="yaretzi" data-page-type="available-xolos" data-lang="en" aria-label="Contact by email about Yaretzi" data-status="available">Contact via Email</a>
     </div>
   </div>
 </article>
@@ -324,7 +324,7 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
   </div>
             
   <div class="puppy-card__actions">
-              <a <a href="mailto:fernando@xolosramirez.com?subject=%5BXOLOS%5D%20event%3Dinfo%20puppy%3Dxochitl&body=context_event%3Dinfo%0Acontext_puppy%3Dxochitl%0Acontext_name%3DXochitl%20Ramirez%0A%0AHello%20Fernando%2C%20I%20would%20like%20to%20receive%20information%20about%20Xochitl%20Ramirez." class="btn-small btn-primary-small cta-lead cta-email" onclick="dataLayer.push({ event: 'click_email', cachorro: 'Xochitl Ramirez', cachorro_slug: 'xochitl', source: 'available_xolos_contact_en' })" data-cta="email" data-lead-type="generate_lead" data-profile="xochitl" data-page-type="available-xolos" data-lang="en" aria-label="Contact by email about Xochitl">Contact via Email</a>
+              <a href="mailto:fernando@xolosramirez.com?subject=%5BXOLOS%5D%20event%3Dsimilar_xolos%20puppy%3Dxochitl&body=context_event%3Dsimilar_xolos%0Acontext_puppy%3Dxochitl%0Acontext_name%3DXochitl%20Ramirez%0Acontext_status%3Dreserved%0Acontext_lang%3Den%0A%0AHello%2C%0A%0AI%20saw%20Xochitl%20Ramirez%27s%20profile%20and%20understand%20this%20Xoloitzcuintle%20is%20currently%20reserved.%0A%0AI%20am%20interested%20in%20future%20litters%20or%20a%20Xoloitzcuintle%20with%20similar%20characteristics.%0A%0AI%20would%20like%20to%20receive%20information%20about%3A%0A%0A-%20future%20puppies%20or%20litters%3B%0A-%20size%2C%20sex%2C%20and%20temperament%3B%0A-%20documentation%20and%20care%3B%0A-%20price%20and%20process%20conditions%3B%0A-%20delivery%20options%20for%20our%20location.%0A%0ACity%20or%20country%3A%0ACharacteristics%20we%20are%20looking%20for%3A%0APrevious%20experience%3A%0AContact%20number%3A%0A%0AThank%20you." class="btn-small btn-primary-small cta-lead cta-email" data-cta="email" data-lead-type="generate_lead" data-profile="xochitl" data-page-type="available-xolos" data-lang="en" aria-label="Contact by email about Xochitl" data-status="reserved">Contact via Email</a>
             </div>
           </div>
         </article>
@@ -385,7 +385,7 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
   </div>
             
   <div class="puppy-card__actions">
-              <a <a href="mailto:fernando@xolosramirez.com?subject=%5BXOLOS%5D%20event%3Dinfo%20puppy%3Dyohualli&body=context_event%3Dinfo%0Acontext_puppy%3Dyohualli%0Acontext_name%3DYohualli%20Ramirez%0A%0AHello%20Fernando%2C%20I%20would%20like%20to%20receive%20information%20about%20Yohualli%20Ramirez." class="btn-small btn-primary-small cta-lead cta-email" onclick="dataLayer.push({ event: 'click_email', cachorro: 'Yohualli Ramirez', cachorro_slug: 'yohualli', source: 'available_xolos_contact_en' })" data-cta="email" data-lead-type="generate_lead" data-profile="yohualli" data-page-type="available-xolos" data-lang="en" aria-label="Contact by email about Yohualli">Contact via Email</a>
+              <a href="mailto:fernando@xolosramirez.com?subject=%5BXOLOS%5D%20event%3Dprofile_inquiry%20puppy%3Dyohualli&body=context_event%3Dprofile_inquiry%0Acontext_puppy%3Dyohualli%0Acontext_name%3DYohualli%20Ramirez%0Acontext_status%3Davailable%0Acontext_lang%3Den%0A%0AHello%2C%0A%0AI%20saw%20Yohualli%20Ramirez%27s%20profile%20on%20the%20Xolos%20Ram%C3%ADrez%20website%20and%20I%20am%20interested%20in%20learning%20more.%0A%0AI%20would%20like%20to%20know%20whether%20this%20Xoloitzcuintle%20could%20be%20a%20good%20fit%20for%20our%20family%20and%20receive%20information%20about%3A%0A%0A-%20personality%20and%20temperament%3B%0A-%20current%20availability%3B%0A-%20documentation%20and%20care%3B%0A-%20price%20and%20process%20conditions%3B%0A-%20delivery%20options%20for%20our%20location.%0A%0ACity%20or%20country%3A%0AType%20of%20home%3A%0APrevious%20experience%20with%20dogs%3A%0AContact%20number%3A%0A%0AThank%20you." class="btn-small btn-primary-small cta-lead cta-email" data-cta="email" data-lead-type="generate_lead" data-profile="yohualli" data-page-type="available-xolos" data-lang="en" aria-label="Contact by email about Yohualli" data-status="available">Contact via Email</a>
             </div>
           </div>
         </article>
@@ -440,7 +440,7 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
     <iframe width="100%" height="100%" src="https://www.youtube.com/embed/tL_jiakmL1o" title="Ozomatli Ramirez" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen loading="lazy"></iframe>
   </div>
   <div class="puppy-card__actions">
-              <a href="mailto:fernando@xolosramirez.com?subject=%5BXOLOS%5D%20event%3Dinfo%20puppy%3Dozomatli&body=context_event%3Dinfo%0Acontext_puppy%3Dozomatli%0Acontext_name%3DOzomatli%20Ramirez%0A%0AHello%20Fernando%2C%20I%20would%20like%20to%20receive%20information%20about%20Ozomatli%20Ramirez." class="btn-small btn-primary-small cta-lead cta-email" onclick="dataLayer.push({ event: 'click_email', cachorro: 'Ozomatli Ramirez', cachorro_slug: 'ozomatli', source: 'available_xolos_contact_en' })" data-cta="email" data-lead-type="generate_lead" data-profile="ozomatli" data-page-type="available-xolos" data-lang="en" aria-label="Contact by email about Ozomatli">Contact via Email</a>
+              <a href="mailto:fernando@xolosramirez.com?subject=%5BXOLOS%5D%20event%3Dprofile_inquiry%20puppy%3Dozomatli&body=context_event%3Dprofile_inquiry%0Acontext_puppy%3Dozomatli%0Acontext_name%3DOzomatli%20Ramirez%0Acontext_status%3Davailable%0Acontext_lang%3Den%0A%0AHello%2C%0A%0AI%20saw%20Ozomatli%20Ramirez%27s%20profile%20on%20the%20Xolos%20Ram%C3%ADrez%20website%20and%20I%20am%20interested%20in%20learning%20more.%0A%0AI%20would%20like%20to%20know%20whether%20this%20Xoloitzcuintle%20could%20be%20a%20good%20fit%20for%20our%20family%20and%20receive%20information%20about%3A%0A%0A-%20personality%20and%20temperament%3B%0A-%20current%20availability%3B%0A-%20documentation%20and%20care%3B%0A-%20price%20and%20process%20conditions%3B%0A-%20delivery%20options%20for%20our%20location.%0A%0ACity%20or%20country%3A%0AType%20of%20home%3A%0APrevious%20experience%20with%20dogs%3A%0AContact%20number%3A%0A%0AThank%20you." class="btn-small btn-primary-small cta-lead cta-email" data-cta="email" data-lead-type="generate_lead" data-profile="ozomatli" data-page-type="available-xolos" data-lang="en" aria-label="Contact by email about Ozomatli" data-status="available">Contact via Email</a>
             </div>
           </div>
         </article>
@@ -487,7 +487,7 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
     <iframe width="100%" height="100%" src="https://www.youtube.com/embed/7SpwHbPB_7Y" title="Nox Ramirez" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen loading="lazy"></iframe>
   </div>
   <div class="puppy-card__actions">
-              <a href="mailto:fernando@xolosramirez.com?subject=%5BXOLOS%5D%20event%3Dinfo%20puppy%3Dnox&body=context_event%3Dinfo%0Acontext_puppy%3Dnox%0Acontext_name%3DNox%20Ramirez%0A%0AHello%20Fernando%2C%20I%20would%20like%20to%20receive%20information%20about%20Nox%20Ramirez." class="btn-small btn-primary-small cta-lead cta-email" onclick="dataLayer.push({ event: 'click_email', cachorro: 'Nox Ramirez', cachorro_slug: 'nox', source: 'available_xolos_contact_en' })" data-cta="email" data-lead-type="generate_lead" data-profile="nox" data-page-type="available-xolos" data-lang="en" aria-label="Contact by email about Nox">Contact via Email</a>
+              <a href="mailto:fernando@xolosramirez.com?subject=%5BXOLOS%5D%20event%3Dsimilar_xolos%20puppy%3Dnox&body=context_event%3Dsimilar_xolos%0Acontext_puppy%3Dnox%0Acontext_name%3DNox%20Ramirez%0Acontext_status%3Dreserved%0Acontext_lang%3Den%0A%0AHello%2C%0A%0AI%20saw%20Nox%20Ramirez%27s%20profile%20and%20understand%20this%20Xoloitzcuintle%20is%20currently%20reserved.%0A%0AI%20am%20interested%20in%20future%20litters%20or%20a%20Xoloitzcuintle%20with%20similar%20characteristics.%0A%0AI%20would%20like%20to%20receive%20information%20about%3A%0A%0A-%20future%20puppies%20or%20litters%3B%0A-%20size%2C%20sex%2C%20and%20temperament%3B%0A-%20documentation%20and%20care%3B%0A-%20price%20and%20process%20conditions%3B%0A-%20delivery%20options%20for%20our%20location.%0A%0ACity%20or%20country%3A%0ACharacteristics%20we%20are%20looking%20for%3A%0APrevious%20experience%3A%0AContact%20number%3A%0A%0AThank%20you." class="btn-small btn-primary-small cta-lead cta-email" data-cta="email" data-lead-type="generate_lead" data-profile="nox" data-page-type="available-xolos" data-lang="en" aria-label="Contact by email about Nox" data-status="reserved">Contact via Email</a>
             </div>
           </div>
         </article>
@@ -548,7 +548,7 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
     <iframe width="100%" height="100%" src="https://www.youtube.com/embed/MbhjQ1sJcG4" title="Teyolia Ramirez" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen loading="lazy"></iframe>
   </div>
   <div class="puppy-card__actions">
-              <a href="mailto:fernando@xolosramirez.com?subject=%5BXOLOS%5D%20event%3Dreserve%20puppy%3Dteyolia&body=context_event%3Dreserve%0Acontext_puppy%3Dteyolia%0Acontext_name%3DTeyolia%20Ramirez%0A%0AHello%20Fernando%2C%20I%20am%20interested%20in%20reserving%20Teyolia%20Ramirez." class="btn-small btn-primary-small cta-lead cta-email" onclick="dataLayer.push({ event: 'click_email', cachorro: 'Teyolia Ramirez', cachorro_slug: 'teyolia', source: 'available_xolos_contact_en' })" data-cta="email" data-lead-type="generate_lead" data-profile="teyolia" data-page-type="available-xolos" data-lang="en" aria-label="Contact by email about Teyolia">Contact via Email</a>
+              <a href="mailto:fernando@xolosramirez.com?subject=%5BXOLOS%5D%20event%3Dsimilar_xolos%20puppy%3Dteyolia&body=context_event%3Dsimilar_xolos%0Acontext_puppy%3Dteyolia%0Acontext_name%3DTeyolia%20Ramirez%0Acontext_status%3Dreserved%0Acontext_lang%3Den%0A%0AHello%2C%0A%0AI%20saw%20Teyolia%20Ramirez%27s%20profile%20and%20understand%20this%20Xoloitzcuintle%20is%20currently%20reserved.%0A%0AI%20am%20interested%20in%20future%20litters%20or%20a%20Xoloitzcuintle%20with%20similar%20characteristics.%0A%0AI%20would%20like%20to%20receive%20information%20about%3A%0A%0A-%20future%20puppies%20or%20litters%3B%0A-%20size%2C%20sex%2C%20and%20temperament%3B%0A-%20documentation%20and%20care%3B%0A-%20price%20and%20process%20conditions%3B%0A-%20delivery%20options%20for%20our%20location.%0A%0ACity%20or%20country%3A%0ACharacteristics%20we%20are%20looking%20for%3A%0APrevious%20experience%3A%0AContact%20number%3A%0A%0AThank%20you." class="btn-small btn-primary-small cta-lead cta-email" data-cta="email" data-lead-type="generate_lead" data-profile="teyolia" data-page-type="available-xolos" data-lang="en" aria-label="Contact by email about Teyolia" data-status="reserved">Contact via Email</a>
             </div>
           </div>
         </article>
@@ -604,7 +604,7 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
     <iframe width="100%" height="100%" src="https://www.youtube.com/embed/KU7aR7z9G-0" title="Onix Ramirez" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen loading="lazy"></iframe>
   </div>
   <div class="puppy-card__actions">
-      <a href="mailto:fernando@xolosramirez.com?subject=%5BXOLOS%5D%20event%3Dinfo%20puppy%3Donix&body=context_event%3Dinfo%0Acontext_puppy%3Donix%0Acontext_name%3D%C3%93nix%20Ramirez%0A%0AHello%20Fernando%2C%20I%20would%20like%20to%20receive%20information%20about%20%C3%93nix%20Ramirez." class="btn-small btn-primary-small cta-lead cta-email" onclick="dataLayer.push({ event: 'click_email', cachorro: 'Ónix Ramirez', cachorro_slug: 'onix', source: 'xolos_disponibles_contactar' })" data-cta="email" data-lead-type="generate_lead" data-profile="onix" data-page-type="available-xolos" data-lang="en" aria-label="Contact by email about Onix">Contact by Email</a>
+      <a href="mailto:fernando@xolosramirez.com?subject=%5BXOLOS%5D%20event%3Dsimilar_xolos%20puppy%3Donix&body=context_event%3Dsimilar_xolos%0Acontext_puppy%3Donix%0Acontext_name%3D%C3%93nix%20Ramirez%0Acontext_status%3Dreserved%0Acontext_lang%3Den%0A%0AHello%2C%0A%0AI%20saw%20%C3%93nix%20Ramirez%27s%20profile%20and%20understand%20this%20Xoloitzcuintle%20is%20currently%20reserved.%0A%0AI%20am%20interested%20in%20future%20litters%20or%20a%20Xoloitzcuintle%20with%20similar%20characteristics.%0A%0AI%20would%20like%20to%20receive%20information%20about%3A%0A%0A-%20future%20puppies%20or%20litters%3B%0A-%20size%2C%20sex%2C%20and%20temperament%3B%0A-%20documentation%20and%20care%3B%0A-%20price%20and%20process%20conditions%3B%0A-%20delivery%20options%20for%20our%20location.%0A%0ACity%20or%20country%3A%0ACharacteristics%20we%20are%20looking%20for%3A%0APrevious%20experience%3A%0AContact%20number%3A%0A%0AThank%20you." class="btn-small btn-primary-small cta-lead cta-email" data-cta="email" data-lead-type="generate_lead" data-profile="onix" data-page-type="available-xolos" data-lang="en" aria-label="Contact by email about Onix" data-status="reserved">Contact by Email</a>
     </div>
   </div>
 </article>
@@ -656,7 +656,7 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
     <iframe width="100%" height="100%" src="https://www.youtube.com/embed/0qcQvELxVpU" title="Chimalma Ramirez" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen loading="lazy"></iframe>
   </div>
   <div class="puppy-card__actions">
-      <a href="mailto:fernando@xolosramirez.com?subject=%5BXOLOS%5D%20event%3Dinfo%20puppy%3Dchimalma&body=context_event%3Dinfo%0Acontext_puppy%3Dchimalma%0Acontext_name%3DChimalma%20Ramirez%0A%0AHello%20Fernando%2C%20I%20would%20like%20to%20receive%20information%20about%20Chimalma%20Ramirez." class="btn-small btn-primary-small cta-lead cta-email" onclick="dataLayer.push({ event: 'click_email', cachorro: 'Chimalma Ramirez', cachorro_slug: 'chimalma', source: 'available_xolos_contact_en' })" data-cta="email" data-lead-type="generate_lead" data-profile="chimalma" data-page-type="available-xolos" data-lang="en" aria-label="Contact by email about Chimalma">Contact by Email</a>
+      <a href="mailto:fernando@xolosramirez.com?subject=%5BXOLOS%5D%20event%3Dsimilar_xolos%20puppy%3Dchimalma&body=context_event%3Dsimilar_xolos%0Acontext_puppy%3Dchimalma%0Acontext_name%3DChimalma%20Ramirez%0Acontext_status%3Dreserved%0Acontext_lang%3Den%0A%0AHello%2C%0A%0AI%20saw%20Chimalma%20Ramirez%27s%20profile%20and%20understand%20this%20Xoloitzcuintle%20is%20currently%20reserved.%0A%0AI%20am%20interested%20in%20future%20litters%20or%20a%20Xoloitzcuintle%20with%20similar%20characteristics.%0A%0AI%20would%20like%20to%20receive%20information%20about%3A%0A%0A-%20future%20puppies%20or%20litters%3B%0A-%20size%2C%20sex%2C%20and%20temperament%3B%0A-%20documentation%20and%20care%3B%0A-%20price%20and%20process%20conditions%3B%0A-%20delivery%20options%20for%20our%20location.%0A%0ACity%20or%20country%3A%0ACharacteristics%20we%20are%20looking%20for%3A%0APrevious%20experience%3A%0AContact%20number%3A%0A%0AThank%20you." class="btn-small btn-primary-small cta-lead cta-email" data-cta="email" data-lead-type="generate_lead" data-profile="chimalma" data-page-type="available-xolos" data-lang="en" aria-label="Contact by email about Chimalma" data-status="reserved">Contact by Email</a>
     </div>
   </div>
 </article>
@@ -750,19 +750,19 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
     </section>
 
     <section class="como-reservar parallax" data-aos="fade-up" data-aos-duration="1000">
-      <h2>How do I reserve?</h2>
+      <h2>How does the process begin?</h2>
       <div class="pasos-reserva">
         <div class="paso">
           <img src="../img/icono-eleccion.svg" alt="" width="50" height="50" loading="lazy" />
-          <p><strong>1. Choose your Xolo:</strong> Review the profiles and select the one that best fits your family.</p>
+          <p><strong>1. Meet the profiles.</strong> Review each Xoloitzcuintle’s age, size, personality, and needs.</p>
         </div>
         <div class="paso">
           <img src="../img/icono-contacto.svg" alt="" width="50" height="50" loading="lazy" />
-          <p><strong>2. Contact us:</strong> Click and send us an email to start the reservation.</p>
+          <p><strong>2. Write to us by WhatsApp or email.</strong> Tell us what you are looking for and where you are located.</p>
         </div>
         <div class="paso">
           <img src="../img/icono-reserva.svg" alt="" width="50" height="50" loading="lazy" />
-          <p><strong>3. Reserve:</strong> Confirm the deposit and we'll coordinate the delivery with you.</p>
+          <p><strong>3. We talk about your family.</strong> We review location, lifestyle, and compatibility; when there is a good match, we personally explain the next steps.</p>
         </div>
       </div>
     </section>
@@ -804,8 +804,8 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
         <p>It includes a vaccination card, microchip, care guide, and post-adoption follow-up.</p>
       </details>
       <details>
-        <summary>What is the payment process?</summary>
-        <p>A deposit is made to reserve the puppy, and the rest is paid according to the established agreement (prior to delivery). We accept cash, bank transfers, and, for our international clients or Web3 community, decentralized payments using eCash (XEC).</p>
+        <summary>How are the process conditions explained?</summary>
+        <p>Specific conditions are explained personally after confirming availability, compatibility, and the family’s location.</p>
       </details>
       <details>
         <summary>Do you ship internationally?</summary>
@@ -836,14 +836,13 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
 
   <a
     class="wa-float cta-lead cta-whatsapp"
-    href="https://wa.me/message/435RTKGJLTX2J1"
+    href="https://wa.me/525518555993?text=Hello%2C%20I%E2%80%99m%20interested%20in%20learning%20about%20the%20price%20and%20current%20availability%20of%20a%20Xoloitzcuintle.%20I%20would%20also%20like%20guidance%20about%20sizes%2C%20documentation%20and%20delivery.%20My%20city%20or%20country%20is%3A"
     target="_blank"
     rel="noopener noreferrer"
     data-gtm="whatsapp-floating-en"
-    onclick="dataLayer.push({ event: 'click_whatsapp', source: 'floating_button_en' })"
     data-cta="whatsapp" data-lead-type="generate_lead" data-profile="general" data-page-type="available-xolos" data-lang="en" aria-label="Talk to Xolos Ramírez on WhatsApp">
     <span class="wa-float__icon" aria-hidden="true">💬</span>
-    <span class="wa-float__text">Talk to us</span>
+    <span class="wa-float__text">Ask about Xoloitzcuintle price</span>
   </a>
 
   <script src="https://unpkg.com/aos@2.3.1/dist/aos.js"></script>

--- a/xolos-disponibles.html
+++ b/xolos-disponibles.html
@@ -131,10 +131,10 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
       </section>
 
       <section class="container card" aria-labelledby="commercial-info-es" data-aos="fade-up" style="margin-top: 2rem; margin-bottom: 2rem; border-left: 4px solid #d4af37;">
-        <h2 id="commercial-info-es">Precio, reserva y qué incluye</h2>
+        <h2 id="commercial-info-es">Precio de xoloitzcuintle y acompañamiento</h2>
         <ul>
-          <li>Precio de referencia según ejemplar y talla.</li>
-          <li>Reserva mediante anticipo.</li>
+          <li>Orientación personalizada según ejemplar, talla y compatibilidad familiar.</li>
+          <li>Disponibilidad confirmada directamente por nuestro equipo.</li>
           <li>Incluye cartilla, microchip, seguimiento y acompañamiento.</li>
           <li>Entregas en CDMX, México y extranjero.</li>
         </ul>
@@ -187,9 +187,9 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
           </article>
           <article class="card trust-card">
             <span class="trust-icon" aria-hidden="true">🔒💳</span>
-            <h4>Pagos Seguros y Flexibles</h4>
+            <h4>Acompañamiento claro y personalizado</h4>
             <p>
-              Aceptamos transferencia bancaria, criptomonedas, efectivo y opciones de pago digitales nacionales e internacionales. Te brindamos claridad y acompañamiento profesional para que tu proceso sea seguro y confiable.
+              Te explicamos personalmente las condiciones del proceso después de confirmar disponibilidad, compatibilidad y ubicación de la familia, con acompañamiento profesional de principio a fin.
             </p>
           </article>
           <article class="card trust-card">
@@ -331,7 +331,7 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
     </div>
 
     <div class="puppy-card__actions">
-      <a href="mailto:fernando@xolosramirez.com?subject=Consulta%20sobre%20Yaretzi" class="btn-small btn-primary-small cta-lead cta-email" style="background-color: #25D366; border-color: #25D366; width: 100%; justify-content: center;" data-cta="email" data-lead-type="generate_lead" data-profile="yaretzi" data-page-type="available-xolos" data-lang="es" aria-label="Escribir por correo sobre Yaretzi">Correo directo ✉️</a>
+      <a href="mailto:fernando@xolosramirez.com?subject=%5BXOLOS%5D%20event%3Dprofile_inquiry%20puppy%3Dyaretzi&body=context_event%3Dprofile_inquiry%0Acontext_puppy%3Dyaretzi%0Acontext_name%3DYaretzi%20Ramirez%0Acontext_status%3Davailable%0Acontext_lang%3Des%0A%0AHola%2C%0A%0AVi%20el%20perfil%20de%20Yaretzi%20Ramirez%20en%20el%20sitio%20de%20Xolos%20Ram%C3%ADrez%20y%20me%20interesa%20conocer%20m%C3%A1s%20sobre%20%C3%A9l.%0A%0AQuisiera%20saber%20si%20podr%C3%ADa%20ser%20adecuado%20para%20nuestra%20familia%20y%20recibir%20informaci%C3%B3n%20sobre%3A%0A%0A-%20su%20personalidad%20y%20temperamento%3B%0A-%20su%20disponibilidad%20actual%3B%0A-%20documentaci%C3%B3n%20y%20cuidados%20correspondientes%3B%0A-%20precio%20y%20condiciones%20del%20proceso%3B%0A-%20opciones%20de%20entrega%20para%20nuestra%20ubicaci%C3%B3n.%0A%0ACiudad%20o%20pa%C3%ADs%3A%0ATipo%20de%20hogar%3A%0AExperiencia%20previa%20con%20perros%3A%0AN%C3%BAmero%20de%20contacto%3A%0A%0AGracias." class="btn-small btn-primary-small cta-lead cta-email" style="background-color: #25D366; border-color: #25D366; width: 100%; justify-content: center;" data-cta="email" data-lead-type="generate_lead" data-profile="yaretzi" data-page-type="available-xolos" data-lang="es" aria-label="Escribir por correo sobre Yaretzi" data-status="available">Correo directo ✉️</a>
     </div>
   </div>
 </article>
@@ -403,7 +403,7 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
   </div>
       
   <div class="puppy-card__actions">
-    <a href="mailto:fernando@xolosramirez.com?subject=Consulta%20sobre%20Xochitl" class="btn-small btn-primary-small cta-lead cta-email" style="background-color: #25D366; border-color: #25D366; width: 100%; justify-content: center;" data-cta="email" data-lead-type="generate_lead" data-profile="xochitl" data-page-type="available-xolos" data-lang="es" aria-label="Escribir por correo sobre Xochitl">Correo directo ✉️</a>
+    <a href="mailto:fernando@xolosramirez.com?subject=%5BXOLOS%5D%20event%3Dsimilar_xolos%20puppy%3Dxochitl&body=context_event%3Dsimilar_xolos%0Acontext_puppy%3Dxochitl%0Acontext_name%3DXochitl%20Ramirez%0Acontext_status%3Dreserved%0Acontext_lang%3Des%0A%0AHola%2C%0A%0AVi%20el%20perfil%20de%20Xochitl%20Ramirez%20y%20entiendo%20que%20actualmente%20est%C3%A1%20reservado.%0A%0AMe%20interesa%20conocer%20futuras%20camadas%20o%20alg%C3%BAn%20xoloitzcuintle%20con%20caracter%C3%ADsticas%20similares.%0A%0AQuisiera%20recibir%20informaci%C3%B3n%20sobre%3A%0A%0A-%20ejemplares%20o%20camadas%20futuras%3B%0A-%20talla%2C%20sexo%20y%20temperamento%3B%0A-%20documentaci%C3%B3n%20y%20cuidados%3B%0A-%20precio%20y%20condiciones%20del%20proceso%3B%0A-%20opciones%20de%20entrega%20para%20nuestra%20ubicaci%C3%B3n.%0A%0ACiudad%20o%20pa%C3%ADs%3A%0ACaracter%C3%ADsticas%20que%20buscamos%3A%0AExperiencia%20previa%3A%0AN%C3%BAmero%20de%20contacto%3A%0A%0AGracias." class="btn-small btn-primary-small cta-lead cta-email" style="background-color: #25D366; border-color: #25D366; width: 100%; justify-content: center;" data-cta="email" data-lead-type="generate_lead" data-profile="xochitl" data-page-type="available-xolos" data-lang="es" aria-label="Escribir por correo sobre Xochitl" data-status="reserved">Correo directo ✉️</a>
   </div>
 </div>
   </article>
@@ -474,7 +474,7 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
   </div>
       
   <div class="puppy-card__actions">
-    <a href="mailto:fernando@xolosramirez.com?subject=Consulta%20sobre%20Yohualli" class="btn-small btn-primary-small cta-lead cta-email" style="background-color: #25D366; border-color: #25D366; width: 100%; justify-content: center;" data-cta="email" data-lead-type="generate_lead" data-profile="yohualli" data-page-type="available-xolos" data-lang="es" aria-label="Escribir por correo sobre Yohualli">Correo directo ✉️</a>
+    <a href="mailto:fernando@xolosramirez.com?subject=%5BXOLOS%5D%20event%3Dprofile_inquiry%20puppy%3Dyohualli&body=context_event%3Dprofile_inquiry%0Acontext_puppy%3Dyohualli%0Acontext_name%3DYohualli%20Ramirez%0Acontext_status%3Davailable%0Acontext_lang%3Des%0A%0AHola%2C%0A%0AVi%20el%20perfil%20de%20Yohualli%20Ramirez%20en%20el%20sitio%20de%20Xolos%20Ram%C3%ADrez%20y%20me%20interesa%20conocer%20m%C3%A1s%20sobre%20%C3%A9l.%0A%0AQuisiera%20saber%20si%20podr%C3%ADa%20ser%20adecuado%20para%20nuestra%20familia%20y%20recibir%20informaci%C3%B3n%20sobre%3A%0A%0A-%20su%20personalidad%20y%20temperamento%3B%0A-%20su%20disponibilidad%20actual%3B%0A-%20documentaci%C3%B3n%20y%20cuidados%20correspondientes%3B%0A-%20precio%20y%20condiciones%20del%20proceso%3B%0A-%20opciones%20de%20entrega%20para%20nuestra%20ubicaci%C3%B3n.%0A%0ACiudad%20o%20pa%C3%ADs%3A%0ATipo%20de%20hogar%3A%0AExperiencia%20previa%20con%20perros%3A%0AN%C3%BAmero%20de%20contacto%3A%0A%0AGracias." class="btn-small btn-primary-small cta-lead cta-email" style="background-color: #25D366; border-color: #25D366; width: 100%; justify-content: center;" data-cta="email" data-lead-type="generate_lead" data-profile="yohualli" data-page-type="available-xolos" data-lang="es" aria-label="Escribir por correo sobre Yohualli" data-status="available">Correo directo ✉️</a>
   </div>
 </div>
   </article>
@@ -541,7 +541,7 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
     <iframe width="100%" height="100%" src="https://www.youtube.com/embed/tL_jiakmL1o" title="Ozomatli Ramirez" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen loading="lazy"></iframe>
   </div>
   <div class="puppy-card__actions">
-    <a href="mailto:fernando@xolosramirez.com?subject=Consulta%20sobre%20Ozomatli" class="btn-small btn-primary-small cta-lead cta-email" style="background-color: #25D366; border-color: #25D366; width: 100%; justify-content: center;" data-cta="email" data-lead-type="generate_lead" data-profile="ozomatli" data-page-type="available-xolos" data-lang="es" aria-label="Escribir por correo sobre Ozomatli">Correo directo ✉️</a>
+    <a href="mailto:fernando@xolosramirez.com?subject=%5BXOLOS%5D%20event%3Dprofile_inquiry%20puppy%3Dozomatli&body=context_event%3Dprofile_inquiry%0Acontext_puppy%3Dozomatli%0Acontext_name%3DOzomatli%20Ramirez%0Acontext_status%3Davailable%0Acontext_lang%3Des%0A%0AHola%2C%0A%0AVi%20el%20perfil%20de%20Ozomatli%20Ramirez%20en%20el%20sitio%20de%20Xolos%20Ram%C3%ADrez%20y%20me%20interesa%20conocer%20m%C3%A1s%20sobre%20%C3%A9l.%0A%0AQuisiera%20saber%20si%20podr%C3%ADa%20ser%20adecuado%20para%20nuestra%20familia%20y%20recibir%20informaci%C3%B3n%20sobre%3A%0A%0A-%20su%20personalidad%20y%20temperamento%3B%0A-%20su%20disponibilidad%20actual%3B%0A-%20documentaci%C3%B3n%20y%20cuidados%20correspondientes%3B%0A-%20precio%20y%20condiciones%20del%20proceso%3B%0A-%20opciones%20de%20entrega%20para%20nuestra%20ubicaci%C3%B3n.%0A%0ACiudad%20o%20pa%C3%ADs%3A%0ATipo%20de%20hogar%3A%0AExperiencia%20previa%20con%20perros%3A%0AN%C3%BAmero%20de%20contacto%3A%0A%0AGracias." class="btn-small btn-primary-small cta-lead cta-email" style="background-color: #25D366; border-color: #25D366; width: 100%; justify-content: center;" data-cta="email" data-lead-type="generate_lead" data-profile="ozomatli" data-page-type="available-xolos" data-lang="es" aria-label="Escribir por correo sobre Ozomatli" data-status="available">Correo directo ✉️</a>
   </div>
 </div>
   </article>
@@ -602,7 +602,7 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
     <iframe width="100%" height="100%" src="https://www.youtube.com/embed/7SpwHbPB_7Y" title="Nox Ramirez" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen loading="lazy"></iframe>
   </div>
   <div class="puppy-card__actions">
-    <a href="mailto:fernando@xolosramirez.com?subject=Consulta%20sobre%20Nox" class="btn-small btn-primary-small cta-lead cta-email" style="background-color: #25D366; border-color: #25D366; width: 100%; justify-content: center;" data-cta="email" data-lead-type="generate_lead" data-profile="nox" data-page-type="available-xolos" data-lang="es" aria-label="Escribir por correo sobre Nox">Correo directo ✉️</a>
+    <a href="mailto:fernando@xolosramirez.com?subject=%5BXOLOS%5D%20event%3Dsimilar_xolos%20puppy%3Dnox&body=context_event%3Dsimilar_xolos%0Acontext_puppy%3Dnox%0Acontext_name%3DNox%20Ramirez%0Acontext_status%3Dreserved%0Acontext_lang%3Des%0A%0AHola%2C%0A%0AVi%20el%20perfil%20de%20Nox%20Ramirez%20y%20entiendo%20que%20actualmente%20est%C3%A1%20reservado.%0A%0AMe%20interesa%20conocer%20futuras%20camadas%20o%20alg%C3%BAn%20xoloitzcuintle%20con%20caracter%C3%ADsticas%20similares.%0A%0AQuisiera%20recibir%20informaci%C3%B3n%20sobre%3A%0A%0A-%20ejemplares%20o%20camadas%20futuras%3B%0A-%20talla%2C%20sexo%20y%20temperamento%3B%0A-%20documentaci%C3%B3n%20y%20cuidados%3B%0A-%20precio%20y%20condiciones%20del%20proceso%3B%0A-%20opciones%20de%20entrega%20para%20nuestra%20ubicaci%C3%B3n.%0A%0ACiudad%20o%20pa%C3%ADs%3A%0ACaracter%C3%ADsticas%20que%20buscamos%3A%0AExperiencia%20previa%3A%0AN%C3%BAmero%20de%20contacto%3A%0A%0AGracias." class="btn-small btn-primary-small cta-lead cta-email" style="background-color: #25D366; border-color: #25D366; width: 100%; justify-content: center;" data-cta="email" data-lead-type="generate_lead" data-profile="nox" data-page-type="available-xolos" data-lang="es" aria-label="Escribir por correo sobre Nox" data-status="reserved">Correo directo ✉️</a>
   </div>
     </div>
   </article>
@@ -673,7 +673,7 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
     <iframe width="100%" height="100%" src="https://www.youtube.com/embed/MbhjQ1sJcG4" title="Teyolia Ramirez" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen loading="lazy"></iframe>
   </div>
   <div class="puppy-card__actions">
-    <a href="mailto:fernando@xolosramirez.com?subject=Consulta%20sobre%20Teyolia" class="btn-small btn-primary-small cta-lead cta-email" style="background-color: #25D366; border-color: #25D366; width: 100%; justify-content: center;" data-cta="email" data-lead-type="generate_lead" data-profile="teyolia" data-page-type="available-xolos" data-lang="es" aria-label="Escribir por correo sobre Teyolia">Correo directo ✉️</a>
+    <a href="mailto:fernando@xolosramirez.com?subject=%5BXOLOS%5D%20event%3Dsimilar_xolos%20puppy%3Dteyolia&body=context_event%3Dsimilar_xolos%0Acontext_puppy%3Dteyolia%0Acontext_name%3DTeyolia%20Ramirez%0Acontext_status%3Dreserved%0Acontext_lang%3Des%0A%0AHola%2C%0A%0AVi%20el%20perfil%20de%20Teyolia%20Ramirez%20y%20entiendo%20que%20actualmente%20est%C3%A1%20reservado.%0A%0AMe%20interesa%20conocer%20futuras%20camadas%20o%20alg%C3%BAn%20xoloitzcuintle%20con%20caracter%C3%ADsticas%20similares.%0A%0AQuisiera%20recibir%20informaci%C3%B3n%20sobre%3A%0A%0A-%20ejemplares%20o%20camadas%20futuras%3B%0A-%20talla%2C%20sexo%20y%20temperamento%3B%0A-%20documentaci%C3%B3n%20y%20cuidados%3B%0A-%20precio%20y%20condiciones%20del%20proceso%3B%0A-%20opciones%20de%20entrega%20para%20nuestra%20ubicaci%C3%B3n.%0A%0ACiudad%20o%20pa%C3%ADs%3A%0ACaracter%C3%ADsticas%20que%20buscamos%3A%0AExperiencia%20previa%3A%0AN%C3%BAmero%20de%20contacto%3A%0A%0AGracias." class="btn-small btn-primary-small cta-lead cta-email" style="background-color: #25D366; border-color: #25D366; width: 100%; justify-content: center;" data-cta="email" data-lead-type="generate_lead" data-profile="teyolia" data-page-type="available-xolos" data-lang="es" aria-label="Escribir por correo sobre Teyolia" data-status="reserved">Correo directo ✉️</a>
   </div>
     </div>
   </article>
@@ -736,7 +736,7 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
     <iframe width="100%" height="100%" src="https://www.youtube.com/embed/KU7aR7z9G-0" title="Onix Ramirez" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen loading="lazy"></iframe>
   </div>
   <div class="puppy-card__actions">
-    <a href="mailto:fernando@xolosramirez.com?subject=Consulta%20sobre%20Onix" class="btn-small btn-primary-small cta-lead cta-email" style="background-color: #25D366; border-color: #25D366; width: 100%; justify-content: center;" data-cta="email" data-lead-type="generate_lead" data-profile="onix" data-page-type="available-xolos" data-lang="es" aria-label="Escribir por correo sobre Onix">Correo directo ✉️</a>
+    <a href="mailto:fernando@xolosramirez.com?subject=%5BXOLOS%5D%20event%3Dsimilar_xolos%20puppy%3Donix&body=context_event%3Dsimilar_xolos%0Acontext_puppy%3Donix%0Acontext_name%3D%C3%93nix%20Ramirez%0Acontext_status%3Dreserved%0Acontext_lang%3Des%0A%0AHola%2C%0A%0AVi%20el%20perfil%20de%20%C3%93nix%20Ramirez%20y%20entiendo%20que%20actualmente%20est%C3%A1%20reservado.%0A%0AMe%20interesa%20conocer%20futuras%20camadas%20o%20alg%C3%BAn%20xoloitzcuintle%20con%20caracter%C3%ADsticas%20similares.%0A%0AQuisiera%20recibir%20informaci%C3%B3n%20sobre%3A%0A%0A-%20ejemplares%20o%20camadas%20futuras%3B%0A-%20talla%2C%20sexo%20y%20temperamento%3B%0A-%20documentaci%C3%B3n%20y%20cuidados%3B%0A-%20precio%20y%20condiciones%20del%20proceso%3B%0A-%20opciones%20de%20entrega%20para%20nuestra%20ubicaci%C3%B3n.%0A%0ACiudad%20o%20pa%C3%ADs%3A%0ACaracter%C3%ADsticas%20que%20buscamos%3A%0AExperiencia%20previa%3A%0AN%C3%BAmero%20de%20contacto%3A%0A%0AGracias." class="btn-small btn-primary-small cta-lead cta-email" style="background-color: #25D366; border-color: #25D366; width: 100%; justify-content: center;" data-cta="email" data-lead-type="generate_lead" data-profile="onix" data-page-type="available-xolos" data-lang="es" aria-label="Escribir por correo sobre Onix" data-status="reserved">Correo directo ✉️</a>
   </div>
     </div>
   </article>
@@ -791,7 +791,7 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
     <iframe width="100%" height="100%" src="https://www.youtube.com/embed/0qcQvELxVpU" title="Chimalma Ramirez" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen loading="lazy"></iframe>
   </div>
   <div class="puppy-card__actions">
-    <a href="mailto:fernando@xolosramirez.com?subject=Consulta%20sobre%20Chimalma" class="btn-small btn-primary-small cta-lead cta-email" style="background-color: #25D366; border-color: #25D366; width: 100%; justify-content: center;" data-cta="email" data-lead-type="generate_lead" data-profile="chimalma" data-page-type="available-xolos" data-lang="es" aria-label="Escribir por correo sobre Chimalma">Correo directo ✉️</a>
+    <a href="mailto:fernando@xolosramirez.com?subject=%5BXOLOS%5D%20event%3Dsimilar_xolos%20puppy%3Dchimalma&body=context_event%3Dsimilar_xolos%0Acontext_puppy%3Dchimalma%0Acontext_name%3DChimalma%20Ramirez%0Acontext_status%3Dreserved%0Acontext_lang%3Des%0A%0AHola%2C%0A%0AVi%20el%20perfil%20de%20Chimalma%20Ramirez%20y%20entiendo%20que%20actualmente%20est%C3%A1%20reservado.%0A%0AMe%20interesa%20conocer%20futuras%20camadas%20o%20alg%C3%BAn%20xoloitzcuintle%20con%20caracter%C3%ADsticas%20similares.%0A%0AQuisiera%20recibir%20informaci%C3%B3n%20sobre%3A%0A%0A-%20ejemplares%20o%20camadas%20futuras%3B%0A-%20talla%2C%20sexo%20y%20temperamento%3B%0A-%20documentaci%C3%B3n%20y%20cuidados%3B%0A-%20precio%20y%20condiciones%20del%20proceso%3B%0A-%20opciones%20de%20entrega%20para%20nuestra%20ubicaci%C3%B3n.%0A%0ACiudad%20o%20pa%C3%ADs%3A%0ACaracter%C3%ADsticas%20que%20buscamos%3A%0AExperiencia%20previa%3A%0AN%C3%BAmero%20de%20contacto%3A%0A%0AGracias." class="btn-small btn-primary-small cta-lead cta-email" style="background-color: #25D366; border-color: #25D366; width: 100%; justify-content: center;" data-cta="email" data-lead-type="generate_lead" data-profile="chimalma" data-page-type="available-xolos" data-lang="es" aria-label="Escribir por correo sobre Chimalma" data-status="reserved">Correo directo ✉️</a>
   </div>
     </div>
   </article> 
@@ -889,19 +889,19 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
       </section>
 
       <section class="como-reservar parallax" data-aos="fade-up" data-aos-duration="1000">
-        <h2>¿Cómo reservo?</h2>
+        <h2>¿Cómo comienza el proceso?</h2>
         <div class="pasos-reserva">
           <div class="paso">
             <img src="img/icono-eleccion.svg" alt="" width="50" height="50" loading="lazy" />
-            <p><strong>1. Elige a tu Xolo:</strong> Revisa los perfiles y selecciona el que mejor se adapte a tu familia.</p>
+            <p><strong>1. Conoce los perfiles.</strong> Revisa edad, talla, personalidad y necesidades de cada xoloitzcuintle.</p>
           </div>
           <div class="paso">
             <img src="img/icono-contacto.svg" alt="" width="50" height="50" loading="lazy" />
-            <p><strong>2. Escríbenos:</strong> Haz clic y envíanos un correo para iniciar la reserva.</p>
+            <p><strong>2. Escríbenos por WhatsApp o correo.</strong> Cuéntanos qué estás buscando y desde dónde nos contactas.</p>
           </div>
           <div class="paso">
             <img src="img/icono-reserva.svg" alt="" width="50" height="50" loading="lazy" />
-            <p><strong>3. Reserva:</strong> Confirma el anticipo y coordinamos la entrega contigo.</p>
+            <p><strong>3. Conversamos sobre tu familia.</strong> Revisamos ubicación, estilo de vida y compatibilidad; cuando existe compatibilidad, explicamos personalmente los siguientes pasos.</p>
           </div>
         </div>
       </section>
@@ -944,8 +944,8 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
           <p>Incluye cartilla de vacunación, microchip, guía de cuidados y seguimiento post-adopción.</p>
         </details>
         <details>
-          <summary>¿Cuál es el proceso de pago?</summary>
-          <p>Se realiza un anticipo para reservar al cachorro y el resto se liquida según el acuerdo establecido (previo a la entrega). Aceptamos efectivo, transferencias bancarias y, para nuestros clientes internacionales o de la comunidad Web3, pagos descentralizados mediante eCash (XEC). <a href="blog/guia-pago-con-tonalli-wallet.html" style="color: var(--accent-color);">Ver guía de pagos digitales aquí.</a></p>
+          <summary>¿Cómo se explican las condiciones del proceso?</summary>
+          <p>Las condiciones particulares se explican personalmente después de confirmar disponibilidad, compatibilidad y ubicación de la familia.</p>
         </details>
         <details>
           <summary>¿Hacen envíos internacionales?</summary>
@@ -981,14 +981,13 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
 
     <a
       class="wa-float cta-lead cta-whatsapp"
-      href="https://wa.me/message/435RTKGJLTX2J1"
+      href="https://wa.me/525518555993?text=Hola%2C%20me%20interesa%20conocer%20el%20precio%20y%20la%20disponibilidad%20de%20un%20xoloitzcuintle.%20Tambi%C3%A9n%20quisiera%20recibir%20orientaci%C3%B3n%20sobre%20tallas%2C%20documentaci%C3%B3n%20y%20proceso%20de%20entrega.%20Mi%20ciudad%20o%20pa%C3%ADs%20es%3A"
       target="_blank"
       rel="noopener noreferrer"
       data-gtm="whatsapp-floating"
-      onclick="dataLayer.push({ event: 'click_whatsapp', source: 'floating_button' })"
       data-cta="whatsapp" data-lead-type="generate_lead" data-profile="general" data-page-type="available-xolos" data-lang="es" aria-label="Hablar con Xolos Ramírez por WhatsApp">
       <span class="wa-float__icon" aria-hidden="true">💬</span>
-      <span class="wa-float__text">Hablar con nosotros</span>
+      <span class="wa-float__text">Preguntar precio de un xoloitzcuintle</span>
     </a>
 
     <script src="js/main.js" defer></script>


### PR DESCRIPTION
### Motivation
- Capture the SEO intent around “precio xoloitzcuintle” on the Available Xolos pages while avoiding publishing numeric prices. 
- Preserve a dedicated, accessible email floating CTA on the home page (mail contact to `fernando@xolosramirez.com`) and prevent it from inheriting the WhatsApp float styles that broke mobile layout. 
- Make profile contact flows contextual so inquiries carry profile/status metadata and encourage family-matching / personal guidance instead of transactional payment language.

### Description
- Updated Spanish and English copy on the Available Xolos pages to emphasize personalized price guidance, availability confirmation and family-matching instead of public numeric prices or transactional payment terms. 
- Replaced transactional reservation/payment wording with family-oriented process language and FAQ edits in both `xolos-disponibles.html` and `en/available-xolos.html`. 
- Rewrote profile `mailto:` CTAs to include structured `subject` and `body` (with `context_event`, `context_puppy`, `context_name`, `context_status`, `context_lang`) and added `data-status` attributes so emails are contextual to each profile. 
- Kept WhatsApp floating CTAs on available-Xolos pages but changed visible text to price-intent phrases, replaced `wa.me/message/...` with `wa.me` URLs prefilled with encoded messages, and removed inline `onclick=

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a56748d6afc833295e8a52e18a7bd2d)