### PR TITLE
feat: add Iztli Ramirez available puppy profile

### DIFF
--- a/en/available-xolos.html
+++ b/en/available-xolos.html
@@ -278,6 +278,66 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
   </div>
 </article>
 
+<article class="puppy-card" data-aos="fade-up" data-aos-duration="800" data-aos-delay="200">
+  <div class="puppy-card__image-wrapper">
+    <span class="puppy-card__status status-disponible">Available</span>
+
+    <div class="swipe-indicator" aria-hidden="true">
+      <span>Swipe</span>
+      <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M5 12h14M12 5l7 7-7 7"/></svg>
+    </div>
+
+    <div style="display: flex; overflow-x: auto; scroll-snap-type: x mandatory; scrollbar-width: none; -ms-overflow-style: none;">
+      <style>
+        .puppy-card__image-wrapper div::-webkit-scrollbar { display: none; }
+      </style>
+
+      <img
+        src="https://i.imgur.com/hhJ5WaL.jpeg"
+        alt="Newborn Xoloitzcuintli Iztli Ramirez"
+        class="puppy-card__image"
+        loading="lazy"
+        style="flex: 0 0 100%; scroll-snap-align: start; object-fit: cover;"
+      />
+    </div>
+  </div>
+
+  <div class="puppy-card__content">
+    <h3 class="puppy-card__name">Iztli Ramirez</h3>
+
+    <ul class="puppy-card__details">
+      <li><strong>Age</strong>Newborn</li>
+      <li><strong>Gender</strong>Male</li>
+      <li><strong>Size</strong>To be confirmed</li>
+      <li><strong>Color</strong>Black</li>
+    </ul>
+
+    <!-- IZTLI RAMIREZ VIDEO:
+    To publish the video:
+    1. Replace IZTLI_YOUTUBE_VIDEO_ID with the real video ID.
+    2. Uncomment the full block.
+    -->
+    <!--
+    <div class="puppy-video-container" style="margin: 1rem 0; border-radius: 8px; overflow: hidden; aspect-ratio: 16/9;">
+      <iframe
+        width="100%"
+        height="100%"
+        src="https://www.youtube.com/embed/IZTLI_YOUTUBE_VIDEO_ID"
+        title="Iztli Ramirez"
+        frameborder="0"
+        allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
+        allowfullscreen
+        loading="lazy">
+      </iframe>
+    </div>
+    -->
+
+    <div class="puppy-card__actions">
+      <a href="mailto:fernando@xolosramirez.com?subject=Inquiry%20about%20Iztli%20Ramirez%20%5BRef%3A%20iztli-en-available%5D&body=Hello%2C%0A%0AI%20saw%20Iztli%20Ramirez%27s%20profile%20on%20the%20Xolos%20Ram%C3%ADrez%20website%20and%20I%20am%20interested%20in%20learning%20more.%0A%0AI%20would%20like%20to%20know%20whether%20this%20Xoloitzcuintle%20could%20be%20a%20good%20fit%20for%20our%20family%20and%20receive%20information%20about%3A%0A%0A-%20personality%20and%20temperament%3B%0A-%20current%20availability%3B%0A-%20documentation%20and%20care%3B%0A-%20price%20and%20process%20conditions%3B%0A-%20delivery%20options%20for%20our%20location.%0A%0ATo%20help%20you%20guide%20us%20better%2C%20here%20is%20some%20information%3A%0A%0ACity%20or%20country%3A%0AType%20of%20home%3A%0APrevious%20experience%20with%20dogs%3A%0AWhatsApp%20contact%20number%3A%0A%0AThank%20you." class="btn-small btn-primary-small cta-lead cta-email" data-cta="email" data-lead-type="generate_lead" data-profile="iztli" data-page-type="available-xolos" data-lang="en" aria-label="Contact by email about Iztli" data-status="available">Contact via Email</a>
+    </div>
+  </div>
+</article>
+
 
         <article class="puppy-card" data-aos="fade-up" data-aos-duration="800" data-aos-delay="200">
           <div class="puppy-card__image-wrapper">

--- a/xolos-disponibles.html
+++ b/xolos-disponibles.html
@@ -343,6 +343,67 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
   </div>
 </article>
 
+<article class="puppy-card" data-aos="fade-up" data-aos-duration="800" data-aos-delay="200">
+  <div class="puppy-card__image-wrapper">
+    <span class="puppy-card__status status-disponible">Disponible</span>
+
+    <div class="swipe-indicator" aria-hidden="true">
+      <span>Desliza</span>
+      <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M5 12h14M12 5l7 7-7 7"/></svg>
+    </div>
+
+    <div style="display: flex; overflow-x: auto; scroll-snap-type: x mandatory; scrollbar-width: none; -ms-overflow-style: none;">
+      <style>
+        /* Ocultar barra de scroll para mantener la estética limpia */
+        .puppy-card__image-wrapper div::-webkit-scrollbar { display: none; }
+      </style>
+
+      <img
+        src="https://i.imgur.com/hhJ5WaL.jpeg"
+        alt="Xoloitzcuintle Iztli Ramirez recién nacido"
+        class="puppy-card__image"
+        loading="lazy"
+        style="flex: 0 0 100%; scroll-snap-align: start; object-fit: cover;"
+      />
+    </div>
+  </div>
+
+  <div class="puppy-card__content">
+    <h3 class="puppy-card__name">Iztli Ramirez</h3>
+
+    <ul class="puppy-card__details">
+      <li><strong>Edad</strong>Recién nacido</li>
+      <li><strong>Género</strong>Macho</li>
+      <li><strong>Talla</strong>Por confirmar</li>
+      <li><strong>Color</strong>Negro</li>
+    </ul>
+
+    <!-- VIDEO DE IZTLI RAMIREZ:
+    Para publicar el video:
+    1. Reemplazar IZTLI_YOUTUBE_VIDEO_ID con el ID real del video.
+    2. Descomentar el bloque completo.
+    -->
+    <!--
+    <div class="puppy-video-container" style="margin: 1rem 0; border-radius: 8px; overflow: hidden; aspect-ratio: 16/9;">
+      <iframe
+        width="100%"
+        height="100%"
+        src="https://www.youtube.com/embed/IZTLI_YOUTUBE_VIDEO_ID"
+        title="Iztli Ramirez"
+        frameborder="0"
+        allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
+        allowfullscreen
+        loading="lazy">
+      </iframe>
+    </div>
+    -->
+
+    <div class="puppy-card__actions">
+      <a href="mailto:fernando@xolosramirez.com?subject=Consulta%20sobre%20Iztli%20Ramirez%20%5BRef%3A%20iztli-es-available%5D&body=Hola%2C%0A%0AVi%20el%20perfil%20de%20Iztli%20Ramirez%20en%20el%20sitio%20de%20Xolos%20Ram%C3%ADrez%20y%20me%20interesa%20conocer%20m%C3%A1s%20sobre%20sus%20caracter%C3%ADsticas.%0A%0AQuisiera%20saber%20si%20podr%C3%ADa%20integrarse%20bien%20a%20nuestra%20familia%20y%20recibir%20informaci%C3%B3n%20sobre%3A%0A%0A-%20su%20personalidad%20y%20temperamento%3B%0A-%20su%20disponibilidad%20actual%3B%0A-%20documentaci%C3%B3n%20y%20cuidados%20correspondientes%3B%0A-%20precio%20y%20condiciones%20del%20proceso%3B%0A-%20opciones%20de%20entrega%20para%20nuestra%20ubicaci%C3%B3n.%0A%0APara%20que%20puedan%20orientarme%20mejor%2C%20comparto%20estos%20datos%3A%0A%0ACiudad%20o%20pa%C3%ADs%3A%0ATipo%20de%20hogar%20%28casa/departamento%29%3A%0AExperiencia%20previa%20con%20perros%3A%0AN%C3%BAmero%20de%20WhatsApp%20de%20contacto%3A%0A%0AGracias." class="btn-small btn-primary-small cta-lead cta-email" style="background-color: #25D366; border-color: #25D366; width: 100%; justify-content: center;" data-cta="email" data-lead-type="generate_lead" data-profile="iztli" data-page-type="available-xolos" data-lang="es" aria-label="Escribir por correo sobre Iztli" data-status="available">Correo directo ✉️</a>
+    </div>
+  </div>
+</article>
+
    <article class="puppy-card" data-aos="fade-up" data-aos-duration="800" data-aos-delay="200">
     <div class="puppy-card__image-wrapper">
       <span class="puppy-card__status status-disponible">Reservada</span>


### PR DESCRIPTION
### Motivation
- Add a new bilingual available profile for the puppy `iztli` following the exact visual, semantic and tracking patterns used by existing puppy cards. 
- Keep markup, classes, accessibility, mailto tracking and responsive image/gallery behavior identical to neighboring newborn profiles to allow future additions without layout changes.

### Description
- Inserted a new `<article class="puppy-card">` for Iztli Ramirez in `xolos-disponibles.html` (Spanish) immediately after Yaretzi and the matching card in `en/available-xolos.html` (English) in the same relative position. 
- The card preserves the gallery wrapper, `puppy-card__image-wrapper`, `puppy-card__image` with `loading="lazy"` and `object-fit: cover`, the `puppy-card__content` structure and the `puppy-card__actions` area. 
- Added the language-appropriate details and alt text (`alt=

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a57d5fc16a48332ad931bf071ec19d1)