### PR TITLE
feat(analytics): emit structured generate_lead events to GTM

### DIFF
--- a/contacto.html
+++ b/contacto.html
@@ -141,6 +141,13 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
           data-aos="fade-up"
           data-aos-delay="150"
           data-gtm="contact-form"
+          data-lead-type="generate_lead"
+          data-cta="form"
+          data-profile="general"
+          data-page-type="contact"
+          data-lang="es"
+          data-cta-location="contact_form"
+          data-lead-intent="contact_form"
         >
           <div>
             <label for="nombre">Nombre completo</label>
@@ -239,7 +246,6 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
       target="_blank"
       rel="noopener noreferrer"
       data-gtm="email-floating"
-      onclick="dataLayer.push({ event: 'click_email', source: 'floating_button' })"
      data-cta="email" data-lead-type="generate_lead" data-profile="general" data-page-type="contact" data-lang="es" aria-label="Escribir por correo a Xolos Ramírez">
       <span>✉️ Escríbenos por correo</span>
     </a>

--- a/docs/analytics/generate-lead-setup.md
+++ b/docs/analytics/generate-lead-setup.md
@@ -1,0 +1,150 @@
+# generate_lead setup
+
+Este repositorio unicamente empuja el evento `generate_lead` a `window.dataLayer`. Todavia se requiere configurar Google Tag Manager, Google Analytics 4 y Google Ads para que el evento se procese como conversion o evento clave. El sitio no envia valores, moneda, precios ni datos personales a Analytics.
+
+## Configuración en GTM
+
+Crear variables de capa de datos, versión 2:
+
+DLV - lead_channel
+DLV - cta_location
+DLV - lead_intent
+DLV - profile
+DLV - profile_status
+DLV - page_type
+DLV - lang
+
+Cada variable debe usar el nombre correspondiente:
+
+lead_channel
+cta_location
+lead_intent
+profile
+profile_status
+page_type
+lang
+
+Crear un activador:
+
+Nombre:
+Custom Event - generate_lead
+
+Tipo:
+Evento personalizado
+
+Nombre del evento:
+generate_lead
+
+Activación:
+Todos los eventos personalizados con ese nombre.
+
+Crear una etiqueta:
+
+Nombre:
+GA4 Event - generate_lead
+
+Tipo:
+Google Analytics: evento de GA4
+
+Usar la Google tag o etiqueta de configuración GA4 ya existente.
+
+Nombre del evento:
+generate_lead
+
+Parámetros:
+
+lead_channel = {{DLV - lead_channel}}
+cta_location = {{DLV - cta_location}}
+lead_intent = {{DLV - lead_intent}}
+profile = {{DLV - profile}}
+profile_status = {{DLV - profile_status}}
+page_type = {{DLV - page_type}}
+lang = {{DLV - lang}}
+
+Activador:
+Custom Event - generate_lead
+
+No enviar valor ni moneda.
+
+## Matriz de prueba en Tag Assistant
+
+Home correo español:
+
+lead_channel=email
+cta_location=floating
+lead_intent=general_inquiry
+profile=general
+profile_status=not_applicable
+page_type=home
+lang=es
+
+WhatsApp disponibles español:
+
+lead_channel=whatsapp
+cta_location=floating
+lead_intent=price_inquiry
+profile=general
+profile_status=not_applicable
+page_type=available-xolos
+lang=es
+
+Yaretzi o perfil available:
+
+lead_channel=email
+cta_location=profile_card
+lead_intent=profile_inquiry
+profile=slug
+profile_status=available
+page_type=available-xolos
+lang=es|en
+
+Perfil reserved:
+
+lead_channel=email
+cta_location=profile_card
+lead_intent=similar_xolos
+profile=slug
+profile_status=reserved
+page_type=available-xolos
+lang=es|en
+
+Formulario:
+
+lead_channel=form
+cta_location=contact_form
+lead_intent=contact_form
+profile=general
+profile_status=not_applicable
+page_type=contact
+lang=es|en
+
+## Configuración en GA4
+
+1. Publicar el contenedor de GTM.
+2. Ejecutar al menos una prueba real.
+3. Verificar generate_lead en DebugView o Tiempo real.
+4. Marcar generate_lead como evento clave.
+5. También puede marcarse anticipadamente escribiendo exactamente:
+   generate_lead
+6. Los informes estándar pueden tardar hasta 24 horas.
+
+## Configuración en Google Ads
+
+1. Confirmar que GA4 y Google Ads estén vinculados.
+2. Crear una conversión basada en el evento clave generate_lead.
+3. La categoría recomendada para este evento unificado es Contacto, porque incluye:
+   - WhatsApp
+   - correo
+   - formulario
+4. No seleccionar purchase como conversión de leads.
+5. No asignar a cada lead el precio total de un xoloitzcuintle.
+6. Inicialmente validar el conteo antes de usarlo para puja automática.
+7. Después de validar, configurarlo como acción principal para el objetivo de leads.
+
+generate_lead podría no aparecer todavía por estas razones:
+
+- el sitio no lo había enviado;
+- GTM todavía no estaba configurado o publicado;
+- GA4 aún no lo había recibido;
+- no estaba marcado como evento clave;
+- Google Ads puede tardar en mostrarlo después de la recepción y vinculación.

--- a/en/contact.html
+++ b/en/contact.html
@@ -143,7 +143,13 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
           data-aos="fade-up"
           data-aos-delay="150"
           data-gtm="contact-form"
-          onsubmit="dataLayer.push({ event: 'submit_contact', form: 'contacto_general' })"
+          data-lead-type="generate_lead"
+          data-cta="form"
+          data-profile="general"
+          data-page-type="contact"
+          data-lang="en"
+          data-cta-location="contact_form"
+          data-lead-intent="contact_form"
         >
           <div>
             <label for="nombre">Full name</label>

--- a/js/main.js
+++ b/js/main.js
@@ -66,3 +66,152 @@ document.addEventListener('click', (event) => {
     href: naturalsLink.getAttribute('href') || '',
   });
 });
+const CONTACT_FORM_SELECTOR = 'form[data-gtm="contact-form"]';
+const LEAD_DEDUPLICATION_MS = 1500;
+let lastGenerateLeadSignature = '';
+let lastGenerateLeadAt = 0;
+
+function getLeadElement(target) {
+  if (!(target instanceof Element)) return null;
+
+  return target.closest('[data-lead-type="generate_lead"]');
+}
+
+function getDatasetField(element, key, fallback = 'unknown') {
+  return element.dataset[key] || fallback;
+}
+
+function getLeadChannel(element) {
+  const cta = getDatasetField(element, 'cta', '').toLowerCase();
+
+  if (cta === 'whatsapp') return 'whatsapp';
+  if (cta === 'email') return 'email';
+  if (cta === 'contact-form' || cta === 'form') return 'form';
+
+  return 'unknown';
+}
+
+function getCtaLocation(element) {
+  if (element.dataset.ctaLocation) return element.dataset.ctaLocation;
+  if (element.classList.contains('wa-float')) return 'floating';
+  if (element.classList.contains('home-email-float')) return 'floating';
+  if (element.closest('.puppy-card')) return 'profile_card';
+  if (element.closest('footer')) return 'footer';
+  if (element.closest(CONTACT_FORM_SELECTOR)) return 'contact_form';
+
+  return 'inline';
+}
+
+function normalizeLang(rawLang) {
+  const lang = (rawLang || '').toLowerCase();
+
+  if (lang === 'es' || lang.startsWith('es-')) return 'es';
+  if (lang === 'en' || lang.startsWith('en-')) return 'en';
+
+  return 'unknown';
+}
+
+function getLeadIntent(element) {
+  if (element.dataset.leadIntent) return element.dataset.leadIntent;
+
+  const leadChannel = getLeadChannel(element);
+  const profile = getDatasetField(element, 'profile', 'general');
+  const profileStatus = getDatasetField(element, 'status', 'not_applicable');
+  const pageType = getDatasetField(element, 'pageType', 'unknown');
+  const ctaLocation = getCtaLocation(element);
+
+  if (leadChannel === 'whatsapp' && pageType === 'available-xolos') {
+    return 'price_inquiry';
+  }
+
+  if (leadChannel === 'email' && profileStatus === 'reserved') {
+    return 'similar_xolos';
+  }
+
+  if (leadChannel === 'email' && profile !== 'general') {
+    return 'profile_inquiry';
+  }
+
+  if (leadChannel === 'email' && pageType === 'home') {
+    return 'general_inquiry';
+  }
+
+  if (ctaLocation === 'contact_form') {
+    return 'contact_form';
+  }
+
+  return 'lead_inquiry';
+}
+
+function buildLeadPayload(element) {
+  const lang = element.dataset.lang || document.documentElement.lang;
+
+  return {
+    event: 'generate_lead',
+    lead_channel: getLeadChannel(element),
+    cta_location: getCtaLocation(element),
+    lead_intent: getLeadIntent(element),
+    profile: getDatasetField(element, 'profile', 'general'),
+    profile_status: getDatasetField(element, 'status', 'not_applicable'),
+    page_type: getDatasetField(element, 'pageType', 'unknown'),
+    lang: normalizeLang(lang),
+  };
+}
+
+function getLeadSignature(payload) {
+  return [
+    payload.lead_channel,
+    payload.cta_location,
+    payload.lead_intent,
+    payload.profile,
+    payload.profile_status,
+    payload.page_type,
+    payload.lang,
+  ].join('|');
+}
+
+function pushGenerateLead(payload) {
+  const now = Date.now();
+  const signature = getLeadSignature(payload);
+
+  if (
+    signature === lastGenerateLeadSignature &&
+    now - lastGenerateLeadAt < LEAD_DEDUPLICATION_MS
+  ) {
+    return;
+  }
+
+  lastGenerateLeadSignature = signature;
+  lastGenerateLeadAt = now;
+  window.dataLayer = window.dataLayer || [];
+  window.dataLayer.push(payload);
+}
+
+function shouldIgnoreLeadClick(element) {
+  const tagName = element.tagName.toLowerCase();
+  const type = (element.getAttribute('type') || '').toLowerCase();
+
+  return (
+    (tagName === 'button' && type === 'submit') ||
+    (tagName === 'input' && type === 'submit') ||
+    element.dataset.cta === 'contact-form' ||
+    Boolean(element.closest(CONTACT_FORM_SELECTOR))
+  );
+}
+
+document.addEventListener('click', (event) => {
+  const leadElement = getLeadElement(event.target);
+  if (!leadElement) return;
+  if (shouldIgnoreLeadClick(leadElement)) return;
+
+  pushGenerateLead(buildLeadPayload(leadElement));
+});
+
+document.addEventListener('submit', (event) => {
+  const form = event.target;
+  if (!(form instanceof HTMLFormElement)) return;
+  if (!form.matches(CONTACT_FORM_SELECTOR)) return;
+  if (!form.checkValidity()) return;
+
+  pushGenerateLead(buildLeadPayload(form));
+});

--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
     "lint:links": "linkinator https://xolosramirez.com --recurse --silent",
     "test:lighthouse:home": "lighthouse https://xolosramirez.com --only-categories=performance,accessibility,best-practices,seo --preset=desktop --output=html --output-path=./reports/lighthouse-home.html",
     "test:lighthouse:available": "lighthouse https://xolosramirez.com/xolos-disponibles.html --only-categories=performance,accessibility,best-practices,seo --preset=desktop --output=html --output-path=./reports/lighthouse-available.html",
-    "test:lighthouse:contact": "lighthouse https://xolosramirez.com/contacto.html --only-categories=performance,accessibility,best-practices,seo --preset=desktop --output=html --output-path=./reports/lighthouse-contact.html"
+    "test:lighthouse:contact": "lighthouse https://xolosramirez.com/contacto.html --only-categories=performance,accessibility,best-practices,seo --preset=desktop --output=html --output-path=./reports/lighthouse-contact.html",
+    "test:generate-lead": "node scripts/test-generate-lead-tracking.mjs"
   },
   "devDependencies": {
     "htmlhint": "^1.4.6",

--- a/scripts/test-generate-lead-tracking.mjs
+++ b/scripts/test-generate-lead-tracking.mjs
@@ -1,0 +1,121 @@
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+
+const read = (path) => readFileSync(path, 'utf8');
+const main = read('js/main.js');
+const leadCode = main.slice(main.indexOf('function getLeadElement'));
+
+function includes(haystack, needle, message) {
+  assert.ok(haystack.includes(needle), message || 'Expected to find ' + needle);
+}
+
+function notMatches(haystack, pattern, message) {
+  assert.equal(pattern.test(haystack), false, message || 'Unexpected match: ' + pattern);
+}
+
+function formTag(html) {
+  const match = html.match(/<form[\s\S]*?data-gtm="contact-form"[\s\S]*?>/);
+  assert.ok(match, 'Expected contact form with data-gtm="contact-form"');
+  return match[0];
+}
+
+includes(main, "document.addEventListener('click'", 'Expected delegated click listener');
+includes(main, "target.closest('[data-lead-type=\"generate_lead\"]')", 'Expected closest() based lead lookup');
+includes(main, "event: 'generate_lead'", 'Expected generate_lead event push');
+
+for (const key of [
+  'lead_channel',
+  'cta_location',
+  'lead_intent',
+  'profile',
+  'profile_status',
+  'page_type',
+  'lang',
+]) {
+  includes(leadCode, key, 'Expected payload parameter ' + key);
+}
+
+notMatches(leadCode, /\bvalue\b/, 'generate_lead must not send value');
+notMatches(leadCode, /\bcurrency\b/, 'generate_lead must not send currency');
+notMatches(leadCode, /\.value\b|new FormData|FormData\s*\(/, 'generate_lead must not read field values');
+notMatches(leadCode, /querySelector(?:All)?\(['"](?:input|textarea|select)/, 'generate_lead must not query form fields');
+notMatches(leadCode, /href|Click URL/i, 'generate_lead must not send href or Click URL');
+
+includes(main, 'LEAD_DEDUPLICATION_MS = 1500', 'Expected 1500 ms deduplication window');
+includes(main, 'getLeadSignature(payload)', 'Expected signature-based deduplication');
+includes(main, "tagName === 'button' && type === 'submit'", 'Click listener must ignore submit buttons');
+includes(main, "tagName === 'input' && type === 'submit'", 'Click listener must ignore submit inputs');
+includes(main, "element.dataset.cta === 'contact-form'", 'Click listener must ignore contact-form CTA clicks');
+includes(main, 'Boolean(element.closest(CONTACT_FORM_SELECTOR))', 'Click listener must ignore leads inside contact forms');
+includes(main, "document.addEventListener('submit'", 'Expected delegated submit listener');
+includes(main, 'form instanceof HTMLFormElement', 'Submit listener must require HTMLFormElement');
+includes(main, "form.matches(CONTACT_FORM_SELECTOR)", 'Submit listener must target contact form');
+includes(main, 'form.checkValidity()', 'Submit listener must only measure valid submissions');
+
+const contactEs = read('contacto.html');
+const contactEn = read('en/contact.html');
+const esForm = formTag(contactEs);
+const enForm = formTag(contactEn);
+for (const entry of [[esForm, 'es'], [enForm, 'en']]) {
+  const tag = entry[0];
+  const lang = entry[1];
+  includes(tag, 'data-lead-type="generate_lead"');
+  includes(tag, 'data-cta="form"');
+  includes(tag, 'data-profile="general"');
+  includes(tag, 'data-page-type="contact"');
+  includes(tag, 'data-lang="' + lang + '"');
+  includes(tag, 'data-cta-location="contact_form"');
+  includes(tag, 'data-lead-intent="contact_form"');
+  includes(tag, 'data-gtm="contact-form"');
+  includes(tag, 'action="https://formspree.io/f/xbdzegwj"');
+  includes(tag, 'method="POST"');
+  includes(tag, 'aria-label=');
+}
+
+for (const path of ['index.html', 'en/index.html']) {
+  const html = read(path);
+  assert.ok(/class="[^"]*(wa-float|home-email-float)[^"]*"[\s\S]*?data-cta="email"[\s\S]*?data-lead-type="generate_lead"/.test(html), path + ' must keep floating email lead CTA');
+}
+
+for (const path of ['xolos-disponibles.html', 'en/available-xolos.html']) {
+  const html = read(path);
+  assert.ok(/class="[^"]*wa-float[^"]*"[\s\S]*?data-cta="whatsapp"[\s\S]*?data-lead-type="generate_lead"/.test(html), path + ' must keep floating WhatsApp lead CTA');
+  assert.ok(/data-profile="(?!general)[^"]+"/.test(html), path + ' must keep profile slugs');
+  assert.ok(/data-status="(?:available|reserved|delivered|teyolia)"/.test(html), path + ' must keep profile statuses');
+}
+
+for (const path of [
+  'index.html',
+  'en/index.html',
+  'xolos-disponibles.html',
+  'en/available-xolos.html',
+  'contacto.html',
+  'en/contact.html',
+]) {
+  const html = read(path);
+  includes(html, 'GTM-MGTMWN7T', path + ' must keep GTM container');
+}
+
+for (const path of ['index.html', 'en/index.html', 'xolos-disponibles.html', 'en/available-xolos.html', 'contacto.html', 'en/contact.html']) {
+  const html = read(path);
+  const inlineLeadPattern = new RegExp('onclick=[^>]*' +
+    'generate_lead', 'i');
+  const inlineLeadMessage = path + ' must not add inline onclick ' +
+    'generate_lead';
+  notMatches(html, inlineLeadPattern, inlineLeadMessage);
+}
+
+const repoFiles = [
+  'js/main.js',
+  'index.html',
+  'en/index.html',
+  'xolos-disponibles.html',
+  'en/available-xolos.html',
+  'contacto.html',
+  'en/contact.html',
+];
+for (const path of repoFiles) {
+  notMatches(read(path), /gtag\(\s*['"]event['"]\s*,\s*['"]generate_lead['"]/i, path + ' must not send generate_lead through gtag');
+}
+
+console.log('generate_lead tracking checks passed');


### PR DESCRIPTION
## Objetivo

Emitir un único evento `generate_lead` hacia `dataLayer` para contactos por WhatsApp, correo y formularios.

## Implementación

- Seguimiento delegado mediante `closest()`.
- Parámetros estructurados:
  - `lead_channel`
  - `cta_location`
  - `lead_intent`
  - `profile`
  - `profile_status`
  - `page_type`
  - `lang`
- Formularios medidos únicamente mediante `submit` válido.
- Deduplicación defensiva de 1500 ms.
- Sin lectura ni envío de información personal.
- Documentación para GTM, GA4 y Google Ads.

## Validación

- `npm run test:generate-lead`
- `npm run lint:html`
- `git diff --check`

## Fuera de alcance

- Sin `gtag()` directo.
- Sin `onclick` para leads.
- Sin precios, `value` o `currency`.
- Sin cambios en `purchase`.
- Sin cambios en WalletConnect.
- Sin cambios en el contenedor GTM.