### PR TITLE
Update Yohualli Ramirez photos and video

### DIFF
--- a/en/available-xolos.html
+++ b/en/available-xolos.html
@@ -454,19 +454,23 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
       <div class="puppy-carousel__track" tabindex="0">
         <div class="puppy-carousel__slide">
           <img
-                src="https://i.imgur.com/QL6ZGl6.jpeg"
-                alt="Xoloitzcuintle Yohualli Ramirez"
+                src="https://i.imgur.com/8Gz0PYU.jpeg"
+                alt="Yohualli Ramirez, newborn female Xoloitzcuintli puppy, photo 1"
                 class="puppy-card__image"
                 loading="lazy"
+                decoding="async"
+                draggable="false"
 
               />
         </div>
         <div class="puppy-carousel__slide">
           <img
-                src="https://i.imgur.com/e7htC5b.jpeg"
-                alt="Xoloitzcuintle Ozomatli Ramirez 2"
+                src="https://i.imgur.com/IpXYwO3.jpeg"
+                alt="Yohualli Ramirez, newborn female Xoloitzcuintli puppy, photo 2"
                 class="puppy-card__image"
                 loading="lazy"
+                decoding="async"
+                draggable="false"
 
               />
         </div>
@@ -487,7 +491,7 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
             </ul>
 
              <div class="puppy-video-container" style="margin: 1rem 0; border-radius: 8px; overflow: hidden; aspect-ratio: 16/9;">
-    <iframe width="100%" height="100%" src="https://www.youtube.com/embed/2CJfI4QumzM" title="Yohualli Ramirez" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen loading="lazy"></iframe>
+    <iframe width="100%" height="100%" src="https://www.youtube.com/embed/WJxXzy27oP0" title="Yohualli Ramirez" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen loading="lazy"></iframe>
   </div>
 
   <div class="puppy-card__actions">

--- a/xolos-disponibles.html
+++ b/xolos-disponibles.html
@@ -532,19 +532,23 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
       <div class="puppy-carousel__track" tabindex="0">
         <div class="puppy-carousel__slide">
           <img
-          src="https://i.imgur.com/QL6ZGl6.jpeg"
-          alt="Xoloitzcuintle Yohualli Ramirez"
+          src="https://i.imgur.com/8Gz0PYU.jpeg"
+          alt="Yohualli Ramirez, cachorra xoloitzcuintle hembra recién nacida, fotografía 1"
           class="puppy-card__image"
           loading="lazy"
+          decoding="async"
+          draggable="false"
 
           />
         </div>
         <div class="puppy-carousel__slide">
           <img
-          src="https://i.imgur.com/e7htC5b.jpeg"
-          alt="Xoloitzcuintle Yohualli Ramirez 2"
+          src="https://i.imgur.com/IpXYwO3.jpeg"
+          alt="Yohualli Ramirez, cachorra xoloitzcuintle hembra recién nacida, fotografía 2"
           class="puppy-card__image"
           loading="lazy"
+          decoding="async"
+          draggable="false"
 
         />
         </div>
@@ -565,7 +569,7 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
       </ul>
 
       <div class="puppy-video-container" style="margin: 1rem 0; border-radius: 8px; overflow: hidden; aspect-ratio: 16/9;">
-    <iframe width="100%" height="100%" src="https://www.youtube.com/embed/2CJfI4QumzM" title="Yohualli Ramirez" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen loading="lazy"></iframe>
+    <iframe width="100%" height="100%" src="https://www.youtube.com/embed/WJxXzy27oP0" title="Yohualli Ramirez" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen loading="lazy"></iframe>
   </div>
 
   <div class="puppy-card__actions">


### PR DESCRIPTION
### Motivation
- Actualizar las fotografías y el video del perfil de Yohualli Ramirez en las versiones en español e inglés manteniendo la estructura y accesibilidad del carrusel.
- Corregir el `alt` incorrecto en la versión inglesa que referenciaba a otro ejemplar y asegurar que los nuevos assets reemplacen por completo a los anteriores.

### Description
- Reemplacé las dos imágenes del carrusel de Yohualli en `xolos-disponibles.html` y `en/available-xolos.html` por `https://i.imgur.com/8Gz0PYU.jpeg` (primera) y `https://i.imgur.com/IpXYwO3.jpeg` (segunda), y actualicé sus textos alternativos a los locales solicitados. 
- Añadí `decoding="async"` y `draggable="false"` a las imágenes nuevas manteniendo `class="puppy-card__image"` y `loading="lazy"` tal como se requería. 
- Sustituí el `src` del `iframe` de YouTube en ambos archivos por `https://www.youtube.com/embed/WJxXzy27oP0` conservando `title="Yohualli Ramirez"`, `frameborder`, `allow`, `allowfullscreen` y `loading="lazy"`. 
- Conservé intacta la estructura y funcionalidad del carrusel (atributos `data-puppy-carousel`, `puppy-carousel__track`, `puppy-carousel__slide`, botones, `puppy-carousel__dots`, `puppy-carousel__live` y ARIA en cada idioma).

### Testing
- Ejecuté un script de verificación que comprobó que `8Gz0PYU.jpeg` y `IpXYwO3.jpeg` aparecen exactamente una vez en cada archivo, que `WJxXzy27oP0` aparece una vez en cada archivo, y que `QL6ZGl6.jpeg`, `e7htC5b.jpeg` y `2CJfI4QumzM` ya no aparecen; la verificación pasó correctamente. 
- Ejecuté `git diff --check` para detectar problemas de espacios en blanco y no se reportaron errores. 
- Ejecuté `npm run lint:html -- xolos-disponibles.html en/available-xolos.html` (HTMLHint) y el linter revisó los archivos sin reportar errores.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a62542494648332913a4641c34339a7)