### PR TITLE
chore: remove older Xilonen carousel photo

### DIFF
--- a/en/available-xolos.html
+++ b/en/available-xolos.html
@@ -354,16 +354,6 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
       <div class="puppy-carousel__track" tabindex="0">
         <div class="puppy-carousel__slide">
           <img
-        src="https://i.imgur.com/6z2dW6v.jpeg"
-        alt="Newborn Xoloitzcuintli Xilonen Ramirez"
-        class="puppy-card__image"
-        loading="lazy"
-        decoding="async"
-        draggable="false"
-      />
-        </div>
-        <div class="puppy-carousel__slide">
-          <img
         src="https://i.imgur.com/QeNNg9H.jpeg"
         alt="Close-up portrait of newborn female Xoloitzcuintli Xilonen Ramirez"
         class="puppy-card__image"

--- a/xolos-disponibles.html
+++ b/xolos-disponibles.html
@@ -417,16 +417,6 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
       <div class="puppy-carousel__track" tabindex="0">
         <div class="puppy-carousel__slide">
           <img
-        src="https://i.imgur.com/6z2dW6v.jpeg"
-        alt="Xoloitzcuintle Xilonen Ramirez recién nacida"
-        class="puppy-card__image"
-        loading="lazy"
-        decoding="async"
-        draggable="false"
-      />
-        </div>
-        <div class="puppy-carousel__slide">
-          <img
         src="https://i.imgur.com/QeNNg9H.jpeg"
         alt="Primer plano de Xilonen Ramirez, cachorra xoloitzcuintle recién nacida"
         class="puppy-card__image"


### PR DESCRIPTION
### Motivation
- Eliminar la fotografía más antigua del carrusel del perfil de Xilonen Ramirez en las versiones en español e inglés para que queden solo sus dos fotos más recientes en el orden requerido.

### Description
- Eliminé el elemento `.puppy-carousel__slide` que contenía la imagen `https://i.imgur.com/6z2dW6v.jpeg` en `xolos-disponibles.html` y en `en/available-xolos.html`.
- Aseguré que el track del carrusel contenga exactamente las dos imágenes restantes en el orden `https://i.imgur.com/QeNNg9H.jpeg` seguido de `https://i.imgur.com/QN6BMnO.jpeg` y que los textos alternativos coincidan con los solicitados.
- Conservé intactos el contenedor `.puppy-carousel`, el atributo `data-puppy-carousel`, los botones, los puntos, el elemento `.puppy-carousel__live`, el video de YouTube, las referencias y todos los demás perfiles y metadatos.

### Testing
- Ejecuté una validación con `python3` que comprobó que cada perfil de Xilonen contiene exactamente 2 elementos `.puppy-carousel__slide`, que `QeNNg9H.jpeg` aparece antes que `QN6BMnO.jpeg`, que `6z2dW6v.jpeg` no aparece y que el video y la referencia están presentes, y la validación pasó.
- Ejecuté el linter `npx htmlhint xolos-disponibles.html en/available-xolos.html` y no se reportaron errores.
- Realicé comprobaciones de diff/status del repositorio para confirmar que únicamente se modificaron `xolos-disponibles.html` y `en/available-xolos.html` y que el diff muestra la eliminación esperada del slide antiguo.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a60f52db7ac83329ad5232abf0e0c20)