### PR TITLE
chore: remove outdated Iztli carousel photo

### DIFF
--- a/en/available-xolos.html
+++ b/en/available-xolos.html
@@ -283,15 +283,6 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
       <div class="puppy-carousel__track" tabindex="0">
         <div class="puppy-carousel__slide">
           <img
-        src="https://i.imgur.com/hhJ5WaL.jpeg"
-        alt="Newborn Xoloitzcuintli Iztli Ramirez"
-        class="puppy-card__image"
-        loading="lazy"
-
-      />
-        </div>
-        <div class="puppy-carousel__slide">
-          <img
         src="https://i.imgur.com/n1qEeLN.jpeg"
         alt="Close-up portrait of newborn male Xoloitzcuintli Iztli Ramirez"
         class="puppy-card__image"

--- a/xolos-disponibles.html
+++ b/xolos-disponibles.html
@@ -346,15 +346,6 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
       <div class="puppy-carousel__track" tabindex="0">
         <div class="puppy-carousel__slide">
           <img
-        src="https://i.imgur.com/hhJ5WaL.jpeg"
-        alt="Xoloitzcuintle Iztli Ramirez recién nacido"
-        class="puppy-card__image"
-        loading="lazy"
-
-      />
-        </div>
-        <div class="puppy-carousel__slide">
-          <img
         src="https://i.imgur.com/n1qEeLN.jpeg"
         alt="Primer plano de Iztli Ramirez, cachorro xoloitzcuintle macho recién nacido"
         class="puppy-card__image"


### PR DESCRIPTION
### Motivation
- Remove the outdated carousel slide for Iztli Ramirez so the profile displays only the two newest photos in both Spanish and English pages.

### Description
- Deleted the slide containing `https://i.imgur.com/hhJ5WaL.jpeg` from `xolos-disponibles.html` and `en/available-xolos.html`.
- Kept the two remaining slides in the exact order: `https://i.imgur.com/n1qEeLN.jpeg` then `https://i.imgur.com/YVI378h.jpeg`.
- Preserved the `div.puppy-carousel` container, `data-puppy-carousel`, `tabindex="0"` on the track, previous/next buttons, dots container, live region, accessibility attributes, video `https://www.youtube.com/embed/pkxpkk_HrzM`, size text (`Intermedia chica` / `Small intermediate`) and email links unchanged.
- Changes were limited to the Iztli carousel markup in the two files and did not affect other profiles, CSS, or JavaScript.

### Testing
- Executed a Python validation that confirms each Iztli article contains exactly two `puppy-carousel__slide` elements in the requested order and that `https://i.imgur.com/hhJ5WaL.jpeg` is absent; validation passed for both files.
- Verified the video URL, size texts, accessibility attributes, and contact links remain present and unchanged.
- Ran `git diff --check` and `git diff --numstat` to ensure there are no whitespace errors and to inspect the file diffs; checks passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a60f51ab9f4833295a3763d7c11b8da)