### PR TITLE
Add English guardianship profiles for Ozomatli and Nox (6 months)

### DIFF
--- a/en/teyolias-guardianship.html
+++ b/en/teyolias-guardianship.html
@@ -446,6 +446,110 @@
                     </div>
                 </article>
 
+                <article class="rounded-2xl border border-amber-200 bg-amber-50 overflow-hidden shadow-sm">
+                    <div class="grid grid-cols-1 md:grid-cols-5 gap-0 h-full">
+                        <div class="md:col-span-2 bg-stone-950 relative h-[28rem] md:h-full min-h-[430px]" data-carousel data-carousel-name="Ozomatli Ramírez">
+                            <div class="teyolia-carousel-track carousel-scrollbar-hidden" data-carousel-track aria-label="Photos and video of Ozomatli Ramírez">
+                                <div class="teyolia-carousel-slide teyolia-carousel-image-slide" data-carousel-slide>
+                                    <img src="https://i.imgur.com/GGRUvHI.png" alt="Ozomatli Ramírez, Active Teyolía" loading="lazy" />
+                                </div>
+                                <div class="teyolia-carousel-slide teyolia-carousel-image-slide" data-carousel-slide>
+                                    <img src="https://i.imgur.com/artsE6a.jpeg" alt="Ozomatli Ramírez, Active Teyolía" loading="lazy" />
+                                </div>
+                                <div class="teyolia-carousel-slide teyolia-carousel-image-slide" data-carousel-slide>
+                                    <img src="https://i.imgur.com/zyRGNA6.jpeg" alt="Ozomatli Ramírez, Active Teyolía" loading="lazy" />
+                                </div>
+                                <div class="teyolia-carousel-slide teyolia-carousel-video-slide" data-carousel-slide>
+                                    <iframe src="https://www.youtube.com/embed/tL_jiakmL1o?playsinline=1" title="Ozomatli Ramírez Video" loading="lazy" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" referrerpolicy="strict-origin-when-cross-origin" allowfullscreen></iframe>
+                                </div>
+                            </div>
+                            <button class="teyolia-carousel-button teyolia-carousel-button--prev" type="button" data-carousel-prev aria-label="View previous slide of Ozomatli">‹</button>
+                            <button class="teyolia-carousel-button teyolia-carousel-button--next" type="button" data-carousel-next aria-label="View next slide of Ozomatli">›</button>
+                            <div class="absolute bottom-4 left-0 right-0 flex flex-col items-center gap-3 pointer-events-none">
+                                <div class="teyolia-carousel-dots pointer-events-auto" data-carousel-dots aria-label="Carousel pagination for Ozomatli"></div>
+                                <div class="bg-black/60 text-amber-100 text-xs font-bold px-4 py-2 rounded-full backdrop-blur-md flex items-center gap-2 shadow-lg border border-amber-500/30">
+                                    <span aria-hidden="true">↔</span> Swipe
+                                </div>
+                            </div>
+                        </div>
+
+                        <div class="md:col-span-3 p-6 text-left flex flex-col justify-center">
+                            <p class="text-xs uppercase tracking-widest text-amber-700 font-bold mb-2">
+                                Available · 6 months
+                            </p>
+                            <h4 class="text-2xl font-serif font-bold text-stone-900 mb-3">
+                                Ozomatli Ramírez
+                            </h4>
+                            <ul class="text-sm text-stone-700 space-y-1 mb-5">
+                                <li><strong>Age:</strong> 6 months</li>
+                                <li><strong>Gender:</strong> Male</li>
+                                <li><strong>Size:</strong> Standard</li>
+                                <li><strong>Color:</strong> Black</li>
+                            </ul>
+                            <p class="text-stone-700 text-sm leading-relaxed mb-5">
+                                Ozomatli has reached the age required to join the Teyolías Guardianship program. Interested families may request information and apply as prospective guardians.
+                            </p>
+                            <div>
+                                <a href="mailto:fernando@xolosramirez.com?subject=Application%20for%20Ozomatli%20Ram%C3%ADrez%27s%20Teyol%C3%ADa%20Guardianship&amp;body=Hello%2C%0A%0AI%20am%20interested%20in%20applying%20as%20a%20guardian%20for%20Ozomatli%20Ram%C3%ADrez%20through%20the%20Teyol%C3%ADas%20Guardianship%20program.%0A%0ACity%20or%20country%3A%0AType%20of%20home%3A%0APrevious%20experience%20with%20dogs%3A%0AWhatsApp%20contact%20number%3A%0A%0AThank%20you." class="inline-block bg-stone-900 text-amber-500 px-5 py-3 rounded-full font-bold hover:bg-amber-600 hover:text-stone-900 transition-all">
+                                    Apply for Ozomatli's Teyolía ✨
+                                </a>
+                            </div>
+                        </div>
+                    </div>
+                </article>
+
+                <article class="rounded-2xl border border-amber-200 bg-amber-50 overflow-hidden shadow-sm">
+                    <div class="grid grid-cols-1 md:grid-cols-5 gap-0 h-full">
+                        <div class="md:col-span-2 bg-stone-950 relative h-[28rem] md:h-full min-h-[430px]" data-carousel data-carousel-name="Nox Ramírez">
+                            <div class="teyolia-carousel-track carousel-scrollbar-hidden" data-carousel-track aria-label="Photos and video of Nox Ramírez">
+                                <div class="teyolia-carousel-slide teyolia-carousel-image-slide" data-carousel-slide>
+                                    <img src="https://i.imgur.com/jLNvtQk.jpeg" alt="Nox Ramírez, Active Teyolía" loading="lazy" />
+                                </div>
+                                <div class="teyolia-carousel-slide teyolia-carousel-image-slide" data-carousel-slide>
+                                    <img src="https://i.imgur.com/WilqbGs.jpeg" alt="Nox Ramírez, Active Teyolía" loading="lazy" />
+                                </div>
+                                <div class="teyolia-carousel-slide teyolia-carousel-image-slide" data-carousel-slide>
+                                    <img src="https://i.imgur.com/tvovZ8K.jpeg" alt="Nox Ramírez, Active Teyolía" loading="lazy" />
+                                </div>
+                                <div class="teyolia-carousel-slide teyolia-carousel-video-slide" data-carousel-slide>
+                                    <iframe src="https://www.youtube.com/embed/Kk2nixqtj74?playsinline=1" title="Nox Ramírez Video" loading="lazy" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" referrerpolicy="strict-origin-when-cross-origin" allowfullscreen></iframe>
+                                </div>
+                            </div>
+                            <button class="teyolia-carousel-button teyolia-carousel-button--prev" type="button" data-carousel-prev aria-label="View previous slide of Nox">‹</button>
+                            <button class="teyolia-carousel-button teyolia-carousel-button--next" type="button" data-carousel-next aria-label="View next slide of Nox">›</button>
+                            <div class="absolute bottom-4 left-0 right-0 flex flex-col items-center gap-3 pointer-events-none">
+                                <div class="teyolia-carousel-dots pointer-events-auto" data-carousel-dots aria-label="Carousel pagination for Nox"></div>
+                                <div class="bg-black/60 text-amber-100 text-xs font-bold px-4 py-2 rounded-full backdrop-blur-md flex items-center gap-2 shadow-lg border border-amber-500/30">
+                                    <span aria-hidden="true">↔</span> Swipe
+                                </div>
+                            </div>
+                        </div>
+
+                        <div class="md:col-span-3 p-6 text-left flex flex-col justify-center">
+                            <p class="text-xs uppercase tracking-widest text-amber-700 font-bold mb-2">
+                                Available · 6 months
+                            </p>
+                            <h4 class="text-2xl font-serif font-bold text-stone-900 mb-3">
+                                Nox Ramírez
+                            </h4>
+                            <ul class="text-sm text-stone-700 space-y-1 mb-5">
+                                <li><strong>Age:</strong> 6 months</li>
+                                <li><strong>Gender:</strong> Male</li>
+                                <li><strong>Size:</strong> Standard</li>
+                                <li><strong>Color:</strong> Black</li>
+                            </ul>
+                            <p class="text-stone-700 text-sm leading-relaxed mb-5">
+                                Nox has reached the age required to join the Teyolías Guardianship program. Interested families may request information and apply as prospective guardians.
+                            </p>
+                            <div>
+                                <a href="mailto:fernando@xolosramirez.com?subject=Application%20for%20Nox%20Ram%C3%ADrez%27s%20Teyol%C3%ADa%20Guardianship&amp;body=Hello%2C%0A%0AI%20am%20interested%20in%20applying%20as%20a%20guardian%20for%20Nox%20Ram%C3%ADrez%20through%20the%20Teyol%C3%ADas%20Guardianship%20program.%0A%0ACity%20or%20country%3A%0AType%20of%20home%3A%0APrevious%20experience%20with%20dogs%3A%0AWhatsApp%20contact%20number%3A%0A%0AThank%20you." class="inline-block bg-stone-900 text-amber-500 px-5 py-3 rounded-full font-bold hover:bg-amber-600 hover:text-stone-900 transition-all">
+                                    Apply for Nox's Teyolía ✨
+                                </a>
+                            </div>
+                        </div>
+                    </div>
+                </article>
+
                 
             </div>
         </section>


### PR DESCRIPTION
### Motivation
- Add the English versions of Ozomatli Ramírez and Nox Ramírez to the `Active Teyolías` grid so they are available on the English guardianship page with their current age set to `6 months`.
- Preserve existing layout, accessibility, and carousel behavior while providing pre-filled contact CTAs for guardian applications.

### Description
- Inserted two new `<article>` cards for Ozomatli Ramírez and Nox Ramírez immediately after the Puka Ramírez card inside the `div` with `class="grid grid-cols-1 md:grid-cols-2 gap-6"` in `en/teyolias-guardianship.html`.
- Each card uses the same visual structure and classes as existing cards and includes a `data-carousel` carousel with `data-carousel-track`, four `data-carousel-slide` entries (three `img` slides with `loading="lazy"` followed by a YouTube `iframe`), `data-carousel-prev`, `data-carousel-next`, and `data-carousel-dots` controls and ARIA labels that reference the specimen name.
- Each profile shows `Available · 6 months`, the requested fields (`Age`, `Gender`, `Size`, `Color`), the provided three images (kept in the specified order) and the specified video as the final slide.
- Added `mailto:` CTAs targeting `fernando@xolosramirez.com` with URL-encoded `subject` and `body`, using `&amp;` between parameters; no CSS or JS files were modified.

### Testing
- Ran a custom HTML validation script (`python3` inline) that asserts well-formed tag nesting, a single card per new specimen, `6 months` age, presence and order of three images then video, four carousel slides, and correct `data-carousel`/ARIA attributes, which passed.
- Ran `npm run lint:html -- en/teyolias-guardianship.html` (HTMLHint) with no errors reported.
- Ran `git diff --check` to ensure no whitespace issues and verified via `git diff --name-only` and `git status --short` that only `en/teyolias-guardianship.html` was changed and the repository is clean after committing.
- Committed the change with message `Add English guardianship profiles for Ozomatli and Nox` and prepared the PR metadata.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a625a2b68b48332a5f98140b70374b7)