### PR TITLE
feat: update Iztli profile photos video and size

### DIFF
--- a/en/available-xolos.html
+++ b/en/available-xolos.html
@@ -290,6 +290,24 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
 
       />
         </div>
+        <div class="puppy-carousel__slide">
+          <img
+        src="https://i.imgur.com/n1qEeLN.jpeg"
+        alt="Close-up portrait of newborn male Xoloitzcuintli Iztli Ramirez"
+        class="puppy-card__image"
+        loading="lazy"
+
+      />
+        </div>
+        <div class="puppy-carousel__slide">
+          <img
+        src="https://i.imgur.com/YVI378h.jpeg"
+        alt="Newborn male Xoloitzcuintli Iztli Ramirez held gently in hands"
+        class="puppy-card__image"
+        loading="lazy"
+
+      />
+        </div>
       </div>
       <button class="puppy-carousel__button puppy-carousel__button--previous" type="button" aria-label="Previous photo">&#8592;</button>
       <button class="puppy-carousel__button puppy-carousel__button--next" type="button" aria-label="Next photo">&#8594;</button>
@@ -304,7 +322,7 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
     <ul class="puppy-card__details">
       <li><strong>Age</strong>Newborn</li>
       <li><strong>Gender</strong>Male</li>
-      <li><strong>Size</strong>Miniature</li>
+      <li><strong>Size</strong>Small intermediate</li>
       <li><strong>Color</strong>Black</li>
     </ul>
 
@@ -313,7 +331,7 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
       <iframe
         width="100%"
         height="100%"
-        src="https://www.youtube.com/embed/EtWK6C4VAOU"
+        src="https://www.youtube.com/embed/pkxpkk_HrzM"
         title="Iztli Ramirez"
         frameborder="0"
         allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"

--- a/xolos-disponibles.html
+++ b/xolos-disponibles.html
@@ -353,6 +353,24 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
 
       />
         </div>
+        <div class="puppy-carousel__slide">
+          <img
+        src="https://i.imgur.com/n1qEeLN.jpeg"
+        alt="Primer plano de Iztli Ramirez, cachorro xoloitzcuintle macho recién nacido"
+        class="puppy-card__image"
+        loading="lazy"
+
+      />
+        </div>
+        <div class="puppy-carousel__slide">
+          <img
+        src="https://i.imgur.com/YVI378h.jpeg"
+        alt="Iztli Ramirez, cachorro xoloitzcuintle macho recién nacido sostenido entre las manos"
+        class="puppy-card__image"
+        loading="lazy"
+
+      />
+        </div>
       </div>
       <button class="puppy-carousel__button puppy-carousel__button--previous" type="button" aria-label="Foto anterior">&#8592;</button>
       <button class="puppy-carousel__button puppy-carousel__button--next" type="button" aria-label="Foto siguiente">&#8594;</button>
@@ -367,7 +385,7 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
     <ul class="puppy-card__details">
       <li><strong>Edad</strong>Recién nacido</li>
       <li><strong>Género</strong>Macho</li>
-      <li><strong>Talla</strong>Miniatura</li>
+      <li><strong>Talla</strong>Intermedia chica</li>
       <li><strong>Color</strong>Negro</li>
     </ul>
 
@@ -376,7 +394,7 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
       <iframe
         width="100%"
         height="100%"
-        src="https://www.youtube.com/embed/EtWK6C4VAOU"
+        src="https://www.youtube.com/embed/pkxpkk_HrzM"
         title="Iztli Ramirez"
         frameborder="0"
         allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"


### PR DESCRIPTION
### Motivation
- Update the Iztli Ramirez profile in both Spanish and English pages to add two newborn photos to the existing carousel, correct the reported size, and replace the embedded YouTube video while keeping the pages consistent and not touching other profiles.
- Preserve accessibility and carousel behavior by keeping existing carousel controls, `data-puppy-carousel` attributes, and iframe attributes intact.

### Description
- Inserted two new `<div class="puppy-carousel__slide">` slides immediately after the existing first slide in `xolos-disponibles.html` and `en/available-xolos.html`, each containing an `<img>` with `class="puppy-card__image"` and `loading="lazy"`, and the requested alt texts and image URLs (`https://i.imgur.com/n1qEeLN.jpeg` then `https://i.imgur.com/YVI378h.jpeg`).
- Replaced the size list item text in `xolos-disponibles.html` from `Miniatura` to `Intermedia chica` and in `en/available-xolos.html` from `Miniature` to `Small intermediate`.
- Replaced the Iztli iframe `src` in both files from `https://www.youtube.com/embed/EtWK6C4VAOU` to `https://www.youtube.com/embed/pkxpkk_HrzM` while preserving `title`, `allow`, `allowfullscreen`, `frameborder` and `loading="lazy"`.
- Limited edits to only `xolos-disponibles.html` and `en/available-xolos.html`, and only within the Iztli Ramirez profile sections; carousel controls, dots, aria-live messages and other attributes were not modified.

### Testing
- Ran `npm run lint:html` and the HTML linter completed with no errors.
- Executed a validation script that located the Iztli `<article>` in each file and confirmed each carousel contains exactly three slides in the required order with the specified `src` and `alt` values, the size strings are updated, the iframe `src` uses `https://www.youtube.com/embed/pkxpkk_HrzM`, and the old video id is not present; all checks passed.
- Reviewed the repository diff to confirm only the two target files were changed and modifications were limited to Iztli's profile; this review passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a60e87c02d083329bd4a7647cea1bce)