### PR TITLE
Remove selected Xochitl and Yohualli photos

### DIFF
--- a/en/available-xolos.html
+++ b/en/available-xolos.html
@@ -398,24 +398,6 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
 
               />
         </div>
-        <div class="puppy-carousel__slide">
-          <img
-                src="https://i.imgur.com/artsE6a.jpeg"
-                alt="Xoloitzcuintle Ozomatli Ramirez 2"
-                class="puppy-card__image"
-                loading="lazy"
-
-              />
-        </div>
-        <div class="puppy-carousel__slide">
-          <img
-                src="https://i.imgur.com/zyRGNA6.jpeg"
-                alt="Xoloitzcuintle Ozomatli Ramirez 3"
-                class="puppy-card__image"
-                loading="lazy"
-
-              />
-        </div>
       </div>
       <button class="puppy-carousel__button puppy-carousel__button--previous" type="button" aria-label="Previous photo">&#8592;</button>
       <button class="puppy-carousel__button puppy-carousel__button--next" type="button" aria-label="Next photo">&#8594;</button>
@@ -463,15 +445,6 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
           <img
                 src="https://i.imgur.com/e7htC5b.jpeg"
                 alt="Xoloitzcuintle Ozomatli Ramirez 2"
-                class="puppy-card__image"
-                loading="lazy"
-
-              />
-        </div>
-        <div class="puppy-carousel__slide">
-          <img
-                src="https://i.imgur.com/zyRGNA6.jpeg"
-                alt="Xoloitzcuintle Ozomatli Ramirez 3"
                 class="puppy-card__image"
                 loading="lazy"
 

--- a/xolos-disponibles.html
+++ b/xolos-disponibles.html
@@ -470,24 +470,6 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
 
           />
         </div>
-        <div class="puppy-carousel__slide">
-          <img
-          src="https://i.imgur.com/artsE6a.jpeg"
-          alt="Xoloitzcuintle Ozomatli Ramirez 2"
-          class="puppy-card__image"
-          loading="lazy"
-
-        />
-        </div>
-        <div class="puppy-carousel__slide">
-          <img
-          src="https://i.imgur.com/zyRGNA6.jpeg"
-          alt="Xoloitzcuintle Ozomatli Ramirez 3"
-          class="puppy-card__image"
-          loading="lazy"
-
-        />
-        </div>
       </div>
       <button class="puppy-carousel__button puppy-carousel__button--previous" type="button" aria-label="Foto anterior">&#8592;</button>
       <button class="puppy-carousel__button puppy-carousel__button--next" type="button" aria-label="Foto siguiente">&#8594;</button>
@@ -541,15 +523,6 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
           <img
           src="https://i.imgur.com/e7htC5b.jpeg"
           alt="Xoloitzcuintle Yohualli Ramirez 2"
-          class="puppy-card__image"
-          loading="lazy"
-
-        />
-        </div>
-        <div class="puppy-carousel__slide">
-          <img
-          src="https://i.imgur.com/zyRGNA6.jpeg"
-          alt="Xoloitzcuintle Ozomatli Ramirez 3"
           class="puppy-card__image"
           loading="lazy"
 


### PR DESCRIPTION
### Motivation
- Remove specific carousel photos from the Xochitl Ramirez and Yohualli Ramirez profiles to match the requested content update. 
- Keep Spanish and English pages consistent by applying the same removals to both locale files.

### Description
- Deleted the second and third `div.puppy-carousel__slide` entries for Xochitl in `xolos-disponibles.html` and `en/available-xolos.html`, leaving only the primary photo. 
- Deleted the third `div.puppy-carousel__slide` entry for Yohualli in `xolos-disponibles.html` and `en/available-xolos.html`, leaving two photos. 
- Resulting carousel slide counts are now Xochitl = 1 and Yohualli = 2 on both language pages.

### Testing
- Ran `npm run lint:html` (`htmlhint`) which scanned the project and reported "Scanned 162 files, no errors found". 
- Ran `git diff --check` with no whitespace or diff errors reported. 
- Executed a Python verification script that confirmed slide counts as `Xochitl: 1` and `Yohualli: 2` for both `xolos-disponibles.html` and `en/available-xolos.html`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a5e4d64f3d883329e541e9380e78a24)