### PR TITLE
Marcar a Yaretzi Ramirez como reservada (ES/EN)

### DIFF
--- a/en/available-xolos.html
+++ b/en/available-xolos.html
@@ -227,7 +227,8 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
 
 <article class="puppy-card" data-aos="fade-up" data-aos-duration="800" data-aos-delay="200">
   <div class="puppy-card__image-wrapper">
-    <span class="puppy-card__status status-disponible">Available</span>
+    <span class="puppy-card__status status-disponible">Reserved</span>
+    <span class="puppy-card__status" style="top: 40px; background-color: #ff4d4d; color: #fff;">Reserved by Allan</span>
     <div class="puppy-carousel" data-puppy-carousel role="region" aria-roledescription="carousel" aria-label="Yaretzi Ramirez photo carousel">
       <div class="puppy-carousel__track" tabindex="0">
         <div class="puppy-carousel__slide">
@@ -271,7 +272,7 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
     </div>
 
     <div class="puppy-card__actions">
-      <a href="mailto:fernando@xolosramirez.com?subject=Inquiry%20about%20Yaretzi%20Ramirez%20[Ref:%20yaretzi-en-available]&body=Hello%2C%0A%0AI%20saw%20Yaretzi%20Ramirez's%20profile%20on%20the%20Xolos%20Ram%C3%ADrez%20website%20and%20I%20am%20interested%20in%20learning%20more.%0A%0AI%20would%20like%20to%20know%20whether%20this%20Xoloitzcuintle%20could%20be%20a%20good%20fit%20for%20our%20family%20and%20receive%20information%20about%3A%0A%0A-%20personality%20and%20temperament%3B%0A-%20current%20availability%3B%0A-%20documentation%20and%20care%3B%0A-%20price%20and%20process%20conditions%3B%0A-%20delivery%20options%20for%20our%20location.%0A%0ATo%20help%20you%20guide%20us%20better%2C%20here%20is%20some%20information%3A%0A%0ACity%20or%20country%3A%0AType%20of%20home%3A%0APrevious%20experience%20with%20dogs%3A%0AWhatsApp%20contact%20number%3A%0A%0AThank%20you." class="btn-small btn-primary-small cta-lead cta-email" data-cta="email" data-lead-type="generate_lead" data-profile="yaretzi" data-page-type="available-xolos" data-lang="en" aria-label="Contact by email about Yaretzi" data-status="available">Contact via Email</a>
+      <a href="mailto:fernando@xolosramirez.com?subject=Inquiry%20about%20Xoloitzcuintles%20similar%20to%20Yaretzi%20Ramirez%20[Ref:%20yaretzi-en-reserved]&body=Hello%2C%0A%0AI%20understand%20that%20Yaretzi%20Ramirez%20is%20currently%20reserved.%0A%0AI%20would%20like%20information%20about%20future%20litters%20or%20a%20Xoloitzcuintle%20with%20similar%20characteristics%2C%20including%20availability%20and%20the%20reservation%20process.%0A%0AThank%20you." class="btn-small btn-primary-small cta-lead cta-email" data-cta="email" data-lead-type="generate_lead" data-profile="yaretzi" data-page-type="available-xolos" data-lang="en" aria-label="Inquire about Xoloitzcuintles similar to Yaretzi" data-status="reserved">Contact via Email</a>
     </div>
   </div>
 </article>

--- a/xolos-disponibles.html
+++ b/xolos-disponibles.html
@@ -285,7 +285,8 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
 
 <article class="puppy-card" data-aos="fade-up" data-aos-duration="800" data-aos-delay="200">
   <div class="puppy-card__image-wrapper">
-    <span class="puppy-card__status status-disponible">Disponible</span>
+    <span class="puppy-card__status status-disponible">Reservada</span>
+    <span class="puppy-card__status" style="top: 40px; background-color: #ff4d4d; color: #fff;">por Allan</span>
 
     <!--
     <span class="puppy-card__status" style="top: 40px; background-color: #ff4d4d; color: #fff;">por "_"</span>
@@ -334,7 +335,7 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
     </div>
 
     <div class="puppy-card__actions">
-      <a href="mailto:fernando@xolosramirez.com?subject=Consulta%20sobre%20Yaretzi%20Ramirez%20[Ref:%20yaretzi-es-available]&body=Hola%2C%0A%0AVi%20el%20perfil%20de%20Yaretzi%20Ramirez%20en%20el%20sitio%20de%20Xolos%20Ram%C3%ADrez%20y%20me%20interesa%20conocer%20m%C3%A1s%20sobre%20sus%20caracter%C3%ADsticas.%0A%0AQuisiera%20saber%20si%20podr%C3%ADa%20integrarse%20bien%20a%20nuestra%20familia%20y%20recibir%20informaci%C3%B3n%20sobre%3A%0A%0A-%20su%20personalidad%20y%20temperamento%3B%0A-%20su%20disponibilidad%20actual%3B%0A-%20documentaci%C3%B3n%20y%20cuidados%20correspondientes%3B%0A-%20precio%20y%20condiciones%20del%20proceso%3B%0A-%20opciones%20de%20entrega%20para%20nuestra%20ubicaci%C3%B3n.%0A%0APara%20que%20puedan%20orientarme%20mejor%2C%20comparto%20estos%20datos%3A%0A%0ACiudad%20o%20pa%C3%ADs%3A%0ATipo%20de%20hogar%20(casa%2Fdepartamento)%3A%0AExperiencia%20previa%20con%20perros%3A%0AN%C3%BAmero%20de%20WhatsApp%20de%20contacto%3A%0A%0AGracias." class="btn-small btn-primary-small cta-lead cta-email" style="background-color: #25D366; border-color: #25D366; width: 100%; justify-content: center;" data-cta="email" data-lead-type="generate_lead" data-profile="yaretzi" data-page-type="available-xolos" data-lang="es" aria-label="Escribir por correo sobre Yaretzi" data-status="available">Correo directo ✉️</a>
+      <a href="mailto:fernando@xolosramirez.com?subject=Consulta%20sobre%20ejemplares%20similares%20a%20Yaretzi%20Ramirez%20[Ref:%20yaretzi-es-reserved]&body=Hola%2C%0A%0AS%C3%A9%20que%20Yaretzi%20Ramirez%20est%C3%A1%20reservada.%0A%0AMe%20gustar%C3%ADa%20recibir%20informaci%C3%B3n%20sobre%20futuras%20camadas%20o%20ejemplares%20similares%20a%20Yaretzi%2C%20incluyendo%20sus%20caracter%C3%ADsticas%2C%20disponibilidad%20y%20proceso%20de%20reserva.%0A%0AGracias." class="btn-small btn-primary-small cta-lead cta-email" style="background-color: #25D366; border-color: #25D366; width: 100%; justify-content: center;" data-cta="email" data-lead-type="generate_lead" data-profile="yaretzi" data-page-type="available-xolos" data-lang="es" aria-label="Consultar por ejemplares similares a Yaretzi" data-status="reserved">Correo directo ✉️</a>
     </div>
   </div>
 </article>


### PR DESCRIPTION
### Motivation
- Actualizar el perfil de Yaretzi Ramirez para reflejar que está reservada por Allan y cambiar el CTA para invitar a consultar camadas futuras o ejemplares similares en ambas versiones (es/en).

### Description
- En `xolos-disponibles.html` se reemplazó la etiqueta de estado por `<span class="puppy-card__status status-disponible">Reservada</span>` y se añadió `<span class="puppy-card__status" style="top: 40px; background-color: #ff4d4d; color: #fff;">por Allan</span>` dentro del artículo de Yaretzi.
- En `en/available-xolos.html` se reemplazó la etiqueta de estado por `<span class="puppy-card__status status-disponible">Reserved</span>` y se añadió `<span class="puppy-card__status" style="top: 40px; background-color: #ff4d4d; color: #fff;">Reserved by Allan</span>` dentro del artículo de Yaretzi.
- En ambos archivos se sustituyó el enlace de correo por un `mailto:` con referencia `yaretzi-es-reserved` / `yaretzi-en-reserved`, se actualizó `data-status` a `reserved`, y se conservaron `data-profile="yaretzi"`, `data-page-type="available-xolos"`, `data-lang` y el texto visible (`Correo directo ✉️` / `Contact via Email`).
- No se modificaron imágenes, video, nombre, edad, género, talla, color, otros perfiles, CSS, JS ni el orden de las tarjetas; el cambio quedó limitado al bloque de Yaretzi en los dos archivos.

### Testing
- Ejecuté `git diff --check` y no devolvió errores.
- Ejecuté un script de validación en `python3` que comprobó que cada bloque de Yaretzi contiene las cadenas solicitadas, las referencias `yaretzi-es-reserved` / `yaretzi-en-reserved`, `data-status="reserved"`, y que no queda `data-status="available"`, y el script pasó.
- Ejecuté `git diff --name-only` y confirmó que solo se modificaron `xolos-disponibles.html` y `en/available-xolos.html`.
- Verifiqué el estado del árbol con `git status --short` para confirmar que el trabajo quedó limpio tras aplicar los cambios.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a62b351c7d48332ad05cfec1dff2428)