### PR TITLE
feat: update Xilonen carousel and video

### DIFF
--- a/en/available-xolos.html
+++ b/en/available-xolos.html
@@ -358,7 +358,28 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
         alt="Newborn Xoloitzcuintli Xilonen Ramirez"
         class="puppy-card__image"
         loading="lazy"
-
+        decoding="async"
+        draggable="false"
+      />
+        </div>
+        <div class="puppy-carousel__slide">
+          <img
+        src="https://i.imgur.com/QeNNg9H.jpeg"
+        alt="Close-up portrait of newborn female Xoloitzcuintli Xilonen Ramirez"
+        class="puppy-card__image"
+        loading="lazy"
+        decoding="async"
+        draggable="false"
+      />
+        </div>
+        <div class="puppy-carousel__slide">
+          <img
+        src="https://i.imgur.com/QN6BMnO.jpeg"
+        alt="Newborn female Xoloitzcuintli Xilonen Ramirez held gently in hands"
+        class="puppy-card__image"
+        loading="lazy"
+        decoding="async"
+        draggable="false"
       />
         </div>
       </div>
@@ -384,7 +405,7 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
       <iframe
         width="100%"
         height="100%"
-        src="https://www.youtube.com/embed/X0BeFE-pek0"
+        src="https://www.youtube.com/embed/-tOjo7jR67g"
         title="Xilonen Ramirez"
         frameborder="0"
         allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"

--- a/xolos-disponibles.html
+++ b/xolos-disponibles.html
@@ -421,7 +421,28 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
         alt="Xoloitzcuintle Xilonen Ramirez recién nacida"
         class="puppy-card__image"
         loading="lazy"
-
+        decoding="async"
+        draggable="false"
+      />
+        </div>
+        <div class="puppy-carousel__slide">
+          <img
+        src="https://i.imgur.com/QeNNg9H.jpeg"
+        alt="Primer plano de Xilonen Ramirez, cachorra xoloitzcuintle recién nacida"
+        class="puppy-card__image"
+        loading="lazy"
+        decoding="async"
+        draggable="false"
+      />
+        </div>
+        <div class="puppy-carousel__slide">
+          <img
+        src="https://i.imgur.com/QN6BMnO.jpeg"
+        alt="Xilonen Ramirez, cachorra xoloitzcuintle recién nacida sostenida entre las manos"
+        class="puppy-card__image"
+        loading="lazy"
+        decoding="async"
+        draggable="false"
       />
         </div>
       </div>
@@ -447,7 +468,7 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
       <iframe
         width="100%"
         height="100%"
-        src="https://www.youtube.com/embed/X0BeFE-pek0"
+        src="https://www.youtube.com/embed/-tOjo7jR67g"
         title="Xilonen Ramirez"
         frameborder="0"
         allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"


### PR DESCRIPTION
### Motivation
- Update the Xilonen Ramirez profiles (Spanish and English) to include two new photos in the existing carousel and replace an outdated YouTube embed with the provided video ID.

### Description
- Added two new `<div class="puppy-carousel__slide">` slides after the existing first image in both `xolos-disponibles.html` and `en/available-xolos.html` using the requested `src` and `alt` values and preserving the requested slide order.
- Added `decoding="async"` and `draggable="false"` to the images while keeping `class="puppy-card__image"` and `loading="lazy"` to match existing conventions.
- Replaced the iframe `src` from `https://www.youtube.com/embed/X0BeFE-pek0` to `https://www.youtube.com/embed/-tOjo7jR67g` in both files while preserving `title`, `loading`, `allowfullscreen`, `frameborder`, `width`, `height`, and `allow` attributes.
- Only modified `xolos-disponibles.html` and `en/available-xolos.html`, and retained the reusable carousel structure (`.puppy-carousel`, `[data-puppy-carousel]`, `.puppy-carousel__track`, `.puppy-carousel__slide`, nav buttons, `.puppy-carousel__dots`, `.puppy-carousel__live`) and all other requested content.

### Testing
- Ran the profile assertion script (`python3` inline script) that validated the three images (order and attributes), presence of the new embed `-tOjo7jR67g`, and absence of `X0BeFE-pek0`, and it passed.
- Ran `git diff --check` which reported no whitespace or diff-check issues.
- Ran `npm run lint:html` (uses `htmlhint`) which scanned HTML files and found no errors.
- Verified the commit was created and that only `xolos-disponibles.html` and `en/available-xolos.html` were changed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a60f0c26b948332bb133c02d007b720)