### PR TITLE
Mover perfil de Nox Ramírez a Xolos disponibles

### DIFF
--- a/en/available-xolos.html
+++ b/en/available-xolos.html
@@ -338,6 +338,9 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
   </div>
 </article>
 
+
+
+
 <article class="puppy-card" data-aos="fade-up" data-aos-duration="800" data-aos-delay="200">
   <div class="puppy-card__image-wrapper">
     <span class="puppy-card__status status-disponible">Available</span>
@@ -405,6 +408,46 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
 
 
         <article class="puppy-card" data-aos="fade-up" data-aos-duration="800" data-aos-delay="200">
+          <div class="puppy-card__image-wrapper">
+            <span class="puppy-card__status status-disponible">Reserved</span>
+            <span class="puppy-card__status" style="top: 40px; background-color: #ff4d4d; color: #fff;">by Román Morales</span>
+            <div class="puppy-carousel" data-puppy-carousel role="region" aria-roledescription="carousel" aria-label="Nox Ramírez photo carousel">
+              <div class="puppy-carousel__track" tabindex="0">
+                <div class="puppy-carousel__slide">
+                  <img src="https://i.imgur.com/jLNvtQk.jpeg" alt="Nox Ramírez Xoloitzcuintle" class="puppy-card__image" loading="lazy" decoding="async" draggable="false" />
+                </div>
+                <div class="puppy-carousel__slide">
+                  <img src="https://i.imgur.com/WilqbGs.jpeg" alt="Nox Ramírez Xoloitzcuintle" class="puppy-card__image" loading="lazy" decoding="async" draggable="false" />
+                </div>
+                <div class="puppy-carousel__slide">
+                  <img src="https://i.imgur.com/tvovZ8K.jpeg" alt="Nox Ramírez Xoloitzcuintle" class="puppy-card__image" loading="lazy" decoding="async" draggable="false" />
+                </div>
+              </div>
+              <button class="puppy-carousel__button puppy-carousel__button--previous" type="button" aria-label="Previous photo">&#8592;</button>
+              <button class="puppy-carousel__button puppy-carousel__button--next" type="button" aria-label="Next photo">&#8594;</button>
+              <div class="puppy-carousel__dots" aria-label="Select photo"></div>
+              <p class="puppy-carousel__live" aria-live="polite" aria-atomic="true"></p>
+            </div>
+          </div>
+          <div class="puppy-card__content">
+            <h3 class="puppy-card__name">Nox Ramírez</h3>
+            <ul class="puppy-card__details">
+              <li><strong>Age</strong>6 months</li>
+              <li><strong>Gender</strong>Male</li>
+              <li><strong>Size</strong>Standard</li>
+              <li><strong>Color</strong>Black</li>
+              <li><strong>Coat</strong>Hairless</li>
+            </ul>
+            <div class="puppy-video-container" style="margin: 1rem 0; border-radius: 8px; overflow: hidden; aspect-ratio: 16/9;">
+              <iframe width="100%" height="100%" src="https://www.youtube.com/embed/oxsIzDwxZKw" title="Nox Ramírez" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen loading="lazy"></iframe>
+            </div>
+            <div class="puppy-card__actions">
+              <a href="mailto:fernando@xolosramirez.com?subject=Inquiry%20about%20a%20Xoloitzcuintle%20similar%20to%20Nox%20Ram%C3%ADrez%20%5BRef%3A%20nox-en-reserved%5D&amp;body=Hello%2C%0A%0AI%20saw%20Nox%20Ram%C3%ADrez%27s%20profile%20and%20understand%20this%20Xoloitzcuintle%20is%20currently%20reserved.%0A%0AI%20am%20interested%20in%20future%20litters%20or%20a%20Xoloitzcuintle%20with%20similar%20characteristics." class="btn-small btn-primary-small cta-lead cta-email" data-cta="email" data-lead-type="generate_lead" data-profile="nox" data-page-type="available-xolos" data-lang="en" aria-label="Contact by email about Xolos similar to Nox" data-status="reserved">Contact via Email</a>
+            </div>
+          </div>
+        </article>
+
+<article class="puppy-card" data-aos="fade-up" data-aos-duration="800" data-aos-delay="200">
           <div class="puppy-card__image-wrapper">
     <span class="puppy-card__status status-disponible">Reserved</span>
     <div class="puppy-carousel" data-puppy-carousel role="region" aria-roledescription="carousel" aria-label="Xochitl Ramirez photo carousel">

--- a/en/teyolias-guardianship.html
+++ b/en/teyolias-guardianship.html
@@ -498,58 +498,6 @@
                     </div>
                 </article>
 
-                <article class="rounded-2xl border border-amber-200 bg-amber-50 overflow-hidden shadow-sm">
-                    <div class="grid grid-cols-1 md:grid-cols-5 gap-0 h-full">
-                        <div class="md:col-span-2 bg-stone-950 relative h-[28rem] md:h-full min-h-[430px]" data-carousel data-carousel-name="Nox Ramírez">
-                            <div class="teyolia-carousel-track carousel-scrollbar-hidden" data-carousel-track aria-label="Photos and video of Nox Ramírez">
-                                <div class="teyolia-carousel-slide teyolia-carousel-image-slide" data-carousel-slide>
-                                    <img src="https://i.imgur.com/jLNvtQk.jpeg" alt="Nox Ramírez, Active Teyolía" loading="lazy" />
-                                </div>
-                                <div class="teyolia-carousel-slide teyolia-carousel-image-slide" data-carousel-slide>
-                                    <img src="https://i.imgur.com/WilqbGs.jpeg" alt="Nox Ramírez, Active Teyolía" loading="lazy" />
-                                </div>
-                                <div class="teyolia-carousel-slide teyolia-carousel-image-slide" data-carousel-slide>
-                                    <img src="https://i.imgur.com/tvovZ8K.jpeg" alt="Nox Ramírez, Active Teyolía" loading="lazy" />
-                                </div>
-                                <div class="teyolia-carousel-slide teyolia-carousel-video-slide" data-carousel-slide>
-                                    <iframe src="https://www.youtube.com/embed/Kk2nixqtj74?playsinline=1" title="Nox Ramírez Video" loading="lazy" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" referrerpolicy="strict-origin-when-cross-origin" allowfullscreen></iframe>
-                                </div>
-                            </div>
-                            <button class="teyolia-carousel-button teyolia-carousel-button--prev" type="button" data-carousel-prev aria-label="View previous slide of Nox">‹</button>
-                            <button class="teyolia-carousel-button teyolia-carousel-button--next" type="button" data-carousel-next aria-label="View next slide of Nox">›</button>
-                            <div class="absolute bottom-4 left-0 right-0 flex flex-col items-center gap-3 pointer-events-none">
-                                <div class="teyolia-carousel-dots pointer-events-auto" data-carousel-dots aria-label="Carousel pagination for Nox"></div>
-                                <div class="bg-black/60 text-amber-100 text-xs font-bold px-4 py-2 rounded-full backdrop-blur-md flex items-center gap-2 shadow-lg border border-amber-500/30">
-                                    <span aria-hidden="true">↔</span> Swipe
-                                </div>
-                            </div>
-                        </div>
-
-                        <div class="md:col-span-3 p-6 text-left flex flex-col justify-center">
-                            <p class="text-xs uppercase tracking-widest text-amber-700 font-bold mb-2">
-                                Available · 6 months
-                            </p>
-                            <h4 class="text-2xl font-serif font-bold text-stone-900 mb-3">
-                                Nox Ramírez
-                            </h4>
-                            <ul class="text-sm text-stone-700 space-y-1 mb-5">
-                                <li><strong>Age:</strong> 6 months</li>
-                                <li><strong>Gender:</strong> Male</li>
-                                <li><strong>Size:</strong> Standard</li>
-                                <li><strong>Color:</strong> Black</li>
-                            </ul>
-                            <p class="text-stone-700 text-sm leading-relaxed mb-5">
-                                Nox has reached the age required to join the Teyolías Guardianship program. Interested families may request information and apply as prospective guardians.
-                            </p>
-                            <div>
-                                <a href="mailto:fernando@xolosramirez.com?subject=Application%20for%20Nox%20Ram%C3%ADrez%27s%20Teyol%C3%ADa%20Guardianship&amp;body=Hello%2C%0A%0AI%20am%20interested%20in%20applying%20as%20a%20guardian%20for%20Nox%20Ram%C3%ADrez%20through%20the%20Teyol%C3%ADas%20Guardianship%20program.%0A%0ACity%20or%20country%3A%0AType%20of%20home%3A%0APrevious%20experience%20with%20dogs%3A%0AWhatsApp%20contact%20number%3A%0A%0AThank%20you." class="inline-block bg-stone-900 text-amber-500 px-5 py-3 rounded-full font-bold hover:bg-amber-600 hover:text-stone-900 transition-all">
-                                    Apply for Nox's Teyolía ✨
-                                </a>
-                            </div>
-                        </div>
-                    </div>
-                </article>
-
                 
             </div>
         </section>

--- a/teyolias-guardiania.html
+++ b/teyolias-guardiania.html
@@ -557,29 +557,6 @@
             </div>
         </article>
 
-        <article class="rounded-2xl border border-amber-200 bg-amber-50 overflow-hidden shadow-sm">
-            <div class="grid grid-cols-1 md:grid-cols-5 gap-0 h-full">
-                <div class="md:col-span-2 bg-stone-950 relative h-[28rem] md:h-full min-h-[430px]" data-carousel data-carousel-name="Nox Ramírez">
-                    <div class="teyolia-carousel-track carousel-scrollbar-hidden" data-carousel-track aria-label="Fotos y video de Nox Ramírez">
-                        <div class="teyolia-carousel-slide teyolia-carousel-image-slide" data-carousel-slide><img src="https://i.imgur.com/jLNvtQk.jpeg" alt="Nox Ramírez, Teyolía activa — fotografía 1" loading="lazy" /></div>
-                        <div class="teyolia-carousel-slide teyolia-carousel-image-slide" data-carousel-slide><img src="https://i.imgur.com/WilqbGs.jpeg" alt="Nox Ramírez, Teyolía activa — fotografía 2" loading="lazy" /></div>
-                        <div class="teyolia-carousel-slide teyolia-carousel-image-slide" data-carousel-slide><img src="https://i.imgur.com/tvovZ8K.jpeg" alt="Nox Ramírez, Teyolía activa — fotografía 3" loading="lazy" /></div>
-                        <div class="teyolia-carousel-slide teyolia-carousel-video-slide" data-carousel-slide><iframe src="https://www.youtube.com/embed/Kk2nixqtj74?playsinline=1" title="Video Nox Ramírez" loading="lazy" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" referrerpolicy="strict-origin-when-cross-origin" allowfullscreen></iframe></div>
-                    </div>
-                    <button class="teyolia-carousel-button teyolia-carousel-button--prev" type="button" data-carousel-prev aria-label="Ver slide anterior de Nox">‹</button>
-                    <button class="teyolia-carousel-button teyolia-carousel-button--next" type="button" data-carousel-next aria-label="Ver slide siguiente de Nox">›</button>
-                    <div class="absolute bottom-4 left-0 right-0 flex flex-col items-center gap-3 pointer-events-none"><div class="teyolia-carousel-dots pointer-events-auto" data-carousel-dots aria-label="Paginación del carrusel de Nox"></div><div class="bg-black/60 text-amber-100 text-xs font-bold px-4 py-2 rounded-full backdrop-blur-md flex items-center gap-2 shadow-lg border border-amber-500/30"><span aria-hidden="true">↔</span> Desliza</div></div>
-                </div>
-                <div class="md:col-span-3 p-6 text-left flex flex-col justify-center">
-                    <p class="text-xs uppercase tracking-widest text-amber-700 font-bold mb-2">Disponible · 6 meses</p>
-                    <h4 class="text-2xl font-serif font-bold text-stone-900 mb-3">Nox Ramírez</h4>
-                    <ul class="text-sm text-stone-700 space-y-1 mb-5"><li><strong>Edad:</strong> 6 meses</li><li><strong>Género:</strong> Macho</li><li><strong>Talla:</strong> Estándar</li><li><strong>Color:</strong> Negro</li></ul>
-                    <p class="text-stone-700 text-sm leading-relaxed mb-5">Nox ha alcanzado la edad necesaria para integrarse al programa de Guardianía Teyolías. Las familias interesadas pueden solicitar información para postularse como aspirantes a guardianes.</p>
-                    <div><a href="mailto:fernando@xolosramirez.com?subject=Quiero%20participar%20en%20la%20Teyol%C3%ADa%20de%20Nox%20Ram%C3%ADrez&body=Hola%2C%0A%0AMe%20interesa%20participar%20en%20la%20Teyol%C3%ADa%20de%20Nox%20Ram%C3%ADrez.%0A%0ACiudad%20o%20pa%C3%ADs%3A%0ATipo%20de%20hogar%3A%0AExperiencia%20previa%20con%20perros%3A%0AN%C3%BAmero%20de%20WhatsApp%3A" class="inline-block bg-stone-900 text-amber-500 px-5 py-3 rounded-full font-bold hover:bg-amber-600 hover:text-stone-900 transition-all" aria-label="Participar en la Teyolía de Nox Ramírez por correo">Participar en la Teyolía de Nox ✨</a></div>
-                </div>
-            </div>
-        </article>
-
     </div>
 </section>
 

--- a/xolos-disponibles.html
+++ b/xolos-disponibles.html
@@ -401,6 +401,9 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
   </div>
 </article>
 
+
+
+
 <article class="puppy-card" data-aos="fade-up" data-aos-duration="800" data-aos-delay="200">
   <div class="puppy-card__image-wrapper">
     <span class="puppy-card__status status-disponible">Disponible</span>
@@ -467,6 +470,46 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
 
 
    <article class="puppy-card" data-aos="fade-up" data-aos-duration="800" data-aos-delay="200">
+    <div class="puppy-card__image-wrapper">
+      <span class="puppy-card__status status-disponible">Reservado</span>
+      <span class="puppy-card__status" style="top: 40px; background-color: #ff4d4d; color: #fff;">por Román Morales</span>
+      <div class="puppy-carousel" data-puppy-carousel role="region" aria-roledescription="carrusel" aria-label="Carrusel de fotos de Nox Ramírez">
+        <div class="puppy-carousel__track" tabindex="0">
+          <div class="puppy-carousel__slide">
+            <img src="https://i.imgur.com/jLNvtQk.jpeg" alt="Xoloitzcuintle Nox Ramírez" class="puppy-card__image" loading="lazy" decoding="async" draggable="false" />
+          </div>
+          <div class="puppy-carousel__slide">
+            <img src="https://i.imgur.com/WilqbGs.jpeg" alt="Xoloitzcuintle Nox Ramírez" class="puppy-card__image" loading="lazy" decoding="async" draggable="false" />
+          </div>
+          <div class="puppy-carousel__slide">
+            <img src="https://i.imgur.com/tvovZ8K.jpeg" alt="Xoloitzcuintle Nox Ramírez" class="puppy-card__image" loading="lazy" decoding="async" draggable="false" />
+          </div>
+        </div>
+        <button class="puppy-carousel__button puppy-carousel__button--previous" type="button" aria-label="Foto anterior">&#8592;</button>
+        <button class="puppy-carousel__button puppy-carousel__button--next" type="button" aria-label="Foto siguiente">&#8594;</button>
+        <div class="puppy-carousel__dots" aria-label="Seleccionar foto"></div>
+        <p class="puppy-carousel__live" aria-live="polite" aria-atomic="true"></p>
+      </div>
+    </div>
+    <div class="puppy-card__content">
+      <h3 class="puppy-card__name">Nox Ramírez</h3>
+      <ul class="puppy-card__details">
+        <li><strong>Edad</strong>6 meses</li>
+        <li><strong>Género</strong>Macho</li>
+        <li><strong>Talla</strong>Estándar</li>
+        <li><strong>Color</strong>Negro</li>
+        <li><strong>Variedad</strong>Sin pelo</li>
+      </ul>
+      <div class="puppy-video-container" style="margin: 1rem 0; border-radius: 8px; overflow: hidden; aspect-ratio: 16/9;">
+        <iframe width="100%" height="100%" src="https://www.youtube.com/embed/oxsIzDwxZKw" title="Nox Ramírez" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen loading="lazy"></iframe>
+      </div>
+      <div class="puppy-card__actions">
+        <a href="mailto:fernando@xolosramirez.com?subject=Consulta%20sobre%20ejemplar%20similar%20a%20Nox%20Ram%C3%ADrez%20%5BRef%3A%20nox-es-reserved%5D&amp;body=Hola%2C%0A%0AVi%20el%20perfil%20de%20Nox%20Ram%C3%ADrez%20y%20entiendo%20que%20actualmente%20est%C3%A1%20reservado.%0A%0AMe%20interesa%20conocer%20futuras%20camadas%20o%20alg%C3%BAn%20xoloitzcuintle%20con%20caracter%C3%ADsticas%20similares." class="btn-small btn-primary-small cta-lead cta-email" style="background-color: #25D366; border-color: #25D366; width: 100%; justify-content: center;" data-cta="email" data-lead-type="generate_lead" data-profile="nox" data-page-type="available-xolos" data-lang="es" aria-label="Escribir por correo sobre ejemplares similares a Nox" data-status="reserved">Correo directo ✉️</a>
+      </div>
+    </div>
+  </article>
+
+<article class="puppy-card" data-aos="fade-up" data-aos-duration="800" data-aos-delay="200">
     <div class="puppy-card__image-wrapper">
     <span class="puppy-card__status status-disponible">Reservada</span>
 


### PR DESCRIPTION
### Motivation
- El perfil de Nox Ramírez debe dejar de mostrarse en las páginas de Guardianía y aparecer en las páginas de Xolos disponibles, marcado como reservado por Román Morales, para reflejar su estado actual.\

### Description
- Eliminé el `<article>` completo con `data-carousel-name="Nox Ramírez"` de `teyolias-guardiania.html` y `en/teyolias-guardianship.html` sin tocar los perfiles de Puka ni Ozomatli.\
- Inserté un único perfil de Nox en `xolos-disponibles.html` inmediatamente antes del artículo de Xochitl Ramirez con estado `Reservado` y segunda etiqueta `por Román Morales`, usando `data-profile="nox"`, `data-page-type="available-xolos"`, `data-lang="es"`, `data-status="reserved"` y referencia de correo `nox-es-reserved`; el HTML conserva las clases, carrusel (3 fotos), atributos AOS y botón de correo solicitado.\
- Inserté la versión en inglés en `en/available-xolos.html` inmediatamente antes de Xochitl con estado `Reserved`, segunda etiqueta `by Román Morales`, mismas 3 fotos, mismo video (ID `oxsIzDwxZKw`), y atributos `data-profile="nox"`, `data-page-type="available-xolos"`, `data-lang="en"`, `data-status="reserved"` con referencia de correo `nox-en-reserved`.\
- Conservé accesibilidad y comportamiento: `role="region"`, `aria-roledescription`, `aria-label`, `tabindex`, `aria-live`, `aria-atomic`; todas las imágenes tienen `loading="lazy"`, `decoding="async"`, `draggable="false"`; el `iframe` tiene `loading="lazy"` y `allowfullscreen`; no se añadió CSS/JS y no se modificaron otros perfiles, encabezados ni metadatos.\

### Testing
- Ejecuté las aserciones automáticas incluidas en el rollout (Python) que verifican que `Nox Ramírez` ya no aparece en las dos páginas de Guardianía y que existe exactamente un perfil `data-profile="nox"` por cada página de disponibles; las aserciones pasaron.\
- Ejecuté `git diff --check` y `npm run lint:html` (HTMLHint); ambos regresaron sin errores.\
- Validé que el carrusel contiene las tres fotos requeridas y que el video usa exclusivamente el ID `oxsIzDwxZKw` (comprobación por conteo en script).\
- Generé una captura local con Playwright/`npx playwright screenshot` de `xolos-disponibles.html` para inspección visual; la captura se generó y revisó localmente (sin errores de lint ni HTML).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a62b10e53cc833286786bdda5ef3f61)