### PR TITLE
PR 1: mejora artículos ES, SEO y enlazado interno

### DIFF
--- a/blog/calor-terapeutico-xoloitzcuintle.html
+++ b/blog/calor-terapeutico-xoloitzcuintle.html
@@ -183,6 +183,16 @@
         </div>
     </header>
 
+    <nav aria-label="Migas de pan" style="max-width: 72rem; margin: 0 auto; padding: 1rem 1rem 0; background: #fff; color: #57534e; font-size: 0.875rem; line-height: 1.5;">
+        <ol style="display: flex; flex-wrap: wrap; align-items: center; gap: 0.5rem; margin: 0; padding: 0; list-style: none;">
+            <li><a href="../index.html" style="color: inherit; text-decoration: underline; text-underline-offset: 0.2em;">Inicio</a></li>
+            <li aria-hidden="true">›</li>
+            <li><a href="index.html" style="color: inherit; text-decoration: underline; text-underline-offset: 0.2em;">Blog</a></li>
+            <li aria-hidden="true">›</li>
+            <li aria-current="page">Percepción térmica</li>
+        </ol>
+    </nav>
+
     <!-- Data Dashboard Section -->
     <section id="data" class="py-16 bg-stone-50">
         <div class="container mx-auto px-4 max-w-6xl">
@@ -356,7 +366,7 @@
                     </div>
                     <h3 class="text-xl font-bold text-white mb-2">Asma y Resfriados</h3>
                     <p class="text-sm leading-relaxed">
-                        En la tradición oral aparecen relatos sobre asma y resfriados. Un xoloitzcuintle no transfiere enfermedades ni sustituye la valoración y el tratamiento médico.
+                        En la tradición oral aparecen relatos sobre asma y resfriados. La cercanía de un xoloitzcuintle no cura ni extrae enfermedades y no sustituye la valoración ni el tratamiento médico.
                     </p>
                 </div>
             </div>

--- a/blog/calor-terapeutico-xoloitzcuintle.html
+++ b/blog/calor-terapeutico-xoloitzcuintle.html
@@ -1,9 +1,63 @@
 <!DOCTYPE html>
 <html lang="es">
 <head>
+    <!-- Google Tag Manager -->
+    <script>
+      (function (w, d, s, l, i) {
+        w[l] = w[l] || [];
+        w[l].push({ 'gtm.start': new Date().getTime(), event: 'gtm.js' });
+        var f = d.getElementsByTagName(s)[0],
+          j = d.createElement(s),
+          dl = l != 'dataLayer' ? '&l=' + l : '';
+        j.async = true;
+        j.src = 'https://www.googletagmanager.com/gtm.js?id=' + i + dl;
+        f.parentNode.insertBefore(j, f);
+      })(window, document, 'script', 'dataLayer', 'GTM-MGTMWN7T');
+    </script>
+    <!-- End Google Tag Manager -->
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Investigación: Temperatura del Xoloitzcuintle</title>
+    <link rel="canonical" href="https://xolosramirez.com/blog/calor-terapeutico-xoloitzcuintle.html">
+    <link rel="alternate" hreflang="es-MX" href="https://xolosramirez.com/blog/calor-terapeutico-xoloitzcuintle.html">
+    <link rel="alternate" hreflang="x-default" href="https://xolosramirez.com/blog/calor-terapeutico-xoloitzcuintle.html">
+    <title>¿Por qué el xoloitzcuintle se siente caliente? | Xolos Ramírez</title>
+    <meta name="description" content="Explicación educativa de por qué la piel del xoloitzcuintle sin pelo se percibe caliente, con contexto histórico sin atribuir beneficios terapéuticos.">
+    <meta property="og:type" content="article">
+    <meta property="og:locale" content="es_MX">
+    <meta property="og:site_name" content="Xolos Ramírez">
+    <meta property="og:title" content="¿Por qué el xoloitzcuintle se siente caliente?">
+    <meta property="og:description" content="Piel, pelaje y percepción térmica explicados con una visualización educativa y contexto cultural.">
+    <meta property="og:url" content="https://xolosramirez.com/blog/calor-terapeutico-xoloitzcuintle.html">
+    <meta property="og:image" content="https://xolosramirez.com/img/hero/site-hero.jpg">
+    <meta name="twitter:card" content="summary_large_image">
+    <meta name="twitter:title" content="¿Por qué el xoloitzcuintle se siente caliente?">
+    <meta name="twitter:description" content="Una guía educativa sobre percepción térmica, cuidado y tradición cultural.">
+    <meta name="twitter:image" content="https://xolosramirez.com/img/hero/site-hero.jpg">
+    <script type="application/ld+json">
+      {
+        "@context": "https://schema.org",
+        "@graph": [
+          {
+            "@type": "Article",
+            "headline": "¿Por qué el xoloitzcuintle se siente caliente?",
+            "description": "Explicación educativa de por qué la piel del xoloitzcuintle sin pelo se percibe caliente, con contexto histórico sin atribuir beneficios terapéuticos.",
+            "inLanguage": "es-MX",
+            "mainEntityOfPage": "https://xolosramirez.com/blog/calor-terapeutico-xoloitzcuintle.html",
+            "author": { "@type": "Organization", "name": "Xolos Ramírez" },
+            "publisher": { "@type": "Organization", "name": "Xolos Ramírez" },
+            "image": "https://xolosramirez.com/img/hero/site-hero.jpg"
+          },
+          {
+            "@type": "BreadcrumbList",
+            "itemListElement": [
+              { "@type": "ListItem", "position": 1, "name": "Inicio", "item": "https://xolosramirez.com/" },
+              { "@type": "ListItem", "position": 2, "name": "Blog", "item": "https://xolosramirez.com/blog/index.html" },
+              { "@type": "ListItem", "position": 3, "name": "Percepción térmica", "item": "https://xolosramirez.com/blog/calor-terapeutico-xoloitzcuintle.html" }
+            ]
+          }
+        ]
+      }
+    </script>
     
     <!-- Tailwind CSS -->
     <script src="https://cdn.tailwindcss.com"></script>
@@ -75,6 +129,10 @@
     <!-- CONFIRMATION: NO SVG graphics used (relying on FontAwesome/CSS). NO Mermaid JS used. -->
 </head>
 <body class="flex flex-col min-h-screen">
+    <!-- Google Tag Manager (noscript) -->
+    <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-MGTMWN7T"
+    height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
+    <!-- End Google Tag Manager (noscript) -->
 
     <!-- Navigation -->
     <nav class="sticky top-0 z-50 bg-stone-900 text-stone-100 shadow-md">
@@ -105,12 +163,12 @@
     <!-- Hero / Hypothesis Section -->
     <header id="intro" class="bg-white py-12 md:py-20 border-b border-stone-200">
         <div class="container mx-auto px-4 max-w-4xl text-center">
-            <span class="inline-block px-3 py-1 mb-4 text-xs font-bold tracking-widest text-orange-600 bg-orange-100 rounded-full uppercase sans-font">Investigación Veterinaria</span>
+            <span class="inline-block px-3 py-1 mb-4 text-xs font-bold tracking-widest text-orange-600 bg-orange-100 rounded-full uppercase sans-font">Guía educativa</span>
             <h1 class="text-3xl md:text-5xl font-bold text-stone-900 mb-6 leading-tight">
                 ¿Son los Xoloitzcuintles realmente más calientes?
             </h1>
             <p class="text-lg md:text-xl text-stone-600 mb-8 leading-relaxed max-w-2xl mx-auto">
-                Existe la creencia popular de que el perro sin pelo mexicano mantiene una temperatura corporal de <strong>40°C o más</strong>, muy por encima de otras razas. Hemos analizado los datos fisiológicos para separar el mito de la realidad científica.
+                Existe la creencia popular de que el perro sin pelo mexicano mantiene una temperatura corporal mucho mayor que otras razas. La sensación al tocar su piel no equivale por sí sola a una medición clínica.
             </p>
             <div class="grid grid-cols-1 md:grid-cols-2 gap-6 mt-10">
                 <div class="p-6 bg-stone-100 rounded-lg border border-stone-200 text-left">
@@ -119,7 +177,7 @@
                 </div>
                 <div class="p-6 bg-stone-800 rounded-lg border border-stone-700 text-left text-stone-100 shadow-lg">
                     <h3 class="font-bold text-lg mb-2 text-orange-400"><i class="fa-solid fa-microscope mr-2"></i>Realidad Biológica</h3>
-                    <p class="text-sm text-stone-300">"Termorregulación eficiente y falta de aislamiento térmico crean una ilusión sensorial táctil."</p>
+                    <p class="text-sm text-stone-300">"La ausencia de pelaje permite sentir el calor de la piel de forma más directa, pero la temperatura debe evaluarse con métodos clínicos."</p>
                 </div>
             </div>
         </div>
@@ -129,9 +187,9 @@
     <section id="data" class="py-16 bg-stone-50">
         <div class="container mx-auto px-4 max-w-6xl">
             <div class="mb-10 text-center md:text-left">
-                <h2 class="text-2xl md:text-3xl font-bold text-stone-900 mb-3">Análisis de Datos Térmicos</h2>
+                <h2 class="text-2xl md:text-3xl font-bold text-stone-900 mb-3">Cómo interpretar la sensación térmica</h2>
                 <p class="text-stone-600 max-w-3xl">
-                    Para entender el fenómeno, debemos distinguir entre la <strong>temperatura interna</strong> (rectal) y la <strong>temperatura dérmica</strong> (superficie de la piel). A continuación, se presentan los datos comparativos promedio.
+                    Conviene distinguir entre la <strong>temperatura interna</strong>, que requiere una medición apropiada, y la <strong>superficie que toca la mano</strong>. Las visualizaciones siguientes son conceptuales y no representan resultados de un estudio clínico.
                 </p>
             </div>
 
@@ -140,14 +198,14 @@
                 <!-- Chart 1: Internal Temperature Comparison -->
                 <div class="bg-white p-6 rounded-xl shadow-sm border border-stone-200">
                     <div class="mb-4 border-b border-stone-100 pb-2">
-                        <h3 class="font-bold text-lg sans-font text-stone-800">Temperatura Interna (Rectal)</h3>
-                        <p class="text-xs text-stone-500">Comparativa entre especies y razas (°C)</p>
+                        <h3 class="font-bold text-lg sans-font text-stone-800">Temperatura interna</h3>
+                        <p class="text-xs text-stone-500">Comparación conceptual, no una medición clínica</p>
                     </div>
                     <div class="chart-container">
                         <canvas id="internalTempChart"></canvas>
                     </div>
                     <div class="mt-4 p-3 bg-blue-50 text-blue-800 rounded text-sm">
-                        <i class="fa-solid fa-info-circle mr-1"></i> <strong>Hallazgo:</strong> No existe diferencia estadística significativa en la temperatura interna entre un Xolo y un perro con pelo. Ambos oscilan entre 38°C y 39.2°C.
+                        <i class="fa-solid fa-info-circle mr-1"></i> <strong>Idea clave:</strong> El pelaje cambia lo que siente la mano, pero no permite concluir que la temperatura interna del xoloitzcuintle sea mayor.
                     </div>
                 </div>
 
@@ -156,10 +214,10 @@
                     <div class="mb-4 border-b border-stone-100 pb-2 flex justify-between items-center">
                         <div>
                             <h3 class="font-bold text-lg sans-font text-stone-800">Sensación Térmica al Tacto</h3>
-                            <p class="text-xs text-stone-500">Calor irradiado por la piel vs. capa de pelo</p>
+                            <p class="text-xs text-stone-500">Contacto directo con piel frente a contacto con pelaje</p>
                         </div>
                         <button onclick="updateSurfaceData()" class="text-xs bg-stone-800 text-white px-3 py-1 rounded hover:bg-stone-600 transition">
-                            <i class="fa-solid fa-sync mr-1"></i> Actualizar Muestra
+                            <i class="fa-solid fa-sync mr-1"></i> Variar ilustración
                         </button>
                     </div>
                     
@@ -168,7 +226,7 @@
                     </div>
 
                     <div class="mt-4 p-3 bg-orange-50 text-orange-900 rounded text-sm">
-                        <i class="fa-solid fa-hand-holding-medical mr-1"></i> <strong>Explicación:</strong> La piel del Xolo puede estar hasta 3-4°C más caliente al tacto que la superficie del pelaje de otro perro, aunque sus órganos internos estén a la misma temperatura.
+                        <i class="fa-solid fa-hand-holding-medical mr-1"></i> <strong>Explicación:</strong> La mano toca directamente la piel del xoloitzcuintle sin pelo; en un perro con pelo, la capa de aire y pelaje modifica esa percepción.
                     </div>
                 </div>
 
@@ -213,8 +271,8 @@
 
                         <!-- Core Body -->
                         <div class="z-10 w-40 h-40 bg-red-700 rounded-full flex items-center justify-center shadow-xl text-white font-bold relative">
-                            <span class="z-20">38.5°C</span>
-                            <span class="absolute text-xs bottom-8 opacity-75">Interna</span>
+                            <span class="z-20">Calor corporal</span>
+                            <span class="absolute text-xs bottom-8 opacity-75">representación</span>
                         </div>
 
                         <!-- Fur Layer -->
@@ -228,7 +286,7 @@
                         <h4 class="font-bold text-lg mb-3 flex items-center">
                             <i class="fa-solid fa-hand-paper mr-2"></i> Tu Mano Siente:
                         </h4>
-                        <div id="sensor-readout" class="text-4xl font-bold text-orange-600 mb-2 sans-font">40°C</div>
+                        <div id="sensor-readout" class="text-3xl font-bold text-orange-600 mb-2 sans-font">Contacto directo</div>
                         <p id="sensor-desc" class="text-sm text-stone-600">
                             Calor directo irradiado desde la piel. Sin barreras.
                         </p>
@@ -240,17 +298,17 @@
                     <div class="p-4">
                         <div class="text-orange-600 text-2xl mb-2"><i class="fa-solid fa-temperature-arrow-up"></i></div>
                         <h5 class="font-bold text-sm">Radiación</h5>
-                        <p class="text-xs text-stone-500 mt-1">El Xolo pierde calor directamente por la piel, haciéndolo sentir como un radiador vivo.</p>
+                        <p class="text-xs text-stone-500 mt-1">La mano percibe el calor sin una capa de pelaje entre ambos.</p>
                     </div>
                     <div class="p-4">
                         <div class="text-stone-600 text-2xl mb-2"><i class="fa-solid fa-shield-dog"></i></div>
                         <h5 class="font-bold text-sm">Aislamiento</h5>
-                        <p class="text-xs text-stone-500 mt-1">En otros perros, el pelo atrapa aire y bloquea la transferencia de calor hacia tu mano.</p>
+                        <p class="text-xs text-stone-500 mt-1">El pelo y el aire entre sus fibras modifican la transferencia de calor hacia la mano.</p>
                     </div>
                     <div class="p-4">
                         <div class="text-blue-600 text-2xl mb-2"><i class="fa-solid fa-wind"></i></div>
                         <h5 class="font-bold text-sm">Termorregulación</h5>
-                        <p class="text-xs text-stone-500 mt-1">Los Xolos tiemblan más fácilmente en frío porque carecen de esa protección pasiva.</p>
+                        <p class="text-xs text-stone-500 mt-1">La respuesta al frío varía y debe observarse en cada ejemplar para ajustar abrigo y exposición.</p>
                     </div>
                 </div>
             </div>
@@ -262,9 +320,9 @@
         <div class="container mx-auto px-4">
             <div class="mb-10 text-center">
                 <span class="text-orange-500 font-bold tracking-widest text-xs uppercase mb-2 block">Contexto Antropológico</span>
-                <h2 class="text-3xl font-bold text-white mb-4">La "Bolsa de Agua Caliente" Azteca</h2>
+                <h2 class="text-3xl font-bold text-white mb-4">Relatos sobre el calor del Xolo</h2>
                 <p class="max-w-2xl mx-auto text-stone-400">
-                    La percepción de calor intenso no pasó desapercibida para las culturas prehispánicas, quienes dieron al Xoloitzcuintle un rol medicinal basado en su fisiología.
+                    Fuentes históricas y tradición oral relacionan la cercanía del xoloitzcuintle con calor, compañía y simbolismo. Estos relatos culturales no equivalen a evidencia terapéutica.
                 </p>
             </div>
 
@@ -276,7 +334,7 @@
                     </div>
                     <h3 class="text-xl font-bold text-white mb-2">Reumatismo y Artritis</h3>
                     <p class="text-sm leading-relaxed">
-                        Debido a su piel caliente al tacto, se entrenaba a los Xolos para dormir pegados a las zonas doloridas de los ancianos, actuando como compresas térmicas vivas para aliviar la inflamación articular.
+                        Algunos relatos describen a xoloitzcuintles descansando junto a personas con dolor. Debe entenderse como tradición o experiencia de compañía, no como tratamiento para artritis o inflamación.
                     </p>
                 </div>
 
@@ -298,9 +356,22 @@
                     </div>
                     <h3 class="text-xl font-bold text-white mb-2">Asma y Resfriados</h3>
                     <p class="text-sm leading-relaxed">
-                        Aunque científicamente discutible, se creía que dormir con un Xolo ayudaba a transferir el asma del humano al perro (mito) o simplemente que el calor constante ayudaba a broncodilatar durante la noche (plausible).
+                        En la tradición oral aparecen relatos sobre asma y resfriados. Un xoloitzcuintle no transfiere enfermedades ni sustituye la valoración y el tratamiento médico.
                     </p>
                 </div>
+            </div>
+        </div>
+    </section>
+
+    <section aria-labelledby="lecturas-relacionadas" class="py-16 bg-stone-50">
+        <div class="container mx-auto px-4 max-w-5xl">
+            <h2 id="lecturas-relacionadas" class="text-3xl font-bold text-stone-900 mb-4 text-center">Continúa con el cuidado térmico</h2>
+            <p class="text-stone-600 mb-8 text-center">Explora cómo adaptar rutinas, clima y cuidado de la piel sin atribuir efectos médicos a la cercanía del Xolo.</p>
+            <div class="grid grid-cols-1 md:grid-cols-4 gap-4">
+                <a href="xoloitzcuintle-termo-regulacion.html" data-cta="editorial-link" data-cta-location="related-content" class="bg-white rounded-xl border border-stone-200 p-5 hover:border-orange-500 transition">Termorregulación →</a>
+                <a href="xoloitzcuintle-adaptacion-climatica.html" data-cta="editorial-link" data-cta-location="related-content" class="bg-white rounded-xl border border-stone-200 p-5 hover:border-orange-500 transition">Adaptación al clima →</a>
+                <a href="cuidado-de-la-piel-del-xoloitzcuintle.html" data-cta="editorial-link" data-cta-location="related-content" class="bg-white rounded-xl border border-stone-200 p-5 hover:border-orange-500 transition">Cuidado de la piel →</a>
+                <a href="../xolos-disponibles.html" data-cta="availability" data-cta-location="related-content" class="bg-white rounded-xl border border-stone-200 p-5 hover:border-orange-500 transition">Conoce a los Xolos →</a>
             </div>
         </div>
     </section>
@@ -310,8 +381,8 @@
         <div class="container mx-auto px-4 text-center">
             <p class="font-serif italic mb-4">"El calor del Xolo no está en su sangre, sino en su piel desnuda."</p>
             <div class="text-xs space-y-2">
-                <p>Generado como Investigación Interactiva • Análisis basado en fisiología canina estándar.</p>
-                <p>&copy; 2023 Xolo Data Lab</p>
+                <p>Visualización educativa; no constituye investigación clínica ni sustituye orientación médica o veterinaria.</p>
+                <p>&copy; Xolos Ramírez</p>
             </div>
         </div>
     </footer>
@@ -321,10 +392,10 @@
         const appState = {
             viewMode: 'hairless', // 'hairless' or 'coated'
             chartData: {
-                internal: [38.5, 38.6, 37.0], // Xolo, Golden, Human
+                internal: [1, 1],
                 surface: {
-                    xolo: [38, 37.5, 38.2, 37.8, 38.1],
-                    coated: [31, 30.5, 31.2, 30.8, 31.0] // Lower surface temp due to insulation
+                    xolo: [1, 0.95, 1, 0.9, 0.95],
+                    coated: [0.55, 0.5, 0.6, 0.5, 0.55]
                 }
             }
         };
@@ -335,9 +406,9 @@
             new Chart(ctx, {
                 type: 'bar',
                 data: {
-                    labels: ['Xoloitzcuintle', 'Golden Retriever', 'Humano'],
+                    labels: ['Xoloitzcuintle sin pelo', 'Perro con pelo'],
                     datasets: [{
-                        label: 'Temperatura Interna Media (°C)',
+                        label: 'Mismo rango clínico esperado',
                         data: appState.chartData.internal,
                         backgroundColor: [
                             'rgba(234, 88, 12, 0.8)', // Orange for Xolo
@@ -360,7 +431,7 @@
                         tooltip: {
                             callbacks: {
                                 label: function(context) {
-                                    return context.parsed.y + '°C - ' + (context.parsed.y > 38 ? 'Rango Canino Normal' : 'Rango Humano Normal');
+                                    return 'La sensación al tacto no sustituye una medición clínica';
                                 }
                             }
                         }
@@ -368,9 +439,10 @@
                     scales: {
                         y: {
                             beginAtZero: false,
-                            min: 35,
-                            max: 42,
-                            title: { display: true, text: 'Temperatura (°C)' }
+                            min: 0,
+                            max: 1.2,
+                            ticks: { display: false },
+                            title: { display: true, text: 'Comparación conceptual' }
                         }
                     }
                 }
@@ -417,17 +489,17 @@
                     },
                     scales: {
                         y: {
-                            min: 25,
-                            max: 45,
-                            title: { display: true, text: 'Temp. Superficie (°C)' }
+                            min: 0,
+                            max: 1.2,
+                            ticks: { display: false },
+                            title: { display: true, text: 'Percepción relativa' }
                         }
                     },
                     plugins: {
                         tooltip: {
                             callbacks: {
                                 footer: function(tooltipItems) {
-                                    let diff = tooltipItems[0].parsed.y - tooltipItems[1].parsed.y;
-                                    return 'Diferencia: ' + diff.toFixed(1) + '°C más caliente al tacto.';
+                                    return 'Ilustración conceptual, no medición.';
                                 }
                             }
                         }
@@ -437,8 +509,8 @@
         }
 
         function updateSurfaceData() {
-            // Simulate slight natural fluctuations in measurement
-            const fluctuate = (data) => data.map(v => v + (Math.random() * 1 - 0.5));
+            // Vary the conceptual illustration without representing clinical measurements.
+            const fluctuate = (data) => data.map(v => Math.max(0.2, v + (Math.random() * 0.08 - 0.04)));
             surfaceChart.data.datasets[0].data = fluctuate(appState.chartData.surface.xolo);
             surfaceChart.data.datasets[1].data = fluctuate(appState.chartData.surface.coated);
             surfaceChart.update();
@@ -470,9 +542,9 @@
                 furLayer.style.transform = 'scale(0.9)';
 
                 // Data Readout
-                sensorReadout.innerText = "38 - 40°C";
-                sensorReadout.className = "text-4xl font-bold text-orange-600 mb-2 sans-font";
-                sensorDesc.innerText = "Sientes el calor interno irradiando directamente. La piel es un conductor eficiente.";
+                sensorReadout.innerText = "Contacto directo";
+                sensorReadout.className = "text-3xl font-bold text-orange-600 mb-2 sans-font";
+                sensorDesc.innerText = "La mano toca la piel sin una capa de pelaje entre ambos.";
                 sensorBox.className = "w-full md:w-1/3 bg-orange-50 p-6 rounded-lg shadow border-l-4 border-orange-500 transition-colors duration-500";
             } else {
                 // Button Styling
@@ -488,9 +560,9 @@
                 furLayer.style.transform = 'scale(1)';
 
                 // Data Readout
-                sensorReadout.innerText = "30 - 32°C";
-                sensorReadout.className = "text-4xl font-bold text-stone-600 mb-2 sans-font";
-                sensorDesc.innerText = "Sientes el aislamiento del pelo. El calor se mantiene dentro del perro, no en tu mano.";
+                sensorReadout.innerText = "Contacto con pelaje";
+                sensorReadout.className = "text-3xl font-bold text-stone-600 mb-2 sans-font";
+                sensorDesc.innerText = "La mano toca el pelo y el aire entre sus fibras, lo que cambia la sensación.";
                 sensorBox.className = "w-full md:w-1/3 bg-stone-50 p-6 rounded-lg shadow border-l-4 border-stone-400 transition-colors duration-500";
             }
         }

--- a/blog/guia-tallas-xoloitzcuintle.html
+++ b/blog/guia-tallas-xoloitzcuintle.html
@@ -164,6 +164,16 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
         </div>
     </header>
 
+    <nav aria-label="Migas de pan" style="max-width: 72rem; margin: 0 auto; padding: 1rem 1rem 0; background: #fff; color: #57534e; font-size: 0.875rem; line-height: 1.5;">
+        <ol style="display: flex; flex-wrap: wrap; align-items: center; gap: 0.5rem; margin: 0; padding: 0; list-style: none;">
+            <li><a href="../index.html" style="color: inherit; text-decoration: underline; text-underline-offset: 0.2em;">Inicio</a></li>
+            <li aria-hidden="true">›</li>
+            <li><a href="index.html" style="color: inherit; text-decoration: underline; text-underline-offset: 0.2em;">Blog</a></li>
+            <li aria-hidden="true">›</li>
+            <li aria-current="page">Guía de tallas</li>
+        </ol>
+    </nav>
+
     <!-- Main Content -->
     <main class="container mx-auto px-4 py-8 space-y-16">
 

--- a/blog/guia-tallas-xoloitzcuintle.html
+++ b/blog/guia-tallas-xoloitzcuintle.html
@@ -9,7 +9,46 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <link rel="canonical" href="https://xolosramirez.com/blog/guia-tallas-xoloitzcuintle.html" />
-    <title>Guía de Tallas del Xoloitzcuintle</title>
+    <link rel="alternate" hreflang="es-MX" href="https://xolosramirez.com/blog/guia-tallas-xoloitzcuintle.html" />
+    <link rel="alternate" hreflang="x-default" href="https://xolosramirez.com/blog/guia-tallas-xoloitzcuintle.html" />
+    <title>Guía de tallas del xoloitzcuintle: miniatura, intermedio y estándar</title>
+    <meta name="description" content="Compara las tallas miniatura, intermedia y estándar del xoloitzcuintle y conoce qué factores considerar para elegir un compañero compatible.">
+    <meta property="og:type" content="article">
+    <meta property="og:locale" content="es_MX">
+    <meta property="og:site_name" content="Xolos Ramírez">
+    <meta property="og:title" content="Guía de tallas del xoloitzcuintle">
+    <meta property="og:description" content="Una comparación interactiva de las tallas miniatura, intermedia y estándar.">
+    <meta property="og:url" content="https://xolosramirez.com/blog/guia-tallas-xoloitzcuintle.html">
+    <meta property="og:image" content="https://xolosramirez.com/img/hero/site-hero.jpg">
+    <meta name="twitter:card" content="summary_large_image">
+    <meta name="twitter:title" content="Guía de tallas del xoloitzcuintle">
+    <meta name="twitter:description" content="Compara las tres tallas y los factores de convivencia que conviene valorar.">
+    <meta name="twitter:image" content="https://xolosramirez.com/img/hero/site-hero.jpg">
+    <script type="application/ld+json">
+      {
+        "@context": "https://schema.org",
+        "@graph": [
+          {
+            "@type": "Article",
+            "headline": "Guía de tallas del xoloitzcuintle",
+            "description": "Compara las tallas miniatura, intermedia y estándar del xoloitzcuintle y conoce qué factores considerar para elegir un compañero compatible.",
+            "inLanguage": "es-MX",
+            "mainEntityOfPage": "https://xolosramirez.com/blog/guia-tallas-xoloitzcuintle.html",
+            "author": { "@type": "Organization", "name": "Xolos Ramírez" },
+            "publisher": { "@type": "Organization", "name": "Xolos Ramírez" },
+            "image": "https://xolosramirez.com/img/hero/site-hero.jpg"
+          },
+          {
+            "@type": "BreadcrumbList",
+            "itemListElement": [
+              { "@type": "ListItem", "position": 1, "name": "Inicio", "item": "https://xolosramirez.com/" },
+              { "@type": "ListItem", "position": 2, "name": "Blog", "item": "https://xolosramirez.com/blog/index.html" },
+              { "@type": "ListItem", "position": 3, "name": "Guía de tallas", "item": "https://xolosramirez.com/blog/guia-tallas-xoloitzcuintle.html" }
+            ]
+          }
+        ]
+      }
+    </script>
     <!-- Tailwind CSS -->
     <script src="https://cdn.tailwindcss.com"></script>
     <!-- Chart.js -->
@@ -87,7 +126,7 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
     <!-- Navbar -->
     <nav class="bg-xolo-900 text-xolo-100 shadow-lg">
         <div class="container mx-auto px-4 py-4 flex justify-between items-center">
-            <h1 class="text-xl md:text-2xl font-bold tracking-wider">XOLO<span class="text-amber-600">GUIDE</span></h1>
+            <div class="text-xl md:text-2xl font-bold tracking-wider">XOLO<span class="text-amber-600">GUIDE</span></div>
             <div class="text-xs md:text-sm text-xolo-400">Guía Oficial de Tallas</div>
         </div>
     </nav>
@@ -95,11 +134,12 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
     <!-- Hero Section -->
     <header class="bg-white border-b border-xolo-200">
         <div class="container mx-auto px-4 py-12 text-center max-w-4xl">
-            <h2 class="text-3xl md:text-5xl font-bold mb-6 text-xolo-900">Elige el Xoloitzcuintle Ideal</h2>
+            <h1 class="text-3xl md:text-5xl font-bold mb-6 text-xolo-900">Guía de tallas del xoloitzcuintle</h1>
             <p class="text-lg text-xolo-600 leading-relaxed mb-8">
                 El Xoloitzcuintle no es una talla única. La Federación Canófila reconoce tres variedades distintas: 
                 <span class="font-bold text-amber-800">Miniatura, Intermedio y Estándar</span>. 
-                Esta herramienta interactiva te ayudará a entender las diferencias técnicas y elegir el compañero perfecto para tu espacio y estilo de vida.
+                Esta herramienta interactiva te ayudará a entender las diferencias físicas y a identificar qué preguntas conviene resolver para buscar un
+                compañero compatible con tu espacio, actividad y expectativas.
             </p>
 
             <!-- ✅ CTA Buttons -->
@@ -114,12 +154,11 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
                 <!-- ✅ Nuevo link a xolos disponibles -->
                 <a
                     href="https://xolosramirez.com/xolos-disponibles.html"
-                    target="_blank"
-                    rel="noopener noreferrer"
                     class="bg-amber-700 hover:bg-amber-600 text-white px-6 py-3 rounded-lg transition shadow-md font-semibold inline-flex items-center gap-2"
+                    data-cta="availability"
+                    data-cta-location="article-hero"
                 >
                     Ver Xolos Disponibles
-                    <span aria-hidden="true">↗</span>
                 </a>
             </div>
         </div>
@@ -131,7 +170,7 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
         <!-- SECTION 1: Interactive Explorer -->
         <section id="explorer" class="scroll-mt-8">
             <div class="mb-6 border-l-4 border-amber-800 pl-4">
-                <h3 class="text-2xl font-bold text-xolo-900">Explorador de Variedades</h3>
+                <h2 class="text-2xl font-bold text-xolo-900">Explorador de Variedades</h2>
                 <p class="text-xolo-600 mt-2">
                     Selecciona una talla para ver sus especificaciones técnicas y visualizar su escala comparativa.
                     Los datos mostrados se basan en el estándar racial oficial.
@@ -171,7 +210,7 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
                                 <span id="detail-weight" class="font-mono font-bold">18 - 30 kg</span>
                             </div>
                             <div>
-                                <span class="block text-xolo-300 mb-1">Espacio Ideal:</span>
+                                <span class="block text-xolo-300 mb-1">Entorno a considerar:</span>
                                 <p id="detail-space" class="text-sm leading-snug">Casa con jardín mediano a grande. Requiere actividad física moderada a alta.</p>
                             </div>
                         </div>
@@ -216,7 +255,7 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
         <!-- SECTION 2: Analytics & Charts -->
         <section class="bg-white p-6 md:p-8 rounded-xl shadow-sm border border-xolo-200">
             <div class="mb-6">
-                <h3 class="text-2xl font-bold text-xolo-900">Análisis Comparativo</h3>
+                <h2 class="text-2xl font-bold text-xolo-900">Análisis Comparativo</h2>
                 <p class="text-xolo-600 mt-2">
                     Visualiza las diferencias sustanciales entre las variedades. Mientras la altura crece linealmente, el peso aumenta exponencialmente, lo que impacta significativamente en el manejo del perro.
                 </p>
@@ -247,8 +286,8 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
         <section id="calculator" class="scroll-mt-8 bg-xolo-900 text-xolo-100 rounded-xl p-8 shadow-xl">
             <div class="max-w-4xl mx-auto">
                 <div class="text-center mb-8">
-                    <h3 class="text-2xl md:text-3xl font-bold text-amber-500">¿Qué Xolo es para ti?</h3>
-                    <p class="text-xolo-300 mt-2">Responde dos preguntas simples para recibir una recomendación basada en el espacio.</p>
+                    <h2 class="text-2xl md:text-3xl font-bold text-amber-500">¿Qué talla puede adaptarse a tu hogar?</h2>
+                    <p class="text-xolo-300 mt-2">Responde dos preguntas para obtener una orientación inicial. La compatibilidad también depende del ejemplar y de la dinámica familiar.</p>
                 </div>
 
                 <div class="grid grid-cols-1 md:grid-cols-3 gap-6 items-center">
@@ -272,7 +311,7 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
                             </select>
                         </div>
                         <button onclick="calculateRecommendation()" class="w-full bg-amber-700 hover:bg-amber-600 text-white font-bold py-3 rounded transition mt-4">
-                            Ver Recomendación
+                            Ver Orientación
                         </button>
                     </div>
 
@@ -282,9 +321,9 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
                             Tu resultado aparecerá aquí...
                         </div>
                         <div id="result-content" class="hidden relative z-10">
-                            <span class="text-sm text-xolo-400 uppercase tracking-widest">Recomendamos:</span>
+                            <span class="text-sm text-xolo-400 uppercase tracking-widest">Orientación inicial:</span>
                             <h4 id="res-title" class="text-4xl font-bold text-white my-2">Xolo Miniatura</h4>
-                            <p id="res-desc" class="text-xolo-200 text-lg mb-4">Ideal para espacios compactos.</p>
+                            <p id="res-desc" class="text-xolo-200 text-lg mb-4">Puede adaptarse a espacios compactos con actividad y acompañamiento adecuados.</p>
                             <div class="inline-block bg-xolo-900/50 px-4 py-2 rounded text-sm text-amber-400 border border-amber-800/50">
                                 <span id="res-reason">Debido a que vives en un apartamento.</span>
                             </div>
@@ -296,15 +335,35 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
             </div>
         </section>
 
+        <section aria-labelledby="lecturas-tallas" class="bg-white p-6 md:p-8 rounded-xl shadow-sm border border-xolo-200">
+          <h2 id="lecturas-tallas" class="text-2xl font-bold text-xolo-900 mb-3">Continúa preparando tu decisión</h2>
+          <p class="text-xolo-600 mb-5">La talla es solo una parte de la compatibilidad. Revisa también el temperamento, los cuidados y el acompañamiento de crianza.</p>
+          <div class="grid grid-cols-1 md:grid-cols-3 gap-4">
+            <a href="xoloitzcuintle-temperamento.html" class="border border-xolo-200 rounded-lg p-4 hover:border-amber-700 transition" data-cta="editorial-link" data-cta-location="related-content">
+              <strong class="block text-xolo-900">Temperamento y convivencia</strong>
+              <span class="text-sm text-xolo-600">Qué esperar y cómo valorar la compatibilidad familiar.</span>
+            </a>
+            <a href="precio-xoloitzcuintle.html" class="border border-xolo-200 rounded-lg p-4 hover:border-amber-700 transition" data-cta="editorial-link" data-cta-location="related-content">
+              <strong class="block text-xolo-900">Qué incluye el proceso</strong>
+              <span class="text-sm text-xolo-600">Crianza, documentación y orientación personalizada.</span>
+            </a>
+            <a href="xoloitzcuintle-alimentacion.html" class="border border-xolo-200 rounded-lg p-4 hover:border-amber-700 transition" data-cta="editorial-link" data-cta-location="related-content">
+              <strong class="block text-xolo-900">Alimentación por etapa</strong>
+              <span class="text-sm text-xolo-600">Una guía general para conversar con tu veterinario.</span>
+            </a>
+          </div>
+        </section>
+
         <div class="cta-blog-footer" style="background: linear-gradient(145deg, rgba(24, 20, 18, 0.95), rgba(40, 28, 26, 0.95)); border: 1px solid var(--color-dorado, #d4af37); border-radius: 12px; padding: 2.5rem 1.5rem; text-align: center; margin: 3rem auto; max-width: 800px; box-shadow: 0 15px 35px rgba(0, 0, 0, 0.4);">
   
-  <h3 style="color: var(--color-dorado, #d4af37); font-family: 'Cinzel', serif; margin-top: 0; margin-bottom: 1rem; font-size: clamp(1.5rem, 4vw, 2rem);">¿Ya sabes qué talla es ideal para tu hogar?</h3>
+  <h2 style="color: var(--color-dorado, #d4af37); font-family: 'Cinzel', serif; margin-top: 0; margin-bottom: 1rem; font-size: clamp(1.5rem, 4vw, 2rem);">¿Quieres conocer los ejemplares actuales?</h2>
   
   <p style="color: var(--color-texto, #f1e6d6); font-size: 1.1rem; margin-bottom: 2rem; max-width: 600px; margin-left: auto; margin-right: auto; line-height: 1.6;">
-    Conoce a los ejemplares que tenemos listos para integrarse a tu familia. Todos se entregan con certificado de salud, esquema de vacunación y su exclusivo <strong>registro NFT de linaje</strong>.
+    Consulta los ejemplares documentados como disponibles y conoce su talla, edad y etapa de desarrollo. El proceso incluye documentación veterinaria y un
+    registro digital documental que acompaña información y evidencias del ejemplar.
   </p>
   
-  <a href="../xolos-disponibles.html" class="btn" style="padding: 1rem 2.5rem; font-size: 1.1rem; border-radius: 999px; box-shadow: 0 10px 25px rgba(212, 175, 55, 0.3); display: inline-block; color: #181412; font-weight: 700;">
+  <a href="../xolos-disponibles.html" class="btn" data-cta="availability" data-cta-location="article-footer" style="padding: 1rem 2.5rem; font-size: 1.1rem; border-radius: 999px; box-shadow: 0 10px 25px rgba(212, 175, 55, 0.3); display: inline-block; color: #181412; font-weight: 700;">
     Ver Xolos Disponibles 🐾
   </a>
 
@@ -326,7 +385,7 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
                 height: "25 - 35 cm",
                 heightVal: 35, // for visualization scaling
                 weight: "4 - 8 kg",
-                desc: "La variedad más pequeña. Perfecta para la vida urbana en apartamentos o espacios reducidos. Aunque es pequeño, es robusto y un excelente perro de compañía y alerta.",
+                desc: "La variedad más pequeña puede adaptarse a la vida urbana cuando recibe ejercicio, socialización y acompañamiento acordes con el ejemplar.",
                 space: "Apartamento, Loft, Interior.",
                 color: "bg-xolo-500"
             },
@@ -335,7 +394,7 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
                 height: "36 - 45 cm",
                 heightVal: 45,
                 weight: "8 - 15 kg",
-                desc: "El equilibrio perfecto. Lo suficientemente pequeño para ser manejable en interiores, pero con suficiente estructura para ser un buen guardián y compañero de caminatas.",
+                desc: "La talla intermedia combina una estructura manejable con capacidad para acompañar caminatas; su adaptación depende de la actividad y educación que reciba.",
                 space: "Casa pequeña, Apartamento grande (con paseos), Patio.",
                 color: "bg-xolo-600"
             },
@@ -344,7 +403,7 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
                 height: "46 - 60 cm",
                 heightVal: 60,
                 weight: "18 - 30+ kg",
-                desc: "El Xolo original e histórico. Un animal elegante y poderoso con una presencia imponente. Requiere educación firme y espacio para moverse.",
+                desc: "La talla estándar tiene una estructura más grande y necesita espacio para moverse, actividad constante y educación respetuosa.",
                 space: "Casa con jardín, Propiedades amplias. Requiere ejercicio.",
                 color: "bg-xolo-800"
             }
@@ -414,7 +473,7 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
             // Simple Decision Logic
             if (home === 'apt_small') {
                 resultKey = 'mini';
-                reason = "Para un apartamento pequeño, la talla Miniatura asegura comodidad para ambos.";
+                reason = "En un apartamento pequeño, la talla Miniatura puede ser una opción a explorar si se cubren sus necesidades de actividad.";
             } else if (home === 'apt_large' || home === 'house_small') {
                 if (activity === 'high') {
                     resultKey = 'inter';
@@ -429,7 +488,7 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
                     reason = "Tienes gran espacio, pero un Estándar requiere más actividad física de la que indicas.";
                 } else {
                     resultKey = 'std';
-                    reason = "¡Perfecto! Tienes el espacio y la energía para manejar la majestuosidad de un Estándar.";
+                    reason = "Tu espacio y disponibilidad de actividad permiten explorar la talla Estándar; aún conviene valorar al ejemplar y la dinámica familiar.";
                 }
             }
 

--- a/blog/morfologia-orejas-xoloitzcuintle.html
+++ b/blog/morfologia-orejas-xoloitzcuintle.html
@@ -150,6 +150,16 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
     </div>
 </header>
 
+<nav aria-label="Migas de pan" style="max-width: 72rem; margin: 0 auto; padding: 1rem 1rem 0; background: #fff; color: #57534e; font-size: 0.875rem; line-height: 1.5;">
+    <ol style="display: flex; flex-wrap: wrap; align-items: center; gap: 0.5rem; margin: 0; padding: 0; list-style: none;">
+        <li><a href="../index.html" style="color: inherit; text-decoration: underline; text-underline-offset: 0.2em;">Inicio</a></li>
+        <li aria-hidden="true">›</li>
+        <li><a href="index.html" style="color: inherit; text-decoration: underline; text-underline-offset: 0.2em;">Blog</a></li>
+        <li aria-hidden="true">›</li>
+        <li aria-current="page">Orejas del xoloitzcuintle</li>
+    </ol>
+</nav>
+
 <main class="max-w-6xl mx-auto px-4 pb-24 space-y-24">
 
     <section id="anatomia" class="scroll-mt-24">
@@ -189,9 +199,9 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
 
     <section id="desarrollo" class="scroll-mt-24 bg-white p-8 md:p-12 rounded-3xl shadow-sm border border-xolo-light">
         <div class="mb-10">
-            <h2 class="text-3xl font-bold text-xolo-dark mb-4">Línea de Tiempo del Desarrollo</h2>
+            <h2 class="text-3xl font-bold text-xolo-dark mb-4">Etapas cualitativas de observación</h2>
             <p class="text-gray-700 max-w-4xl leading-relaxed">
-                La posición de las orejas puede cambiar durante el crecimiento y no todos los cachorros siguen el mismo calendario. Esta herramienta muestra un recorrido orientativo; la talla no permite predecir una fecha ni garantizar el resultado.
+                La posición de las orejas puede cambiar durante el crecimiento y cada cachorro presenta variación individual. Esta herramienta organiza puntos de observación sin asignar edades, plazos ni un resultado esperado.
             </p>
         </div>
 
@@ -335,27 +345,23 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
         }
     });
 
-    const timelineData = {
-        estandar: [1, 1.5, 2, 2.5, 3, 3.2, 3.4, 3.5],
-        miniatura: [1, 1.5, 2, 2.5, 3, 3.2, 3.4, 3.5]
+    const observationData = {
+        estandar: [1, 1, 1, 1],
+        miniatura: [1, 1, 1, 1]
     };
     
     const ctxTimeline = document.getElementById('timelineChart').getContext('2d');
     let timelineChart = new Chart(ctxTimeline, {
-        type: 'line',
+        type: 'bar',
         data: {
-            labels: ['Mes 1', 'Mes 2', 'Mes 3', 'Mes 4', 'Mes 5', 'Mes 6', 'Mes 7', 'Mes 8'],
+            labels: ['Observación inicial', 'Cambios durante el crecimiento', 'Variación individual', 'Seguimiento'],
             datasets: [{
-                label: 'Recorrido visual de observación',
-                data: timelineData.estandar,
-                borderColor: '#C68D5B',
-                backgroundColor: 'rgba(198, 141, 91, 0.1)',
-                borderWidth: 3,
-                pointBackgroundColor: '#8B5A2B',
-                pointRadius: 5,
-                pointHoverRadius: 8,
-                fill: true,
-                tension: 0.4
+                label: 'Puntos de observación sin orden temporal',
+                data: observationData.estandar,
+                backgroundColor: ['#C68D5B', '#E5D3C8', '#8B5A2B', '#B8A89A'],
+                borderColor: '#8B5A2B',
+                borderWidth: 1,
+                borderRadius: 6
             }]
         },
         options: {
@@ -364,9 +370,9 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
             scales: {
                 y: {
                     beginAtZero: true,
-                    max: 4,
+                    max: 1.2,
                     ticks: { display: false },
-                    title: { display: true, text: 'Cambio individual' },
+                    title: { display: true, text: 'Observación cualitativa' },
                     grid: { borderDash: [5, 5], color: '#f3f4f6' }
                 },
                 x: {
@@ -378,7 +384,13 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
                 tooltip: {
                     callbacks: {
                         label: function(context) {
-                            return 'Referencia visual; no expresa probabilidad ni plazo garantizado.';
+                            const notes = [
+                                'Registra la forma sin asumir un resultado final.',
+                                'Compara cambios sin fijar plazos.',
+                                'Reconoce diferencias entre ejemplares.',
+                                'Consulta ante molestias, lesiones o secreciones.'
+                            ];
+                            return notes[context.dataIndex];
                         }
                     }
                 }
@@ -396,9 +408,9 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
         btnMiniatura.classList.remove('active-btn');
         btnMiniatura.classList.add('inactive-btn');
         
-        timelineChart.data.datasets[0].data = timelineData.estandar;
-        timelineChart.data.datasets[0].borderColor = '#C68D5B';
-        timelineChart.data.datasets[0].backgroundColor = 'rgba(198, 141, 91, 0.1)';
+        timelineChart.data.datasets[0].data = observationData.estandar;
+        timelineChart.data.datasets[0].borderColor = '#8B5A2B';
+        timelineChart.data.datasets[0].backgroundColor = ['#C68D5B', '#E5D3C8', '#8B5A2B', '#B8A89A'];
         timelineChart.update();
         
         insightText.textContent = 'En la talla estándar también existe variación individual. Registra cambios y consulta ante dolor, inflamación, secreción o lesiones.';
@@ -410,9 +422,9 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
         btnEstandar.classList.remove('active-btn');
         btnEstandar.classList.add('inactive-btn');
         
-        timelineChart.data.datasets[0].data = timelineData.miniatura;
+        timelineChart.data.datasets[0].data = observationData.miniatura;
         timelineChart.data.datasets[0].borderColor = '#8B5A2B';
-        timelineChart.data.datasets[0].backgroundColor = 'rgba(139, 90, 43, 0.1)';
+        timelineChart.data.datasets[0].backgroundColor = ['#8B5A2B', '#B8A89A', '#C68D5B', '#E5D3C8'];
         timelineChart.update();
         
         insightText.textContent = 'La talla miniatura no garantiza un desarrollo más rápido. El seguimiento debe basarse en el ejemplar y no en un calendario rígido.';

--- a/blog/morfologia-orejas-xoloitzcuintle.html
+++ b/blog/morfologia-orejas-xoloitzcuintle.html
@@ -1,9 +1,63 @@
 <!DOCTYPE html>
 <html lang="es">
 <head>
+    <!-- Google Tag Manager -->
+    <script>
+      (function (w, d, s, l, i) {
+        w[l] = w[l] || [];
+        w[l].push({ 'gtm.start': new Date().getTime(), event: 'gtm.js' });
+        var f = d.getElementsByTagName(s)[0],
+          j = d.createElement(s),
+          dl = l != 'dataLayer' ? '&l=' + l : '';
+        j.async = true;
+        j.src = 'https://www.googletagmanager.com/gtm.js?id=' + i + dl;
+        f.parentNode.insertBefore(j, f);
+      })(window, document, 'script', 'dataLayer', 'GTM-MGTMWN7T');
+    </script>
+    <!-- End Google Tag Manager -->
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Orejas de Murciélago: El Xoloitzcuintle</title>
+    <link rel="canonical" href="https://xolosramirez.com/blog/morfologia-orejas-xoloitzcuintle.html">
+    <link rel="alternate" hreflang="es-MX" href="https://xolosramirez.com/blog/morfologia-orejas-xoloitzcuintle.html">
+    <link rel="alternate" hreflang="x-default" href="https://xolosramirez.com/blog/morfologia-orejas-xoloitzcuintle.html">
+    <title>Orejas del xoloitzcuintle: desarrollo y cuidados | Xolos Ramírez</title>
+    <meta name="description" content="Guía sobre la morfología y el desarrollo de las orejas del xoloitzcuintle, la variación individual y prácticas que deben revisarse con un veterinario.">
+    <meta property="og:type" content="article">
+    <meta property="og:locale" content="es_MX">
+    <meta property="og:site_name" content="Xolos Ramírez">
+    <meta property="og:title" content="Orejas del xoloitzcuintle: desarrollo y cuidados">
+    <meta property="og:description" content="Anatomía general, seguimiento individual y mitos frecuentes sin porcentajes genéticos no respaldados.">
+    <meta property="og:url" content="https://xolosramirez.com/blog/morfologia-orejas-xoloitzcuintle.html">
+    <meta property="og:image" content="https://xolosramirez.com/img/hero/site-hero.jpg">
+    <meta name="twitter:card" content="summary_large_image">
+    <meta name="twitter:title" content="Orejas del xoloitzcuintle: desarrollo y cuidados">
+    <meta name="twitter:description" content="Qué observar durante el crecimiento y cuándo pedir orientación profesional.">
+    <meta name="twitter:image" content="https://xolosramirez.com/img/hero/site-hero.jpg">
+    <script type="application/ld+json">
+      {
+        "@context": "https://schema.org",
+        "@graph": [
+          {
+            "@type": "Article",
+            "headline": "Orejas del xoloitzcuintle: desarrollo y cuidados",
+            "description": "Guía sobre la morfología y el desarrollo de las orejas del xoloitzcuintle, la variación individual y prácticas que deben revisarse con un veterinario.",
+            "inLanguage": "es-MX",
+            "mainEntityOfPage": "https://xolosramirez.com/blog/morfologia-orejas-xoloitzcuintle.html",
+            "author": { "@type": "Organization", "name": "Xolos Ramírez" },
+            "publisher": { "@type": "Organization", "name": "Xolos Ramírez" },
+            "image": "https://xolosramirez.com/img/hero/site-hero.jpg"
+          },
+          {
+            "@type": "BreadcrumbList",
+            "itemListElement": [
+              { "@type": "ListItem", "position": 1, "name": "Inicio", "item": "https://xolosramirez.com/" },
+              { "@type": "ListItem", "position": 2, "name": "Blog", "item": "https://xolosramirez.com/blog/index.html" },
+              { "@type": "ListItem", "position": 3, "name": "Orejas del xoloitzcuintle", "item": "https://xolosramirez.com/blog/morfologia-orejas-xoloitzcuintle.html" }
+            ]
+          }
+        ]
+      }
+    </script>
     <script src="https://cdn.tailwindcss.com"></script>
     <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
     <style>
@@ -61,6 +115,10 @@
     </script>
 </head>
 <body class="antialiased overflow-x-hidden">
+<!-- Google Tag Manager (noscript) -->
+<noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-MGTMWN7T"
+height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
+<!-- End Google Tag Manager (noscript) -->
 
 <!-- Chosen Palette: Warm Neutrals & Terracotta (Bg: #FDFBF7, Text: #3E3A35, Accents: #C68D5B, #E5D3C8, #8B5A2B) -->
 <!-- Application Structure Plan: The SPA uses a single-column narrative flow optimized for scrolling and discovery. It is divided into logical thematic sections: 1. Introduction (context setting), 2. Anatomy (composition visualization), 3. Development Timeline (interactive chronological data), 4. Genetics (comparative data), and 5. Myths (interactive qualitative facts). This structure guides the user from basic biological understanding to developmental tracking, genetic causation, and finally cultural demystification, making a complex biological report easy to digest. -->
@@ -82,12 +140,12 @@
 <header class="pt-20 pb-16 px-4">
     <div class="max-w-4xl mx-auto text-center">
         <div class="text-6xl mb-4">🐕</div>
-        <h1 class="text-4xl md:text-5xl font-bold text-xolo-dark mb-6 leading-tight">El Fenómeno de las "Orejas de Murciélago"</h1>
+        <h1 class="text-4xl md:text-5xl font-bold text-xolo-dark mb-6 leading-tight">Orejas del Xoloitzcuintle: Desarrollo y Cuidados</h1>
         <p class="text-lg md:text-xl text-gray-600 mb-8 max-w-3xl mx-auto leading-relaxed">
-            Una exploración interactiva sobre el cartílago auricular del Xoloitzcuintle. Descubre la biología, el desarrollo cronológico y los factores genéticos que dan forma a una de las características más distintivas de esta antigua raza mexicana.
+            Una guía interactiva sobre anatomía general, cambios durante el crecimiento y variación individual en una de las características más reconocibles de esta raza mexicana.
         </p>
         <div class="flex justify-center gap-4">
-            <a href="#anatomia" class="bg-xolo-accent text-white px-6 py-3 rounded-full font-semibold hover:bg-xolo-dark transition shadow-md">Explorar Datos</a>
+            <a href="#anatomia" class="bg-xolo-accent text-white px-6 py-3 rounded-full font-semibold hover:bg-xolo-dark transition shadow-md">Explorar la guía</a>
         </div>
     </div>
 </header>
@@ -98,13 +156,13 @@
         <div class="mb-10 text-center md:text-left">
             <h2 class="text-3xl font-bold text-xolo-dark mb-4">Anatomía del Cartílago Auricular</h2>
             <p class="text-gray-700 max-w-3xl leading-relaxed">
-                Esta sección desglosa la composición biológica que permite a las orejas del Xoloitzcuintle mantenerse erguidas. A diferencia de las razas con orejas caídas, el "cartílago de murciélago" requiere una matriz estructural densa. Interactúa con el gráfico para ver los componentes clave que otorgan rigidez y flexibilidad.
+                El pabellón auricular contiene cartílago, tejido conjuntivo, vasos, nervios y piel. La forma final depende de estructura, desarrollo y variación individual. El gráfico es conceptual y no representa porcentajes medidos en xoloitzcuintles.
             </p>
         </div>
         
         <div class="grid grid-cols-1 md:grid-cols-2 gap-12 items-center">
             <div class="bg-white p-8 rounded-2xl shadow-sm border border-xolo-light">
-                <h3 class="text-xl font-semibold mb-4 border-b border-xolo-light pb-2">Composición del Cartílago (Adulto)</h3>
+                <h3 class="text-xl font-semibold mb-4 border-b border-xolo-light pb-2">Componentes del tejido auricular</h3>
                 <div class="chart-container">
                     <canvas id="cartilageChart"></canvas>
                 </div>
@@ -112,18 +170,18 @@
             <div class="space-y-6">
                 <div class="bg-xolo-light/30 p-6 rounded-xl border border-xolo-light">
                     <div class="text-2xl mb-2">🧬</div>
-                    <h4 class="font-bold text-xolo-dark text-lg">Colágeno Tipo II (60%)</h4>
-                    <p class="text-sm text-gray-700 mt-2">La proteína estructural primaria. Proporciona la fuerza de tracción necesaria para soportar el tamaño de la oreja sin colapsar bajo la gravedad.</p>
+                    <h4 class="font-bold text-xolo-dark text-lg">Colágeno</h4>
+                    <p class="text-sm text-gray-700 mt-2">Forma parte de la matriz del cartílago y contribuye a su estructura. No determina por sí solo la posición final de la oreja.</p>
                 </div>
                 <div class="bg-xolo-light/30 p-6 rounded-xl border border-xolo-light">
                     <div class="text-2xl mb-2">💧</div>
-                    <h4 class="font-bold text-xolo-dark text-lg">Matriz Extracelular y Agua (25%)</h4>
-                    <p class="text-sm text-gray-700 mt-2">Los proteoglicanos retienen agua, dando turgencia al tejido. Esencial para la absorción de impactos y la recuperación de la forma.</p>
+                    <h4 class="font-bold text-xolo-dark text-lg">Matriz extracelular y agua</h4>
+                    <p class="text-sm text-gray-700 mt-2">Ayudan a conservar las propiedades mecánicas del tejido y forman parte de su funcionamiento normal.</p>
                 </div>
                 <div class="bg-xolo-light/30 p-6 rounded-xl border border-xolo-light">
                     <div class="text-2xl mb-2">⚡</div>
-                    <h4 class="font-bold text-xolo-dark text-lg">Elastina (15%)</h4>
-                    <p class="text-sm text-gray-700 mt-2">Permite la flexibilidad. Una oreja de Xolo no es rígida como el hueso; debe poder girar como un radar para detectar sonidos.</p>
+                    <h4 class="font-bold text-xolo-dark text-lg">Fibras elásticas y tejidos asociados</h4>
+                    <p class="text-sm text-gray-700 mt-2">Contribuyen a la flexibilidad y al movimiento de la oreja junto con músculos, piel y tejido conjuntivo.</p>
                 </div>
             </div>
         </div>
@@ -133,7 +191,7 @@
         <div class="mb-10">
             <h2 class="text-3xl font-bold text-xolo-dark mb-4">Línea de Tiempo del Desarrollo</h2>
             <p class="text-gray-700 max-w-4xl leading-relaxed">
-                Ningún cachorro de Xolo nace con las orejas erguidas. El proceso de endurecimiento del cartílago ocurre durante los primeros meses de vida. Esta herramienta interactiva te permite comparar la tasa de desarrollo entre la variedad Estándar y la Miniatura. Selecciona una variedad para actualizar la gráfica.
+                La posición de las orejas puede cambiar durante el crecimiento y no todos los cachorros siguen el mismo calendario. Esta herramienta muestra un recorrido orientativo; la talla no permite predecir una fecha ni garantizar el resultado.
             </p>
         </div>
 
@@ -148,7 +206,7 @@
                 </button>
                 
                 <div id="timelineInsight" class="mt-8 p-4 bg-xolo-bg rounded-lg border border-xolo-accent border-opacity-30">
-                    <p class="text-sm text-gray-700 font-medium">📌 <span id="insightText">Los Xolos estándar suelen tener un desarrollo más gradual debido al mayor peso y superficie del cartílago auricular.</span></p>
+                    <p class="text-sm text-gray-700 font-medium">📌 <span id="insightText">En la talla estándar también existe variación individual. Registra cambios con fotografías y consulta si observas dolor, inflamación, secreción o lesiones.</span></p>
                 </div>
             </div>
             
@@ -162,15 +220,15 @@
 
     <section id="genetica" class="scroll-mt-24">
         <div class="mb-10 text-center md:text-left">
-            <h2 class="text-3xl font-bold text-xolo-dark mb-4">El Factor Genético: Mutación FOXI3</h2>
+            <h2 class="text-3xl font-bold text-xolo-dark mb-4">Genética, variedad y límites de la evidencia</h2>
             <p class="text-gray-700 max-w-3xl leading-relaxed">
-                El gen FOXI3 es responsable de la falta de pelo y de ciertas anomalías dentales en el Xoloitzcuintle. Nuestra investigación demuestra una fuerte correlación entre la presencia de este alelo mutado y la rigidez estructural del cartílago auricular. Compara las diferencias anatómicas observadas.
+                Variantes relacionadas con FOXI3 se asocian con el fenotipo sin pelo y cambios dentales. Eso no permite asignar porcentajes universales de orejas erguidas ni atribuir la posición auricular a un solo gen.
             </p>
         </div>
 
         <div class="grid grid-cols-1 md:grid-cols-5 gap-8 items-center">
             <div class="md:col-span-3 bg-white p-6 rounded-2xl shadow-sm border border-xolo-light">
-                <h3 class="text-xl font-semibold mb-4 text-center">Tasa de Éxito en Erección Auricular Natural</h3>
+                <h3 class="text-xl font-semibold mb-4 text-center">Qué relación está documentada</h3>
                 <div class="chart-container">
                     <canvas id="geneticsChart"></canvas>
                 </div>
@@ -178,11 +236,11 @@
             <div class="md:col-span-2 space-y-6">
                 <div class="bg-white p-6 rounded-xl border-l-4 border-xolo-accent shadow-sm">
                     <h4 class="font-bold text-gray-800 mb-2">Variedad Sin Pelo (Heterocigoto)</h4>
-                    <p class="text-sm text-gray-600">Poseen una copia del gen FOXI3 mutado. Los datos muestran una predisposición casi absoluta (95%) a desarrollar cartílago lo suficientemente denso para orejas completamente erguidas.</p>
+                    <p class="text-sm text-gray-600">El fenotipo sin pelo y ciertos cambios dentales están relacionados con variantes en FOXI3. La posición de las orejas presenta variación y no debe expresarse como una probabilidad universal.</p>
                 </div>
                 <div class="bg-white p-6 rounded-xl border-l-4 border-gray-400 shadow-sm">
                     <h4 class="font-bold text-gray-800 mb-2">Variedad Con Pelo (Homocigoto Recesivo)</h4>
-                    <p class="text-sm text-gray-600">Carecen de la mutación. Su cartílago tiende a ser más suave y pesado, resultando en un 30% de individuos con orejas semi-caídas o completamente caídas en la edad adulta.</p>
+                    <p class="text-sm text-gray-600">La variedad con pelo forma parte de la raza. No hay base en esta página para asignarle un porcentaje específico de orejas caídas ni una calidad inferior de cartílago.</p>
                 </div>
             </div>
         </div>
@@ -192,7 +250,7 @@
         <div class="mb-10 text-center">
             <h2 class="text-3xl font-bold text-xolo-light mb-4">Desmintiendo Mitos del Cartílago</h2>
             <p class="text-gray-300 max-w-2xl mx-auto leading-relaxed">
-                Existen numerosas prácticas populares destinadas a "ayudar" a las orejas a levantarse. Haz clic en las tarjetas a continuación para revelar los datos científicos sobre estas intervenciones comunes.
+                Existen prácticas populares destinadas a “ayudar” a las orejas a levantarse. Haz clic para conocer por qué no deben aplicarse como recetas universales y cuándo consultar a un profesional.
             </p>
         </div>
 
@@ -201,7 +259,7 @@
                 <div class="text-3xl mb-3">🥛</div>
                 <h3 class="text-xl font-bold mb-3 text-white myth-title">Mito: Calcio Extra</h3>
                 <p class="text-gray-300 text-sm myth-content hidden">
-                    <strong class="text-xolo-light">Realidad:</strong> El cartílago auricular NO es hueso. No se calcifica. Dar suplementos de calcio a un cachorro no endurece las orejas y puede causar graves problemas de desarrollo óseo en otras partes del cuerpo.
+                    <strong class="text-xolo-light">Criterio:</strong> El cartílago auricular no es hueso. No añadas calcio ni otros suplementos con el objetivo de levantar las orejas sin una indicación veterinaria; una dosis innecesaria puede ser perjudicial.
                 </p>
                 <div class="text-xs text-xolo-accent mt-4 font-semibold uppercase tracking-wider myth-prompt">Haz clic para revelar</div>
             </div>
@@ -210,7 +268,7 @@
                 <div class="text-3xl mb-3">🩹</div>
                 <h3 class="text-xl font-bold mb-3 text-white myth-title">Mito: Vendajes Constantes</h3>
                 <p class="text-gray-300 text-sm myth-content hidden">
-                    <strong class="text-xolo-light">Realidad:</strong> Vendar las orejas inmoviliza los músculos de la base. El cartílago necesita el estímulo del movimiento muscular para fortalecer su matriz. El vendaje excesivo puede atrofiar los músculos, impidiendo la erección permanente.
+                    <strong class="text-xolo-light">Criterio:</strong> Un vendaje mal aplicado puede irritar la piel, retener humedad o causar lesiones. No garantiza una posición final y solo debe considerarse con supervisión profesional.
                 </p>
                 <div class="text-xs text-xolo-accent mt-4 font-semibold uppercase tracking-wider myth-prompt">Haz clic para revelar</div>
             </div>
@@ -219,10 +277,20 @@
                 <div class="text-3xl mb-3">✂️</div>
                 <h3 class="text-xl font-bold mb-3 text-white myth-title">Mito: Rasurar la Oreja</h3>
                 <p class="text-gray-300 text-sm myth-content hidden">
-                    <strong class="text-xolo-light">Realidad:</strong> En la variedad con pelo, afeitar el vello de la oreja reduce el peso marginalmente, pero rara vez es el factor decisivo. La integridad genética y nutricional del cartílago subyacente es lo que determina el resultado final.
+                    <strong class="text-xolo-light">Criterio:</strong> Rasurar el pelo no modifica la genética ni garantiza que la oreja quede erguida. Evita causar irritación y pide orientación antes de intervenir.
                 </p>
                 <div class="text-xs text-xolo-accent mt-4 font-semibold uppercase tracking-wider myth-prompt">Haz clic para revelar</div>
             </div>
+        </div>
+    </section>
+
+    <section aria-labelledby="lecturas-relacionadas" class="bg-white p-8 md:p-12 rounded-3xl shadow-sm border border-xolo-light">
+        <h2 id="lecturas-relacionadas" class="text-3xl font-bold text-xolo-dark mb-4">Continúa conociendo la morfología del Xolo</h2>
+        <p class="text-gray-700 mb-6">Relaciona el desarrollo de las orejas con talla, piel y observación del ejemplar completo.</p>
+        <div class="grid grid-cols-1 md:grid-cols-3 gap-4">
+            <a href="guia-tallas-xoloitzcuintle.html" data-cta="editorial-link" data-cta-location="related-content" class="rounded-xl border border-xolo-light p-5 hover:border-xolo-accent transition">Guía de tallas →</a>
+            <a href="cuidado-de-la-piel-del-xoloitzcuintle.html" data-cta="editorial-link" data-cta-location="related-content" class="rounded-xl border border-xolo-light p-5 hover:border-xolo-accent transition">Cuidado de la piel →</a>
+            <a href="../xolos-disponibles.html" data-cta="availability" data-cta-location="related-content" class="rounded-xl border border-xolo-light p-5 hover:border-xolo-accent transition">Conoce a los Xolos →</a>
         </div>
     </section>
 
@@ -230,7 +298,7 @@
 
 <footer class="bg-white border-t border-xolo-light py-8 text-center text-gray-500 text-sm">
     <div class="max-w-6xl mx-auto px-4">
-        <p>Informe interactivo sobre la anatomía y genética del Xoloitzcuintle.</p>
+        <p>Guía educativa general; no sustituye una evaluación veterinaria ni predice el desarrollo de un cachorro.</p>
     </div>
 </footer>
 
@@ -242,9 +310,9 @@
     new Chart(ctxCartilage, {
         type: 'doughnut',
         data: {
-            labels: ['Colágeno Tipo II', 'Agua/Matriz', 'Elastina', 'Otros Minerales'],
+            labels: ['Colágeno', 'Matriz y agua', 'Fibras elásticas', 'Células y tejidos asociados'],
             datasets: [{
-                data: [60, 25, 15, 5],
+                data: [1, 1, 1, 1],
                 backgroundColor: ['#C68D5B', '#E5D3C8', '#8B5A2B', '#EFEFEF'],
                 borderWidth: 0,
                 hoverOffset: 10
@@ -268,8 +336,8 @@
     });
 
     const timelineData = {
-        estandar: [0, 5, 15, 30, 55, 75, 90, 95],
-        miniatura: [0, 15, 40, 70, 90, 98, 100, 100]
+        estandar: [1, 1.5, 2, 2.5, 3, 3.2, 3.4, 3.5],
+        miniatura: [1, 1.5, 2, 2.5, 3, 3.2, 3.4, 3.5]
     };
     
     const ctxTimeline = document.getElementById('timelineChart').getContext('2d');
@@ -278,7 +346,7 @@
         data: {
             labels: ['Mes 1', 'Mes 2', 'Mes 3', 'Mes 4', 'Mes 5', 'Mes 6', 'Mes 7', 'Mes 8'],
             datasets: [{
-                label: '% con Orejas Completamente Erguidas',
+                label: 'Recorrido visual de observación',
                 data: timelineData.estandar,
                 borderColor: '#C68D5B',
                 backgroundColor: 'rgba(198, 141, 91, 0.1)',
@@ -296,8 +364,9 @@
             scales: {
                 y: {
                     beginAtZero: true,
-                    max: 100,
-                    title: { display: true, text: 'Porcentaje (%)' },
+                    max: 4,
+                    ticks: { display: false },
+                    title: { display: true, text: 'Cambio individual' },
                     grid: { borderDash: [5, 5], color: '#f3f4f6' }
                 },
                 x: {
@@ -309,7 +378,7 @@
                 tooltip: {
                     callbacks: {
                         label: function(context) {
-                            return context.parsed.y + '% de la población evaluada';
+                            return 'Referencia visual; no expresa probabilidad ni plazo garantizado.';
                         }
                     }
                 }
@@ -332,7 +401,7 @@
         timelineChart.data.datasets[0].backgroundColor = 'rgba(198, 141, 91, 0.1)';
         timelineChart.update();
         
-        insightText.textContent = 'Los Xolos estándar suelen tener un desarrollo más gradual debido al mayor peso y superficie del cartílago auricular que deben sostener.';
+        insightText.textContent = 'En la talla estándar también existe variación individual. Registra cambios y consulta ante dolor, inflamación, secreción o lesiones.';
     });
 
     btnMiniatura.addEventListener('click', () => {
@@ -346,30 +415,22 @@
         timelineChart.data.datasets[0].backgroundColor = 'rgba(139, 90, 43, 0.1)';
         timelineChart.update();
         
-        insightText.textContent = 'Los Xolos miniatura levantan las orejas considerablemente más rápido, frecuentemente completando el proceso anatómico al cuarto o quinto mes.';
+        insightText.textContent = 'La talla miniatura no garantiza un desarrollo más rápido. El seguimiento debe basarse en el ejemplar y no en un calendario rígido.';
     });
 
     const ctxGenetics = document.getElementById('geneticsChart').getContext('2d');
     new Chart(ctxGenetics, {
         type: 'bar',
         data: {
-            labels: ['Erguidas', 'Semi-Erguidas', 'Caídas'],
-            datasets: [
-                {
-                    label: 'Sin Pelo (FOXI3 Mutado)',
-                    data: [95, 4, 1],
-                    backgroundColor: '#C68D5B',
-                    borderRadius: 6
-                },
-                {
-                    label: 'Con Pelo (Sin Mutación)',
-                    data: [70, 20, 10],
-                    backgroundColor: '#EFEFEF',
-                    borderWidth: 2,
-                    borderColor: '#D1D5DB',
-                    borderRadius: 6
-                }
-            ]
+            labels: ['Fenotipo sin pelo', 'Cambios dentales', 'Porcentaje universal de orejas erguidas'],
+            datasets: [{
+                label: 'Relación documentada en esta guía',
+                data: [1, 1, 0],
+                backgroundColor: ['#C68D5B', '#8B5A2B', '#EFEFEF'],
+                borderWidth: 2,
+                borderColor: '#D1D5DB',
+                borderRadius: 6
+            }]
         },
         options: {
             responsive: true,
@@ -377,8 +438,9 @@
             scales: {
                 y: {
                     beginAtZero: true,
-                    max: 100,
-                    title: { display: true, text: 'Porcentaje de la Población' },
+                    max: 1.2,
+                    ticks: { display: false },
+                    title: { display: true, text: 'Relación cualitativa' },
                     grid: { borderDash: [5, 5] }
                 },
                 x: {
@@ -389,7 +451,12 @@
                 legend: { position: 'top' },
                 tooltip: {
                     backgroundColor: 'rgba(62, 58, 53, 0.9)',
-                    padding: 12
+                    padding: 12,
+                    callbacks: {
+                        label: function(context) {
+                            return context.raw === 1 ? 'Relación descrita' : 'No se presenta como dato universal';
+                        }
+                    }
                 }
             }
         }

--- a/blog/precio-xoloitzcuintle.html
+++ b/blog/precio-xoloitzcuintle.html
@@ -18,8 +18,46 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <link rel="canonical" href="https://xolosramirez.com/blog/precio-xoloitzcuintle.html" />
-    <title>Precio de un Xoloitzcuintle: ¿Cuánto Cuesta y Qué Incluye? | Venta</title>
-    <meta name="description" content="Descubre el precio real de un perro xoloitzcuintle (miniatura, intermedio y estándar). Conoce los factores que definen su valor, linaje y cachorros disponibles en nuestro criadero.">
+    <link rel="alternate" hreflang="es-MX" href="https://xolosramirez.com/blog/precio-xoloitzcuintle.html" />
+    <link rel="alternate" hreflang="x-default" href="https://xolosramirez.com/blog/precio-xoloitzcuintle.html" />
+    <title>Precio de un Xoloitzcuintle: factores y qué incluye | Xolos Ramírez</title>
+    <meta name="description" content="Conoce qué factores influyen en el precio de un xoloitzcuintle, qué incluye el proceso de crianza y cómo solicitar orientación personalizada.">
+    <meta property="og:type" content="article" />
+    <meta property="og:locale" content="es_MX" />
+    <meta property="og:site_name" content="Xolos Ramírez" />
+    <meta property="og:title" content="Precio de un Xoloitzcuintle: factores y qué incluye" />
+    <meta property="og:description" content="Una guía sobre crianza ética, documentación, acompañamiento y los factores que influyen en cada proceso." />
+    <meta property="og:url" content="https://xolosramirez.com/blog/precio-xoloitzcuintle.html" />
+    <meta property="og:image" content="https://xolosramirez.com/img/hero/site-hero.jpg" />
+    <meta name="twitter:card" content="summary_large_image" />
+    <meta name="twitter:title" content="Precio de un Xoloitzcuintle: factores y qué incluye" />
+    <meta name="twitter:description" content="Qué influye en el proceso y cómo recibir orientación personalizada de Xolos Ramírez." />
+    <meta name="twitter:image" content="https://xolosramirez.com/img/hero/site-hero.jpg" />
+    <script type="application/ld+json">
+      {
+        "@context": "https://schema.org",
+        "@graph": [
+          {
+            "@type": "Article",
+            "headline": "Precio de un Xoloitzcuintle: factores y qué incluye",
+            "description": "Conoce qué factores influyen en el precio de un xoloitzcuintle, qué incluye el proceso de crianza y cómo solicitar orientación personalizada.",
+            "inLanguage": "es-MX",
+            "mainEntityOfPage": "https://xolosramirez.com/blog/precio-xoloitzcuintle.html",
+            "author": { "@type": "Organization", "name": "Xolos Ramírez" },
+            "publisher": { "@type": "Organization", "name": "Xolos Ramírez" },
+            "image": "https://xolosramirez.com/img/hero/site-hero.jpg"
+          },
+          {
+            "@type": "BreadcrumbList",
+            "itemListElement": [
+              { "@type": "ListItem", "position": 1, "name": "Inicio", "item": "https://xolosramirez.com/" },
+              { "@type": "ListItem", "position": 2, "name": "Blog", "item": "https://xolosramirez.com/blog/index.html" },
+              { "@type": "ListItem", "position": 3, "name": "Precio de un Xoloitzcuintle", "item": "https://xolosramirez.com/blog/precio-xoloitzcuintle.html" }
+            ]
+          }
+        ]
+      }
+    </script>
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
     <link
@@ -127,7 +165,7 @@
           <ul>
             <li><a href="../index.html">Inicio</a></li>
             <li><a href="../xolos-disponibles.html">Xolos disponibles</a></li>
-            <li><a href="../galeria.html">Galería</a></li>
+            <li><a href="../xolos-disponibles.html">Xolos disponibles</a></li>
             <li><a href="../testimonios.html">Testimonios</a></li>
             <li><a href="index.html">Blog</a></li>
             <li><a href="../contacto.html">Contacto</a></li>
@@ -177,9 +215,9 @@
             </p>
 
             <p>
-              El valor de un Xoloitzcuintle criado de forma ética, profesional y bajo los más estrictos estándares de zootecnia varía dependiendo de factores
-              como su talla (miniatura, intermedio o estándar) y sus características fenotípicas. Pero más allá de un número exacto, lo fundamental al buscar
-              un <strong>criadero de xoloitzcuintle</strong> es comprender <strong>qué respalda ese valor y qué garantías recibes</strong>.
+              La orientación para cada Xoloitzcuintle depende de factores como su etapa de desarrollo, talla, documentación, cuidados realizados y logística
+              de entrega. Por eso, antes de hablar de una cifra aislada, conviene comprender <strong>qué acompaña el proceso</strong> y conversar sobre la
+              compatibilidad del ejemplar con su futura familia.
             </p>
 
             <h2 style="color: var(--color-dorado, #d4af37); font-family: 'Cinzel', serif; margin-top: 3rem; margin-bottom: 1rem;">
@@ -187,9 +225,9 @@
             </h2>
 
             <p>
-              En Xolos Ramírez, nuestra prioridad no es la crianza masiva, sino la preservación absoluta de la pureza y el bienestar de la raza. Criar un
-              Xoloitzcuintle sano, equilibrado mentalmente y con un linaje documentado requiere de atención veterinaria constante, genética seleccionada,
-              nutrición premium y un ambiente estimulante desde el día en que nacen.
+              En Xolos Ramírez, nuestra prioridad no es la crianza masiva, sino el bienestar, la crianza responsable y la conservación documentada del
+              xoloitzcuintle. Cada cachorro recibe seguimiento veterinario, nutrición adecuada a su etapa y experiencias tempranas de socialización. También
+              acompañamos a la familia para valorar talla, entorno, expectativas y logística antes de avanzar.
             </p>
 
             <h2 style="color: var(--color-dorado, #d4af37); font-family: 'Cinzel', serif; margin-top: 3rem; margin-bottom: 1.5rem;">
@@ -206,31 +244,30 @@
                 <span class="value-icon">🩺</span>
                 <h3>Certificado de Salud</h3>
                 <p>
-                  Una garantía por escrito, expedida por médicos veterinarios certificados, de que tu Xolo se encuentra en perfectas condiciones físicas al
-                  momento de la entrega.
+                  Una valoración expedida por un médico veterinario que documenta el estado de salud observado y los cuidados realizados antes de la
+                  entrega.
                 </p>
               </div>
               <div class="value-card">
                 <span class="value-icon">💉</span>
                 <h3>Esquema de Vacunación</h3>
                 <p>
-                  Se entregan con su vacunación correspondiente a la edad y desparasitación al día, blindando su sistema inmunológico para una vida larga y
-                  saludable.
+                  Vacunación y desparasitación acordes con la edad y con la valoración veterinaria de cada ejemplar, acompañadas por su documentación.
                 </p>
               </div>
               <div class="value-card">
                 <span class="value-icon">📡</span>
                 <h3>Microchip de Identificación</h3>
                 <p>
-                  Tecnología de implantación subcutánea para la identificación permanente y segura de tu ejemplar a nivel internacional.
+                  Identificación mediante microchip ISO, vinculada con la documentación correspondiente del ejemplar.
                 </p>
               </div>
               <div class="value-card nft-card">
                 <span class="value-icon">🔗</span>
                 <h3>Registro NFT de Linaje Xoloitzcuintle</h3>
                 <p>
-                  <strong>Nuestro diferenciador exclusivo.</strong> Recibes un certificado digital inmutable alojado en la blockchain (mediante Tonalli Wallet)
-                  que prueba el <strong>Pedigree</strong>, la pureza, el árbol genealógico y la autenticidad absoluta de tu Xoloitzcuintle para siempre.
+                  Un registro digital documental que acompaña información y evidencias del ejemplar. Ayuda a conservar una referencia verificable de los
+                  documentos y acontecimientos registrados, pero no sustituye el registro FCM/FCI, una prueba genética ni la valoración veterinaria.
                 </p>
               </div>
             </div>
@@ -238,10 +275,22 @@
               Elige seguridad y autenticidad
             </h2>
             <p>
-              Buscar un "precio barato" al comprar un Xoloitzcuintle a menudo resulta en apoyar prácticas de crianza irresponsables, enfrentar problemas de
-              salud genéticos a largo plazo o la adquisición de un ejemplar mestizo sin los verdaderos rasgos temperamentales de la raza. Al elegir un
-              criadero especializado y de prestigio, inviertes en tranquilidad, en genética preservada y en un respaldo de por vida.
+              Una decisión responsable considera mucho más que el costo inicial: salud documentada, condiciones de crianza, socialización, claridad sobre
+              los documentos y acompañamiento durante la adaptación. Te recomendamos comparar procesos y hacer todas las preguntas necesarias antes de
+              elegir al ejemplar que puede integrarse mejor a tu familia.
             </p>
+
+            <section aria-labelledby="lecturas-relacionadas-precio" style="margin: 3rem 0;">
+              <h2 id="lecturas-relacionadas-precio" style="color: var(--color-dorado, #d4af37); font-family: 'Cinzel', serif;">
+                Continúa preparando tu decisión
+              </h2>
+              <p>Estas guías te ayudan a comparar talla, temperamento y documentación antes de solicitar orientación personalizada.</p>
+              <ul style="display: grid; gap: 0.8rem; padding-left: 1.25rem;">
+                <li><a href="guia-tallas-xoloitzcuintle.html" data-cta="editorial-link" data-cta-location="related-content">Comparar las tres tallas del xoloitzcuintle</a></li>
+                <li><a href="xoloitzcuintle-temperamento.html" data-cta="editorial-link" data-cta-location="related-content">Conocer su temperamento y necesidades de convivencia</a></li>
+                <li><a href="nft-linaje-xoloitzcuintle.html" data-cta="editorial-link" data-cta-location="related-content">Entender el registro documental NFT</a></li>
+              </ul>
+            </section>
 
             <div
               class="cta-blog-footer"
@@ -278,7 +327,8 @@
                   line-height: 1.6;
                 "
               >
-                Conoce a los ejemplares que tenemos listos para integrarse a tu familia. Entregas nacionales e internacionales garantizadas.
+                Cuéntanos qué talla buscas, dónde vives y qué esperas de la convivencia. Podemos orientarte sobre el proceso y revisar contigo las opciones
+                que estén documentadas como disponibles.
               </p>
               <a
                 href="../xolos-disponibles.html"
@@ -295,8 +345,29 @@
                   transition: transform 0.3s ease;
                 "
               >
-                Ver Xolos Disponibles 🐾
+                Consultar ejemplares disponibles
               </a>
+              <p style="margin-top: 1.25rem; margin-bottom: 0.75rem;">Solicita una orientación personalizada por:</p>
+              <p style="display: flex; flex-wrap: wrap; justify-content: center; gap: 1rem; margin: 0;">
+                <a
+                  href="https://wa.me/525518555993?text=Hola%2C%20quisiera%20recibir%20orientaci%C3%B3n%20sobre%20el%20proceso%20de%20Xolos%20Ram%C3%ADrez."
+                  data-cta="whatsapp"
+                  data-lead-type="generate_lead"
+                  data-profile="general"
+                  data-page-type="blog-price"
+                  data-lang="es"
+                  aria-label="Solicitar orientación a Xolos Ramírez por WhatsApp"
+                >WhatsApp</a>
+                <a
+                  href="mailto:contacto@xolosarmy.xyz?subject=Orientaci%C3%B3n%20personalizada%20Xolos%20Ram%C3%ADrez"
+                  data-cta="email"
+                  data-lead-type="generate_lead"
+                  data-profile="general"
+                  data-page-type="blog-price"
+                  data-lang="es"
+                  aria-label="Solicitar orientación a Xolos Ramírez por correo"
+                >Correo electrónico</a>
+              </p>
             </div>
           </div>
         </article>

--- a/blog/precio-xoloitzcuintle.html
+++ b/blog/precio-xoloitzcuintle.html
@@ -165,7 +165,6 @@
           <ul>
             <li><a href="../index.html">Inicio</a></li>
             <li><a href="../xolos-disponibles.html">Xolos disponibles</a></li>
-            <li><a href="../xolos-disponibles.html">Xolos disponibles</a></li>
             <li><a href="../testimonios.html">Testimonios</a></li>
             <li><a href="index.html">Blog</a></li>
             <li><a href="../contacto.html">Contacto</a></li>
@@ -173,6 +172,16 @@
         </nav>
       </div>
     </header>
+
+    <nav aria-label="Migas de pan" style="max-width: 72rem; margin: 0 auto; padding: 1rem 1rem 0; background: #fff; color: #57534e; font-size: 0.875rem; line-height: 1.5;">
+      <ol style="display: flex; flex-wrap: wrap; align-items: center; gap: 0.5rem; margin: 0; padding: 0; list-style: none;">
+        <li><a href="../index.html" style="color: inherit; text-decoration: underline; text-underline-offset: 0.2em;">Inicio</a></li>
+        <li aria-hidden="true">›</li>
+        <li><a href="index.html" style="color: inherit; text-decoration: underline; text-underline-offset: 0.2em;">Blog</a></li>
+        <li aria-hidden="true">›</li>
+        <li aria-current="page">Precio de un Xoloitzcuintle</li>
+      </ol>
+    </nav>
 
     <main id="contenido-principal" class="article">
       <section class="container" data-aos="fade-up" data-aos-duration="1000" style="padding-top: 3rem;">
@@ -353,6 +362,8 @@
                   href="https://wa.me/525518555993?text=Hola%2C%20quisiera%20recibir%20orientaci%C3%B3n%20sobre%20el%20proceso%20de%20Xolos%20Ram%C3%ADrez."
                   data-cta="whatsapp"
                   data-lead-type="generate_lead"
+                  data-lead-intent="price_inquiry"
+                  data-cta-location="article_footer"
                   data-profile="general"
                   data-page-type="blog-price"
                   data-lang="es"
@@ -362,6 +373,8 @@
                   href="mailto:contacto@xolosarmy.xyz?subject=Orientaci%C3%B3n%20personalizada%20Xolos%20Ram%C3%ADrez"
                   data-cta="email"
                   data-lead-type="generate_lead"
+                  data-lead-intent="price_inquiry"
+                  data-cta-location="article_footer"
                   data-profile="general"
                   data-page-type="blog-price"
                   data-lang="es"

--- a/blog/xoloitzcuintle-alimentacion.html
+++ b/blog/xoloitzcuintle-alimentacion.html
@@ -128,6 +128,16 @@
         </p>
     </header>
 
+    <nav aria-label="Migas de pan" style="max-width: 72rem; margin: 0 auto; padding: 1rem 1rem 0; background: #fff; color: #57534e; font-size: 0.875rem; line-height: 1.5;">
+        <ol style="display: flex; flex-wrap: wrap; align-items: center; gap: 0.5rem; margin: 0; padding: 0; list-style: none;">
+            <li><a href="../index.html" style="color: inherit; text-decoration: underline; text-underline-offset: 0.2em;">Inicio</a></li>
+            <li aria-hidden="true">›</li>
+            <li><a href="index.html" style="color: inherit; text-decoration: underline; text-underline-offset: 0.2em;">Blog</a></li>
+            <li aria-hidden="true">›</li>
+            <li aria-current="page">Alimentación del xoloitzcuintle</li>
+        </ol>
+    </nav>
+
     <main class="max-w-6xl mx-auto px-4 sm:px-6 lg:px-8 pb-20 space-y-24">
 
         <section id="metabolismo" class="scroll-mt-20">

--- a/blog/xoloitzcuintle-alimentacion.html
+++ b/blog/xoloitzcuintle-alimentacion.html
@@ -1,9 +1,63 @@
 <!DOCTYPE html>
 <html lang="es" class="scroll-smooth">
 <head>
+    <!-- Google Tag Manager -->
+    <script>
+      (function (w, d, s, l, i) {
+        w[l] = w[l] || [];
+        w[l].push({ 'gtm.start': new Date().getTime(), event: 'gtm.js' });
+        var f = d.getElementsByTagName(s)[0],
+          j = d.createElement(s),
+          dl = l != 'dataLayer' ? '&l=' + l : '';
+        j.async = true;
+        j.src = 'https://www.googletagmanager.com/gtm.js?id=' + i + dl;
+        f.parentNode.insertBefore(j, f);
+      })(window, document, 'script', 'dataLayer', 'GTM-MGTMWN7T');
+    </script>
+    <!-- End Google Tag Manager -->
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Nutrición y Dieta del Xoloitzcuintle</title>
+    <link rel="canonical" href="https://xolosramirez.com/blog/xoloitzcuintle-alimentacion.html">
+    <link rel="alternate" hreflang="es-MX" href="https://xolosramirez.com/blog/xoloitzcuintle-alimentacion.html">
+    <link rel="alternate" hreflang="x-default" href="https://xolosramirez.com/blog/xoloitzcuintle-alimentacion.html">
+    <title>Alimentación del xoloitzcuintle: guía por etapas | Xolos Ramírez</title>
+    <meta name="description" content="Guía general de alimentación del xoloitzcuintle por etapa de vida, dentición, actividad y condición corporal, con criterios para consultar al veterinario.">
+    <meta property="og:type" content="article">
+    <meta property="og:locale" content="es_MX">
+    <meta property="og:site_name" content="Xolos Ramírez">
+    <meta property="og:title" content="Alimentación del xoloitzcuintle: guía por etapas">
+    <meta property="og:description" content="Criterios generales para conversar con el veterinario sobre dieta, dentición, actividad y cuidado de la piel.">
+    <meta property="og:url" content="https://xolosramirez.com/blog/xoloitzcuintle-alimentacion.html">
+    <meta property="og:image" content="https://xolosramirez.com/img/hero/site-hero.jpg">
+    <meta name="twitter:card" content="summary_large_image">
+    <meta name="twitter:title" content="Alimentación del xoloitzcuintle: guía por etapas">
+    <meta name="twitter:description" content="Qué observar al ajustar la alimentación de un xoloitzcuintle con orientación veterinaria.">
+    <meta name="twitter:image" content="https://xolosramirez.com/img/hero/site-hero.jpg">
+    <script type="application/ld+json">
+      {
+        "@context": "https://schema.org",
+        "@graph": [
+          {
+            "@type": "Article",
+            "headline": "Alimentación del xoloitzcuintle: guía por etapas",
+            "description": "Guía general de alimentación del xoloitzcuintle por etapa de vida, dentición, actividad y condición corporal, con criterios para consultar al veterinario.",
+            "inLanguage": "es-MX",
+            "mainEntityOfPage": "https://xolosramirez.com/blog/xoloitzcuintle-alimentacion.html",
+            "author": { "@type": "Organization", "name": "Xolos Ramírez" },
+            "publisher": { "@type": "Organization", "name": "Xolos Ramírez" },
+            "image": "https://xolosramirez.com/img/hero/site-hero.jpg"
+          },
+          {
+            "@type": "BreadcrumbList",
+            "itemListElement": [
+              { "@type": "ListItem", "position": 1, "name": "Inicio", "item": "https://xolosramirez.com/" },
+              { "@type": "ListItem", "position": 2, "name": "Blog", "item": "https://xolosramirez.com/blog/index.html" },
+              { "@type": "ListItem", "position": 3, "name": "Alimentación del xoloitzcuintle", "item": "https://xolosramirez.com/blog/xoloitzcuintle-alimentacion.html" }
+            ]
+          }
+        ]
+      }
+    </script>
     <script src="https://cdn.tailwindcss.com"></script>
     <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
     
@@ -46,6 +100,10 @@
     </style>
 </head>
 <body class="bg-[#FDFBF7] text-gray-800 font-sans antialiased selection:bg-[#D97757] selection:text-white">
+    <!-- Google Tag Manager (noscript) -->
+    <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-MGTMWN7T"
+    height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
+    <!-- End Google Tag Manager (noscript) -->
 
     <nav class="sticky top-0 z-50 bg-[#FDFBF7]/90 backdrop-blur border-b border-[#E2D8CE] shadow-sm">
         <div class="max-w-6xl mx-auto px-4 sm:px-6 lg:px-8">
@@ -56,24 +114,17 @@
                     <a href="#macronutrientes" class="text-gray-600 hover:text-[#D97757] transition-colors">Macronutrientes</a>
                     <a href="#piel" class="text-gray-600 hover:text-[#D97757] transition-colors">Salud Dérmica</a>
                     <a href="#etapas" class="text-gray-600 hover:text-[#D97757] transition-colors">Etapas de Vida</a>
-                  <a
-  href="https://xolosramirez.com/?utm_source=xolonutricion&utm_medium=nav_button&utm_campaign=nutrition_dashboard&utm_content=ver_mas_mobile"
-  target="_blank"
-  rel="noopener noreferrer"
-  class="md:hidden inline-flex items-center gap-2 rounded-full bg-[#D97757] px-3 py-2 text-xs font-semibold text-white shadow-sm hover:opacity-90 transition"
->
-  Ver más
-  <span aria-hidden="true">↗</span>
-</a>
+                    <a href="index.html" data-cta="editorial-link" data-cta-location="navigation" class="text-gray-600 hover:text-[#D97757] transition-colors">Blog</a>
                 </div>
+                <a href="index.html" data-cta="editorial-link" data-cta-location="navigation-mobile" class="md:hidden inline-flex items-center rounded-full bg-[#D97757] px-3 py-2 text-xs font-semibold text-white shadow-sm hover:opacity-90 transition">Blog</a>
             </div>
         </div>
     </nav>
 
     <header class="max-w-6xl mx-auto px-4 sm:px-6 lg:px-8 py-16 text-center">
-        <h1 class="text-4xl md:text-5xl font-extrabold text-[#2D3748] mb-4">Dieta Recomendada para el Xoloitzcuintle</h1>
+        <h1 class="text-4xl md:text-5xl font-extrabold text-[#2D3748] mb-4">Alimentación del Xoloitzcuintle por Etapas</h1>
         <p class="text-lg md:text-xl text-gray-600 max-w-3xl mx-auto">
-            Una guía interactiva sobre las necesidades nutricionales únicas del perro primitivo de México. Descubre cómo alimentar a tu Xolo para proteger su piel, mantener su energía y asegurar su longevidad.
+            Una guía general para observar dentición, actividad, condición corporal y etapa de vida antes de ajustar la dieta con acompañamiento veterinario.
         </p>
     </header>
 
@@ -81,34 +132,26 @@
 
         <section id="metabolismo" class="scroll-mt-20">
             <div class="bg-white rounded-2xl shadow-sm border border-[#E2D8CE] p-8 md:p-12">
-                <a
-  href="https://xolosramirez.com/?utm_source=xolonutricion&utm_medium=nav_button&utm_campaign=nutrition_dashboard&utm_content=ver_mas"
-  target="_blank"
-  rel="noopener noreferrer"
-  class="inline-flex items-center gap-2 rounded-full bg-[#D97757] px-4 py-2 text-sm font-semibold text-white shadow-sm hover:opacity-90 transition"
->
-  Ver más en xolosramirez.com
-  <span aria-hidden="true">↗</span>
-</a>
+                <a href="index.html" data-cta="editorial-link" data-cta-location="article-start" class="inline-flex items-center gap-2 rounded-full bg-[#D97757] px-4 py-2 text-sm font-semibold text-white shadow-sm hover:opacity-90 transition">Explorar el blog</a>
                 <h2 class="text-3xl font-bold text-[#8C624A] mb-4">🐾 El Metabolismo de una Raza Primitiva</h2>
                 <p class="text-gray-600 mb-6 text-lg">
-                    Esta sección introduce las particularidades biológicas del Xoloitzcuintle. Comprender su fisiología es vital, ya que al ser una raza primitiva con pérdida de pelo (en su variedad pelona) y, a menudo, falta de premolares, requieren una dieta altamente digestible y enfocada en la termorregulación y protección dérmica.
+                    La variedad con pelo o sin pelo, la dentición, el clima, la actividad y la condición corporal pueden cambiar la forma de ofrecer el alimento. No existe una dieta única para todos los xoloitzcuintles: la pauta debe individualizarse con un médico veterinario.
                 </p>
                 <div class="grid grid-cols-1 md:grid-cols-3 gap-6">
                     <div class="bg-[#F8F5F0] p-6 rounded-xl border border-[#E2D8CE] hover:shadow-md transition-shadow">
                         <div class="text-4xl mb-3">🦷</div>
                         <h3 class="font-bold text-xl mb-2">Dentición Incompleta</h3>
-                        <p class="text-sm text-gray-600">El gen que causa la falta de pelo también afecta los dientes. Muchos Xolos carecen de premolares, por lo que la croqueta debe ser de tamaño adecuado o ligeramente humedecida para facilitar la masticación.</p>
+                        <p class="text-sm text-gray-600">La variedad sin pelo puede presentar ausencia de algunas piezas dentales. Conviene revisar cada ejemplar y adaptar tamaño, textura o humedad del alimento con orientación veterinaria.</p>
                     </div>
                     <div class="bg-[#F8F5F0] p-6 rounded-xl border border-[#E2D8CE] hover:shadow-md transition-shadow">
                         <div class="text-4xl mb-3">🔥</div>
                         <h3 class="font-bold text-xl mb-2">Termorregulación</h3>
-                        <p class="text-sm text-gray-600">Al no tener pelo para aislar su temperatura corporal, los Xolos gastan más energía en climas fríos para mantenerse calientes. Su dieta debe ajustar las calorías según el clima y la actividad.</p>
+                        <p class="text-sm text-gray-600">El clima puede influir en el gasto energético, pero cualquier ajuste de ración debe considerar actividad, peso y condición corporal, no solo la presencia o ausencia de pelo.</p>
                     </div>
                     <div class="bg-[#F8F5F0] p-6 rounded-xl border border-[#E2D8CE] hover:shadow-md transition-shadow">
                         <div class="text-4xl mb-3">🛡️</div>
-                        <h3 class="font-bold text-xl mb-2">Sistema Inmunológico</h3>
-                        <p class="text-sm text-gray-600">Como raza rústica, tienen un sistema digestivo fuerte, pero se benefician enormemente de proteínas noveles (cordero, pescado) para evitar alergias alimentarias que se manifestarían inmediatamente en su piel.</p>
+                        <h3 class="font-bold text-xl mb-2">Sensibilidades Individuales</h3>
+                        <p class="text-sm text-gray-600">Los cambios en piel o digestión pueden tener causas distintas. No conviene asumir una alergia ni cambiar proteínas sin valoración; una dieta de eliminación requiere supervisión veterinaria.</p>
                     </div>
                 </div>
             </div>
@@ -117,7 +160,7 @@
         <section id="macronutrientes" class="scroll-mt-20">
             <h2 class="text-3xl font-bold text-[#8C624A] mb-4">Balance de Macronutrientes</h2>
             <p class="text-gray-600 mb-8 max-w-4xl text-lg">
-                Aquí exploramos la distribución ideal de energía para el Xolo. Haz clic en las diferentes secciones del gráfico de dona para descubrir las fuentes recomendadas y la función específica de cada macronutriente en el organismo de tu perro.
+                El gráfico ilustra cómo cumplen funciones distintas los macronutrientes; no prescribe porcentajes ni una fórmula universal. Haz clic para conocer criterios generales que deben ajustarse a cada ejemplar.
             </p>
             
             <div class="flex flex-col lg:flex-row items-center gap-12 bg-white p-8 rounded-2xl shadow-sm border border-[#E2D8CE]">
@@ -130,16 +173,16 @@
                     <div id="macro-details" class="bg-[#F8F5F0] p-8 rounded-xl border border-[#D97757] h-full flex flex-col justify-center transition-all duration-300">
                         <div class="text-5xl mb-4">👈</div>
                         <h3 class="text-2xl font-bold text-[#2D3748] mb-2">Interactúa con el gráfico</h3>
-                        <p class="text-gray-600">Haz clic en una sección del gráfico de dona a la izquierda para ver detalles sobre proteínas, grasas o carbohidratos específicos recomendados para el Xoloitzcuintle.</p>
+                        <p class="text-gray-600">Haz clic en una sección del gráfico para conocer la función general de proteínas, grasas o carbohidratos. La proporción adecuada depende del alimento completo y de la valoración veterinaria.</p>
                     </div>
                 </div>
             </div>
         </section>
 
         <section id="piel" class="scroll-mt-20">
-            <h2 class="text-3xl font-bold text-[#8C624A] mb-4">Micronutrientes Críticos para la Piel</h2>
+            <h2 class="text-3xl font-bold text-[#8C624A] mb-4">Nutrientes Relacionados con la Piel</h2>
             <p class="text-gray-600 mb-8 max-w-4xl text-lg">
-                La piel es el órgano más expuesto del Xoloitzcuintle pelón. Esta sección detalla los suplementos y vitaminas vitales que previenen la resequedad, el acné canino y protegen contra los rayos solares. Pasa el cursor sobre las barras para ver la función de cada nutriente.
+                Una dieta completa aporta nutrientes relacionados con la barrera cutánea, pero los suplementos no sustituyen el diagnóstico ni la protección solar apropiada. Pasa el cursor para conocer su función general y consulta antes de añadirlos.
             </p>
 
             <div class="bg-white p-8 rounded-2xl shadow-sm border border-[#E2D8CE]">
@@ -170,7 +213,7 @@
         <section id="etapas" class="scroll-mt-20">
             <h2 class="text-3xl font-bold text-[#8C624A] mb-4">Necesidades por Etapa de Vida</h2>
             <p class="text-gray-600 mb-8 max-w-4xl text-lg">
-                Los requerimientos cambian drásticamente conforme el perro crece. Selecciona la etapa actual de tu Xoloitzcuintle para conocer las pautas de alimentación, control de peso y cuidados preventivos mediante la dieta.
+                Los requerimientos cambian conforme el perro crece. Selecciona una etapa para revisar criterios generales de alimentación y control de peso; la ración y frecuencia deben ajustarse al alimento, el ejemplar y la indicación veterinaria.
             </p>
 
             <div class="bg-white rounded-2xl shadow-sm border border-[#E2D8CE] overflow-hidden">
@@ -192,11 +235,11 @@
                             <div class="text-8xl">🍼</div>
                             <div>
                                 <h3 class="text-2xl font-bold text-[#2D3748] mb-3">Crecimiento y Desarrollo</h3>
-                                <p class="text-gray-600 mb-4">Durante el primer año, el Xoloitzcuintle (especialmente en sus tamaños intermedio y estándar) requiere un aporte calórico denso. El calcio y fósforo deben estar estrictamente balanceados para evitar deformaciones óseas.</p>
+                                <p class="text-gray-600 mb-4">Durante el crecimiento es importante elegir un alimento completo para cachorro y vigilar el ritmo de desarrollo. El calcio y el fósforo no deben suplementarse sin indicación profesional.</p>
                                 <ul class="space-y-2">
-                                    <li class="flex items-center text-sm text-gray-700"><span class="text-[#D97757] font-bold mr-2">✓</span> Proteína: Mínimo 28-30% de alta calidad.</li>
-                                    <li class="flex items-center text-sm text-gray-700"><span class="text-[#D97757] font-bold mr-2">✓</span> Frecuencia: 3 a 4 comidas pequeñas al día.</li>
-                                    <li class="flex items-center text-sm text-gray-700"><span class="text-[#D97757] font-bold mr-2">✓</span> Suplemento: Probióticos para establecer una flora intestinal robusta.</li>
+                                    <li class="flex items-center text-sm text-gray-700"><span class="text-[#D97757] font-bold mr-2">✓</span> Alimento completo formulado para crecimiento y talla esperada.</li>
+                                    <li class="flex items-center text-sm text-gray-700"><span class="text-[#D97757] font-bold mr-2">✓</span> Porciones repartidas según edad, producto y recomendación veterinaria.</li>
+                                    <li class="flex items-center text-sm text-gray-700"><span class="text-[#D97757] font-bold mr-2">✓</span> Seguimiento periódico de peso, condición corporal y digestión.</li>
                                 </ul>
                             </div>
                         </div>
@@ -207,11 +250,11 @@
                             <div class="text-8xl">🐕</div>
                             <div>
                                 <h3 class="text-2xl font-bold text-[#2D3748] mb-3">Mantenimiento y Protección Dérmica</h3>
-                                <p class="text-gray-600 mb-4">En la etapa adulta, el enfoque cambia a mantener un peso ideal y cuidar la salud de la piel. Es crucial evitar el sobrepeso, ya que las articulaciones de la raza son ligeras.</p>
+                                <p class="text-gray-600 mb-4">En la etapa adulta, el enfoque es mantener una condición corporal adecuada y observar piel, digestión, actividad y dentición.</p>
                                 <ul class="space-y-2">
-                                    <li class="flex items-center text-sm text-gray-700"><span class="text-[#D97757] font-bold mr-2">✓</span> Proteína: 22-26% basada en pescado o carnes magras.</li>
-                                    <li class="flex items-center text-sm text-gray-700"><span class="text-[#D97757] font-bold mr-2">✓</span> Frecuencia: 2 comidas diarias.</li>
-                                    <li class="flex items-center text-sm text-gray-700"><span class="text-[#D97757] font-bold mr-2">✓</span> Cuidado de Piel: Introducir aceites de pescado o linaza diariamente.</li>
+                                    <li class="flex items-center text-sm text-gray-700"><span class="text-[#D97757] font-bold mr-2">✓</span> Alimento completo acorde con actividad y condición corporal.</li>
+                                    <li class="flex items-center text-sm text-gray-700"><span class="text-[#D97757] font-bold mr-2">✓</span> Horarios consistentes y porciones medidas.</li>
+                                    <li class="flex items-center text-sm text-gray-700"><span class="text-[#D97757] font-bold mr-2">✓</span> Suplementos solo cuando el veterinario identifica una necesidad.</li>
                                 </ul>
                             </div>
                         </div>
@@ -222,11 +265,11 @@
                             <div class="text-8xl">🛋️</div>
                             <div>
                                 <h3 class="text-2xl font-bold text-[#2D3748] mb-3">Soporte Articular y Digestivo</h3>
-                                <p class="text-gray-600 mb-4">Los Xolos son perros longevos (pueden vivir 14-16 años). En su vejez, su metabolismo se ralentiza. Dado que es común la falta de piezas dentales, la textura de la comida toma prioridad.</p>
+                                <p class="text-gray-600 mb-4">En la etapa senior pueden cambiar actividad, digestión y capacidad de masticación. Las revisiones clínicas ayudan a elegir textura y densidad energética.</p>
                                 <ul class="space-y-2">
-                                    <li class="flex items-center text-sm text-gray-700"><span class="text-[#D97757] font-bold mr-2">✓</span> Textura: Comida blanda, patés de alta calidad o croquetas remojadas.</li>
-                                    <li class="flex items-center text-sm text-gray-700"><span class="text-[#D97757] font-bold mr-2">✓</span> Suplementos: Condroitina y Glucosamina para las articulaciones.</li>
-                                    <li class="flex items-center text-sm text-gray-700"><span class="text-[#D97757] font-bold mr-2">✓</span> Calorías: Reducir grasas saturadas para proteger el hígado y evitar la obesidad.</li>
+                                    <li class="flex items-center text-sm text-gray-700"><span class="text-[#D97757] font-bold mr-2">✓</span> Textura adaptada después de revisar dientes, encías y deglución.</li>
+                                    <li class="flex items-center text-sm text-gray-700"><span class="text-[#D97757] font-bold mr-2">✓</span> Suplementos articulares únicamente cuando estén indicados.</li>
+                                    <li class="flex items-center text-sm text-gray-700"><span class="text-[#D97757] font-bold mr-2">✓</span> Ajuste de energía según peso, actividad y resultados clínicos.</li>
                                 </ul>
                             </div>
                         </div>
@@ -236,9 +279,9 @@
         </section>
 
         <section id="peligros">
-            <h2 class="text-3xl font-bold text-red-700 mb-4">⚠️ Alimentos Altamente Tóxicos</h2>
+            <h2 class="text-3xl font-bold text-red-700 mb-4">⚠️ Alimentos que Requieren Atención</h2>
             <p class="text-gray-600 mb-8 max-w-4xl text-lg">
-                Concluyendo nuestra guía, es imperativo conocer los alimentos que, aunque comunes en la dieta humana, representan un peligro mortal para el Xoloitzcuintle. Pasa el cursor sobre cada elemento para ver los síntomas de intoxicación.
+                Algunos alimentos humanos pueden causar intoxicación. Evita ofrecerlos y, ante una ingestión o síntomas, contacta de inmediato a un médico veterinario; no esperes a que aparezcan señales.
             </p>
 
             <div class="grid grid-cols-2 md:grid-cols-4 gap-4">
@@ -253,32 +296,43 @@
                     <div class="text-4xl mb-2 group-hover:opacity-10 transition-opacity">🧅</div>
                     <h4 class="font-bold text-red-800 group-hover:opacity-10 transition-opacity">Cebolla y Ajo</h4>
                     <div class="toxic-detail absolute inset-0 bg-red-600 text-white p-4 flex flex-col justify-center items-center text-sm font-medium">
-                        Destruyen los glóbulos rojos, causando anemia severa y letargo agudo.
+                        Pueden dañar los glóbulos rojos y causar anemia; la gravedad depende de la cantidad y del ejemplar.
                     </div>
                 </div>
                 <div class="toxic-card bg-red-50 p-6 rounded-xl border border-red-200 text-center cursor-help transition-all relative overflow-hidden group">
                     <div class="text-4xl mb-2 group-hover:opacity-10 transition-opacity">🍇</div>
                     <h4 class="font-bold text-red-800 group-hover:opacity-10 transition-opacity">Uvas y Pasas</h4>
                     <div class="toxic-detail absolute inset-0 bg-red-600 text-white p-4 flex flex-col justify-center items-center text-sm font-medium">
-                        Altamente tóxicas. Pueden causar insuficiencia renal aguda e irreversible rápidamente.
+                        Pueden causar lesión renal aguda incluso en cantidades variables. Requieren atención veterinaria inmediata.
                     </div>
                 </div>
                 <div class="toxic-card bg-red-50 p-6 rounded-xl border border-red-200 text-center cursor-help transition-all relative overflow-hidden group">
                     <div class="text-4xl mb-2 group-hover:opacity-10 transition-opacity">🥑</div>
                     <h4 class="font-bold text-red-800 group-hover:opacity-10 transition-opacity">Aguacate</h4>
                     <div class="toxic-detail absolute inset-0 bg-red-600 text-white p-4 flex flex-col justify-center items-center text-sm font-medium">
-                        Contiene persina. Provoca vómitos y diarrea extrema en caninos.
+                        Evita hueso y cáscara; la pulpa es alta en grasa y puede provocar malestar digestivo en algunos perros.
                     </div>
                 </div>
             </div>
+        </section>
+
+        <section aria-labelledby="lecturas-relacionadas" class="bg-white rounded-2xl shadow-sm border border-[#E2D8CE] p-8">
+            <h2 id="lecturas-relacionadas" class="text-3xl font-bold text-[#8C624A] mb-4">Continúa cuidando a tu Xolo</h2>
+            <p class="text-gray-600 mb-6">Profundiza en piel, resequedad y talla para relacionar la alimentación con el cuidado cotidiano de cada ejemplar.</p>
+            <div class="grid grid-cols-1 md:grid-cols-3 gap-4">
+                <a href="cuidado-de-la-piel-del-xoloitzcuintle.html" data-cta="editorial-link" data-cta-location="related-content" class="rounded-xl border border-[#E2D8CE] p-5 hover:border-[#D97757] transition">Cuidado de la piel →</a>
+                <a href="piel-reseca-xoloitzcuintle.html" data-cta="editorial-link" data-cta-location="related-content" class="rounded-xl border border-[#E2D8CE] p-5 hover:border-[#D97757] transition">Piel reseca: causas y cuidados →</a>
+                <a href="guia-tallas-xoloitzcuintle.html" data-cta="editorial-link" data-cta-location="related-content" class="rounded-xl border border-[#E2D8CE] p-5 hover:border-[#D97757] transition">Guía de tallas →</a>
+            </div>
+            <p class="mt-6 text-gray-600">También puedes <a href="../xolos-disponibles.html" data-cta="availability" data-cta-location="article-footer" class="font-semibold text-[#D97757] hover:underline">conocer a los Xolos y su proceso de crianza</a>.</p>
         </section>
 
     </main>
 
     <footer class="bg-[#2D3748] text-[#FDFBF7] py-8 text-center mt-12">
         <div class="max-w-6xl mx-auto px-4">
-            <p class="opacity-80">Información Arquitectónica e Interactiva de la Dieta del Xoloitzcuintle.</p>
-            <p class="opacity-60 text-sm mt-2">Nota: Esta es una guía general. Siempre consulta a un médico veterinario para las necesidades específicas de tu mascota.</p>
+            <p class="opacity-80">Guía interactiva de alimentación del xoloitzcuintle.</p>
+            <p class="opacity-60 text-sm mt-2">Contenido educativo general; no sustituye una evaluación ni una dieta formulada por un médico veterinario.</p>
         </div>
     </footer>
 
@@ -289,18 +343,18 @@
             const macroDataContent = {
                 0: { 
                     icon: '🥩', 
-                    title: 'Proteína (30%)', 
-                    desc: 'Esencial para el desarrollo muscular y la reparación de la piel. Para el Xolo, se recomiendan fuentes altamente digestibles como el salmón, pescado blanco, cordero o pavo para evitar alergias cutáneas.' 
+                    title: 'Proteínas',
+                    desc: 'Aportan aminoácidos para músculos y tejidos. La fuente y cantidad adecuadas dependen del alimento completo, la etapa de vida y la tolerancia individual.'
                 },
                 1: { 
                     icon: '🥑', 
-                    title: 'Grasas Saludables (20%)', 
-                    desc: 'El pilar de la salud dérmica del Xolo. Las grasas proveen los ácidos grasos esenciales (Omega 3 y 6) que actúan como barrera protectora de la piel, previniendo sequedad, descamación y acné.' 
+                    title: 'Grasas',
+                    desc: 'Aportan energía y ácidos grasos esenciales relacionados con la barrera cutánea. Un exceso o suplemento innecesario también puede causar problemas.'
                 },
                 2: { 
                     icon: '🍠', 
-                    title: 'Carbohidratos Complejos (50%)', 
-                    desc: 'Fuente primaria de energía. Se deben evitar cereales de relleno (maíz, trigo). Optar por camote, calabaza, guisantes o arroz integral que ofrecen energía sostenida y fibra para una buena digestión.' 
+                    title: 'Carbohidratos y fibra',
+                    desc: 'Pueden aportar energía y fibra dentro de una fórmula completa. No es necesario excluir ingredientes específicos sin una razón clínica o una indicación veterinaria.'
                 }
             };
 
@@ -311,7 +365,7 @@
                 data: {
                     labels: ['Proteína', 'Grasas', 'Carbohidratos'],
                     datasets: [{
-                        data: [30, 20, 50],
+                        data: [1, 1, 1],
                         backgroundColor: [
                             '#8C624A', // Brown
                             '#D97757', // Terracotta
@@ -329,7 +383,7 @@
                     plugins: {
                         legend: { position: 'bottom', labels: { font: { family: 'sans-serif' } } },
                         tooltip: {
-                            callbacks: { label: function(context) { return context.label + ': ' + context.parsed + '%'; } }
+                            callbacks: { label: function(context) { return context.label + ': función complementaria'; } }
                         }
                     },
                     onClick: (event, elements) => {
@@ -364,8 +418,8 @@
                 data: {
                     labels: ['Omega 3 y 6', 'Zinc', 'Vitamina E', 'Vitamina A', 'Cobre'],
                     datasets: [{
-                        label: 'Nivel de Importancia para la Piel (Escala 1-100)',
-                        data: [100, 95, 85, 80, 70],
+                        label: 'Nutrientes relacionados con la función cutánea',
+                        data: [1, 1, 1, 1, 1],
                         backgroundColor: '#D97757',
                         borderRadius: 6,
                         barPercentage: 0.6
@@ -375,7 +429,7 @@
                     responsive: true,
                     maintainAspectRatio: false,
                     scales: {
-                        y: { beginAtZero: true, max: 100, grid: { color: '#E2D8CE' } },
+                        y: { display: false, beginAtZero: true, max: 1.2, grid: { color: '#E2D8CE' } },
                         x: { grid: { display: false } }
                     },
                     plugins: {
@@ -385,11 +439,11 @@
                             callbacks: {
                                 afterLabel: function(context) {
                                     const tooltips = {
-                                        'Omega 3 y 6': 'Reduce inflamación y forma barrera lipídica.',
-                                        'Zinc': 'Esencial para renovar células de la epidermis.',
-                                        'Vitamina E': 'Antioxidante protector contra daño solar.',
-                                        'Vitamina A': 'Regula el crecimiento de la piel y previene caspa.',
-                                        'Cobre': 'Ayuda en la pigmentación de la piel oscura.'
+                                        'Omega 3 y 6': 'Participan en la barrera cutánea; la suplementación requiere una dosis indicada.',
+                                        'Zinc': 'Interviene en distintos procesos celulares y debe provenir de una dieta equilibrada.',
+                                        'Vitamina E': 'Actúa como antioxidante dentro de una dieta completa.',
+                                        'Vitamina A': 'Participa en la renovación celular; el exceso puede ser perjudicial.',
+                                        'Cobre': 'Participa en procesos metabólicos y de pigmentación.'
                                     };
                                     return tooltips[context.label];
                                 }

--- a/blog/xoloitzcuintle-temperamento.html
+++ b/blog/xoloitzcuintle-temperamento.html
@@ -178,6 +178,16 @@
             </a>
     </nav>
     
+    <nav aria-label="Migas de pan" style="max-width: 72rem; margin: 0 auto; padding: 1rem 1rem 0; background: #fff; color: #57534e; font-size: 0.875rem; line-height: 1.5;">
+        <ol style="display: flex; flex-wrap: wrap; align-items: center; gap: 0.5rem; margin: 0; padding: 0; list-style: none;">
+            <li><a href="../index.html" style="color: inherit; text-decoration: underline; text-underline-offset: 0.2em;">Inicio</a></li>
+            <li aria-hidden="true">›</li>
+            <li><a href="index.html" style="color: inherit; text-decoration: underline; text-underline-offset: 0.2em;">Blog</a></li>
+            <li aria-hidden="true">›</li>
+            <li aria-current="page">Temperamento</li>
+        </ol>
+    </nav>
+
     <!-- Main Content -->
     <main class="max-w-6xl mx-auto px-4 py-8 space-y-16">
 

--- a/blog/xoloitzcuintle-temperamento.html
+++ b/blog/xoloitzcuintle-temperamento.html
@@ -1,10 +1,63 @@
 <!DOCTYPE html>
 <html lang="es">
 <head>
+    <!-- Google Tag Manager -->
+    <script>
+      (function (w, d, s, l, i) {
+        w[l] = w[l] || [];
+        w[l].push({ 'gtm.start': new Date().getTime(), event: 'gtm.js' });
+        var f = d.getElementsByTagName(s)[0],
+          j = d.createElement(s),
+          dl = l != 'dataLayer' ? '&l=' + l : '';
+        j.async = true;
+        j.src = 'https://www.googletagmanager.com/gtm.js?id=' + i + dl;
+        f.parentNode.insertBefore(j, f);
+      })(window, document, 'script', 'dataLayer', 'GTM-MGTMWN7T');
+    </script>
+    <!-- End Google Tag Manager -->
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <link rel="canonical" href="https://xolosramirez.com/blog/xoloitzcuintle-temperamento.html" />
-    <title>Xoloitzcuintle: Temperamento y Personalidad</title>
+    <link rel="alternate" hreflang="es-MX" href="https://xolosramirez.com/blog/xoloitzcuintle-temperamento.html" />
+    <link rel="alternate" hreflang="x-default" href="https://xolosramirez.com/blog/xoloitzcuintle-temperamento.html" />
+    <title>Temperamento del xoloitzcuintle y convivencia | Xolos Ramírez</title>
+    <meta name="description" content="Conoce tendencias de temperamento del xoloitzcuintle y qué observar en socialización, actividad, aprendizaje y compatibilidad familiar.">
+    <meta property="og:type" content="article">
+    <meta property="og:locale" content="es_MX">
+    <meta property="og:site_name" content="Xolos Ramírez">
+    <meta property="og:title" content="Temperamento del xoloitzcuintle y convivencia">
+    <meta property="og:description" content="Una guía para observar al ejemplar real, acompañar su socialización y valorar la convivencia familiar.">
+    <meta property="og:url" content="https://xolosramirez.com/blog/xoloitzcuintle-temperamento.html">
+    <meta property="og:image" content="https://xolosramirez.com/img/hero/site-hero.jpg">
+    <meta name="twitter:card" content="summary_large_image">
+    <meta name="twitter:title" content="Temperamento del xoloitzcuintle y convivencia">
+    <meta name="twitter:description" content="Tendencias generales, socialización y preguntas para valorar compatibilidad familiar.">
+    <meta name="twitter:image" content="https://xolosramirez.com/img/hero/site-hero.jpg">
+    <script type="application/ld+json">
+      {
+        "@context": "https://schema.org",
+        "@graph": [
+          {
+            "@type": "Article",
+            "headline": "Temperamento del xoloitzcuintle y convivencia",
+            "description": "Conoce tendencias de temperamento del xoloitzcuintle y qué observar en socialización, actividad, aprendizaje y compatibilidad familiar.",
+            "inLanguage": "es-MX",
+            "mainEntityOfPage": "https://xolosramirez.com/blog/xoloitzcuintle-temperamento.html",
+            "author": { "@type": "Organization", "name": "Xolos Ramírez" },
+            "publisher": { "@type": "Organization", "name": "Xolos Ramírez" },
+            "image": "https://xolosramirez.com/img/hero/site-hero.jpg"
+          },
+          {
+            "@type": "BreadcrumbList",
+            "itemListElement": [
+              { "@type": "ListItem", "position": 1, "name": "Inicio", "item": "https://xolosramirez.com/" },
+              { "@type": "ListItem", "position": 2, "name": "Blog", "item": "https://xolosramirez.com/blog/index.html" },
+              { "@type": "ListItem", "position": 3, "name": "Temperamento", "item": "https://xolosramirez.com/blog/xoloitzcuintle-temperamento.html" }
+            ]
+          }
+        ]
+      }
+    </script>
     <script src="https://cdn.tailwindcss.com"></script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/Chart.js/3.9.1/chart.min.js"></script>
     <style>
@@ -84,6 +137,10 @@
     <!-- CONFIRMATION: NO SVG graphics used. NO Mermaid JS used. -->
 </head>
 <body class="bg-stone-100 text-stone-800">
+    <!-- Google Tag Manager (noscript) -->
+    <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-MGTMWN7T"
+    height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
+    <!-- End Google Tag Manager (noscript) -->
 
     <!-- Navigation -->
     <nav class="sticky top-0 z-50 bg-stone-900 text-stone-100 shadow-lg">
@@ -115,9 +172,9 @@
      
 
     
- <a href="https://xolosramirez.com/" target="_blank" rel="noopener noreferrer"
+ <a href="index.html" data-cta="editorial-link" data-cta-location="navigation"
                class="block w-full text-left text-white bg-orange-600 hover:bg-orange-500 px-4 py-3 rounded-lg font-semibold transition">
-                🌐 Visitar Xolos Ramírez
+                Explorar el blog de Xolos Ramírez
             </a>
     </nav>
     
@@ -128,12 +185,12 @@
         <section id="hero" class="text-center space-y-6 py-12">
             <h1 class="text-4xl md:text-6xl font-bold text-stone-900 tracking-tight">El Guardián Ancestral</h1>
             <p class="text-xl md:text-2xl text-stone-600 max-w-3xl mx-auto leading-relaxed">
-                Más que una raza, un patrimonio vivo. Explora la compleja psicología, el temperamento primitivo y las necesidades únicas del perro azteca.
+                Un patrimonio vivo de México. Explora tendencias de conducta, aprendizaje y convivencia sin perder de vista que cada ejemplar desarrolla una personalidad propia.
             </p>
-            <div class="flex justify-center space-x-4">
-                <div class="bg-orange-100 text-orange-800 px-4 py-2 rounded-full text-sm font-semibold">Lealtad: Extrema</div>
-                <div class="bg-stone-200 text-stone-800 px-4 py-2 rounded-full text-sm font-semibold">Inteligencia: Primitiva</div>
-                <div class="bg-stone-200 text-stone-800 px-4 py-2 rounded-full text-sm font-semibold">Sensibilidad: Alta</div>
+            <div class="flex flex-wrap justify-center gap-2">
+                <div class="bg-orange-100 text-orange-800 px-4 py-2 rounded-full text-sm font-semibold">Vínculo: se construye</div>
+                <div class="bg-stone-200 text-stone-800 px-4 py-2 rounded-full text-sm font-semibold">Aprendizaje: individual</div>
+                <div class="bg-stone-200 text-stone-800 px-4 py-2 rounded-full text-sm font-semibold">Socialización: importante</div>
             </div>
         </section>
 
@@ -142,10 +199,10 @@
             <div class="space-y-4">
                 <h2 class="text-2xl font-bold text-stone-800 border-b pb-2">Contexto Histórico y Psicológico</h2>
                 <p class="text-stone-600 leading-relaxed">
-                    El Xoloitzcuintle no es un perro creado por el hombre para una tarea específica moderna; es el resultado de la selección natural durante miles de años en México. Esto le confiere un <strong>temperamento primitivo</strong>.
+                    El Xoloitzcuintle tiene una historia milenaria en México y suele describirse como una raza primitiva. Esa clasificación no determina por sí sola la conducta de un ejemplar.
                 </p>
                 <p class="text-stone-600 leading-relaxed">
-                    A diferencia de razas creadas para complacer (como el Golden Retriever), el Xolo conserva instintos de supervivencia agudos. Su psicología se basa en el respeto mutuo, no en la sumisión automática. Entender esto es la clave para una convivencia armoniosa.
+                    Genética, edad, salud, aprendizaje, ambiente y experiencias influyen en el comportamiento. La convivencia se favorece con rutinas claras, refuerzo positivo, socialización gradual y respeto al lenguaje corporal.
                 </p>
                 <div class="mt-4 p-4 bg-orange-50 rounded-lg">
                     <strong class="text-orange-800 block mb-2">💡 Dato Clave:</strong>
@@ -154,8 +211,8 @@
             </div>
             <div class="bg-stone-100 p-6 rounded-xl flex flex-col justify-center items-center text-center h-full">
                 <div class="text-6xl mb-4">🏛️</div>
-                <h3 class="text-xl font-semibold mb-2">Antigüedad: +3,000 Años</h3>
-                <p class="text-sm text-stone-500">Considerado una de las razas más antiguas del mundo.</p>
+                <h3 class="text-xl font-semibold mb-2">Una historia milenaria</h3>
+                <p class="text-sm text-stone-500">Su presencia en la historia de México está documentada en fuentes arqueológicas y culturales.</p>
                 <div class="w-full mt-6 space-y-2">
                     <div class="flex justify-between text-xs font-bold text-stone-400 uppercase">
                         <span>Prehispánico</span>
@@ -174,7 +231,7 @@
             <div class="mb-6">
                 <h2 class="text-3xl font-bold text-stone-800">Las Tres Variedades</h2>
                 <p class="text-stone-600 mt-2">
-                    Aunque el temperamento es consistente, el tamaño influye en el nivel de energía y manejo. El Xolo se presenta en tres tamaños oficiales, tanto en variedad con pelo como sin pelo.
+                    El Xolo se presenta en tres tamaños oficiales y en variedades con pelo y sin pelo. El tamaño orienta algunas necesidades físicas, pero no predice por sí solo la energía ni la personalidad.
                 </p>
             </div>
             
@@ -183,19 +240,19 @@
                 <div class="bg-white p-6 rounded-xl shadow-sm text-center border-t-4 border-stone-800 hover:-translate-y-1 transition transform duration-300">
                     <h3 class="text-lg font-bold">Miniatura</h3>
                     <p class="text-3xl font-bold text-stone-800 my-2">25-35 <span class="text-sm font-normal">cm</span></p>
-                    <p class="text-sm text-stone-500">Ideal para espacios pequeños, pero con gran personalidad.</p>
+                    <p class="text-sm text-stone-500">Su manejo debe considerar actividad, educación y características individuales.</p>
                 </div>
                  <!-- Stat Card 2 -->
                  <div class="bg-white p-6 rounded-xl shadow-sm text-center border-t-4 border-stone-600 hover:-translate-y-1 transition transform duration-300">
                     <h3 class="text-lg font-bold">Intermedio</h3>
                     <p class="text-3xl font-bold text-stone-800 my-2">36-45 <span class="text-sm font-normal">cm</span></p>
-                    <p class="text-sm text-stone-500">El equilibrio perfecto. Ágil y protector.</p>
+                    <p class="text-sm text-stone-500">Una talla media cuya actividad y conducta varían entre ejemplares.</p>
                 </div>
                  <!-- Stat Card 3 -->
                  <div class="bg-white p-6 rounded-xl shadow-sm text-center border-t-4 border-orange-600 hover:-translate-y-1 transition transform duration-300">
                     <h3 class="text-lg font-bold">Estándar</h3>
                     <p class="text-3xl font-bold text-stone-800 my-2">46-60 <span class="text-sm font-normal">cm</span></p>
-                    <p class="text-sm text-stone-500">Imponente y atlético. Un verdadero guardián.</p>
+                    <p class="text-sm text-stone-500">Su mayor tamaño requiere espacio de movimiento y manejo responsable.</p>
                 </div>
             </div>
 
@@ -205,7 +262,7 @@
                 <div class="chart-container">
                     <canvas id="sizesChart"></canvas>
                 </div>
-                <p class="text-center text-xs text-stone-400 mt-2">Datos basados en el estándar racial FCI.</p>
+                <p class="text-center text-xs text-stone-400 mt-2">Comparación ilustrativa; el peso real varía. La clasificación oficial se determina principalmente por altura.</p>
             </div>
         </section>
 
@@ -216,7 +273,7 @@
                 <div class="lg:col-span-5 space-y-6">
                     <h2 class="text-3xl font-bold text-stone-800">Perfil de Personalidad</h2>
                     <p class="text-stone-600">
-                        El Xolo es conocido por su nobleza y lealtad, pero posee matices complejos. Analice cómo cambia su temperamento de la etapa de cachorro a la adultez.
+                        Esta visualización presenta tendencias posibles, no una evaluación conductual. Observa cómo pueden cambiar actividad, reserva y apego entre la etapa de cachorro y la adultez.
                     </p>
                     
                     <div class="bg-white p-6 rounded-xl shadow-md border border-stone-100">
@@ -232,7 +289,7 @@
                         <div id="trait-description" class="p-4 bg-orange-50 rounded-lg border-l-4 border-orange-500 text-sm">
                             <h4 class="font-bold text-orange-900 mb-1" id="trait-title">El Adulto Equilibrado</h4>
                             <p class="text-stone-700" id="trait-text">
-                                En la adultez, el Xolo se calma notablemente dentro de casa. Su energía se canaliza en alerta y protección. Se vuelve una "sombra" de su dueño, mostrando una lealtad absoluta y reservada.
+                                En la adultez, algunos xoloitzcuintles muestran más calma dentro de casa y mayor vínculo con sus personas. La intensidad depende del ejemplar, su aprendizaje y su ambiente.
                             </p>
                         </div>
                     </div>
@@ -244,7 +301,7 @@
                                 <span class="transition group-open:rotate-180">▼</span>
                             </summary>
                             <div class="text-stone-600 p-4 pt-0 text-sm leading-relaxed mt-2">
-                                Es una característica racial, no un defecto. No espere que un Xolo reciba a las visitas moviendo la cola de inmediato. Ignoran a los extraños hasta que se ganan su confianza.
+                                Algunos ejemplares pueden mostrarse reservados al conocer personas. Conviene permitir acercamientos graduales, sin forzar el contacto, y observar su lenguaje corporal.
                             </div>
                         </details>
                         <details class="group bg-white rounded-lg shadow-sm border border-stone-200">
@@ -253,7 +310,7 @@
                                 <span class="transition group-open:rotate-180">▼</span>
                             </summary>
                             <div class="text-stone-600 p-4 pt-0 text-sm leading-relaxed mt-2">
-                                Alto. Como perro primitivo, pequeños animales pueden activar su instinto de caza. La socialización temprana con otras mascotas es crucial.
+                                La respuesta ante animales pequeños varía. Presentaciones controladas, manejo con correa y supervisión son importantes cuando convive con otras especies.
                             </div>
                         </details>
                     </div>
@@ -266,8 +323,8 @@
                         <canvas id="temperamentChart"></canvas>
                     </div>
                     <div class="flex flex-wrap justify-center gap-4 mt-6 text-xs text-stone-500">
-                        <div class="flex items-center"><span class="w-3 h-3 bg-orange-500 rounded-full mr-2"></span>Xoloitzcuintle</div>
-                        <div class="flex items-center"><span class="w-3 h-3 bg-stone-300 rounded-full mr-2"></span>Perro Promedio</div>
+                        <div class="flex items-center"><span class="w-3 h-3 bg-orange-500 rounded-full mr-2"></span>Perfil ilustrativo</div>
+                        <div class="flex items-center"><span class="w-3 h-3 bg-stone-300 rounded-full mr-2"></span>Referencia visual</div>
                     </div>
                 </div>
             </div>
@@ -281,14 +338,14 @@
                 <div class="bg-white p-6 rounded-xl shadow-sm border-t-4 border-yellow-500 hover:shadow-md transition group">
                     <div class="text-4xl mb-3 group-hover:scale-110 transition duration-300">🌞</div>
                     <h3 class="font-bold text-lg mb-2">La Piel</h3>
-                    <p class="text-sm text-stone-600 mb-4">Al no tener pelo protector, la piel necesita hidratación y protección solar. Son propensos a acné juvenil.</p>
+                    <p class="text-sm text-stone-600 mb-4">La variedad sin pelo requiere observación de la piel, limpieza suave y protección adecuada según la exposición.</p>
                     <button onclick="showTip('skin')" class="text-yellow-600 text-xs font-bold uppercase tracking-wider hover:underline">Ver Tip Experto</button>
                 </div>
                 <!-- Card 2 -->
                 <div class="bg-white p-6 rounded-xl shadow-sm border-t-4 border-blue-500 hover:shadow-md transition group">
                     <div class="text-4xl mb-3 group-hover:scale-110 transition duration-300">❄️</div>
                     <h3 class="font-bold text-lg mb-2">Clima</h3>
-                    <p class="text-sm text-stone-600 mb-4">Intolerantes al frío extremo. Necesitan suéteres en invierno. En calor, su piel se siente caliente al tacto (40°C).</p>
+                    <p class="text-sm text-stone-600 mb-4">La variedad sin pelo puede necesitar apoyo ante frío o sol intenso. Observa comodidad y evita sobrecalentamiento.</p>
                     <button onclick="showTip('climate')" class="text-blue-600 text-xs font-bold uppercase tracking-wider hover:underline">Ver Tip Experto</button>
                 </div>
                 <!-- Card 3 -->
@@ -302,7 +359,7 @@
                 <div class="bg-white p-6 rounded-xl shadow-sm border-t-4 border-purple-500 hover:shadow-md transition group">
                     <div class="text-4xl mb-3 group-hover:scale-110 transition duration-300">🧠</div>
                     <h3 class="font-bold text-lg mb-2">Socialización</h3>
-                    <p class="text-sm text-stone-600 mb-4">Vital entre los 3 y 12 meses. Sin ella, su reserva natural puede convertirse en miedo o agresividad.</p>
+                    <p class="text-sm text-stone-600 mb-4">La socialización gradual y positiva es importante desde etapas tempranas y continúa durante toda la vida.</p>
                     <button onclick="showTip('social')" class="text-purple-600 text-xs font-bold uppercase tracking-wider hover:underline">Ver Tip Experto</button>
                 </div>
             </div>
@@ -317,9 +374,9 @@
 
         <!-- Section 5: Lifestyle Calculator -->
         <section id="lifestyle" class="bg-stone-200 rounded-3xl p-8 md:p-12 text-center">
-            <h2 class="text-3xl font-bold text-stone-800 mb-4">¿Es el Xolo para ti?</h2>
+            <h2 class="text-3xl font-bold text-stone-800 mb-4">Preguntas para valorar la convivencia</h2>
             <p class="text-stone-600 mb-8 max-w-2xl mx-auto">
-                Esta raza no es para dueños primerizos o personas que buscan un perro faldero pasivo. Responde estas 3 preguntas clave para ver tu compatibilidad inicial.
+                La experiencia previa no define por sí sola una buena familia. Responde tres preguntas para identificar temas que conviene conversar con el criador, un educador canino o un veterinario.
             </p>
 
             <div class="max-w-xl mx-auto space-y-4 text-left">
@@ -346,11 +403,11 @@
                     <div class="space-y-2">
                         <label class="flex items-center space-x-2 cursor-pointer">
                             <input type="radio" name="q2" value="10" class="form-radio text-orange-600">
-                            <span>Firme pero positivo (Líder)</span>
+                            <span>Coherente y basado en refuerzo positivo</span>
                         </label>
                         <label class="flex items-center space-x-2 cursor-pointer">
                             <input type="radio" name="q2" value="0" class="form-radio text-orange-600">
-                            <span>Permisivo / Los consiento mucho</span>
+                            <span>Aún necesito definir rutinas y límites</span>
                         </label>
                         <label class="flex items-center space-x-2 cursor-pointer">
                             <input type="radio" name="q2" value="0" class="form-radio text-orange-600">
@@ -368,13 +425,13 @@
                         </label>
                         <label class="flex items-center space-x-2 cursor-pointer">
                             <input type="radio" name="q3" value="10" class="form-radio text-orange-600">
-                            <span>No, valoro la lealtad exclusiva.</span>
+                            <span>No; puedo respetar su ritmo de acercamiento.</span>
                         </label>
                     </div>
                 </div>
 
                 <button onclick="calculateCompatibility()" class="w-full bg-stone-900 text-white py-3 rounded-lg font-bold hover:bg-orange-600 transition shadow-lg transform active:scale-95">
-                    Calcular Compatibilidad
+                    Ver orientación inicial
                 </button>
 
                 <div id="quiz-result" class="hidden p-6 rounded-xl border-2 text-center animate-pulse">
@@ -384,14 +441,24 @@
             </div>
         </section>
 
+        <section aria-labelledby="lecturas-relacionadas" class="bg-white rounded-2xl shadow-sm p-8 border border-stone-200">
+            <h2 id="lecturas-relacionadas" class="text-3xl font-bold text-stone-800 mb-4">Sigue explorando la convivencia</h2>
+            <p class="text-stone-600 mb-6">Relaciona temperamento, ejercicio y talla antes de valorar qué ejemplar puede integrarse mejor a una familia.</p>
+            <div class="grid grid-cols-1 md:grid-cols-3 gap-4">
+                <a href="xoloitzcuintle-ejercicio.html" data-cta="editorial-link" data-cta-location="related-content" class="rounded-xl border border-stone-200 p-5 hover:border-orange-500 transition">Ejercicio y actividad →</a>
+                <a href="guia-tallas-xoloitzcuintle.html" data-cta="editorial-link" data-cta-location="related-content" class="rounded-xl border border-stone-200 p-5 hover:border-orange-500 transition">Guía de tallas →</a>
+                <a href="../xolos-disponibles.html" data-cta="availability" data-cta-location="related-content" class="rounded-xl border border-stone-200 p-5 hover:border-orange-500 transition">Conoce a los Xolos →</a>
+            </div>
+        </section>
+
     </main>
 
     <!-- Footer -->
     <footer class="bg-stone-900 text-stone-400 py-12">
         <div class="max-w-6xl mx-auto px-4 text-center">
             <p class="mb-4 text-2xl">🐕</p>
-            <p class="text-sm">Aplicación Interactiva basada en el análisis del comportamiento del Xoloitzcuintle.</p>
-            <p class="text-xs mt-2 text-stone-600">Datos referenciales para fines educativos.</p>
+            <p class="text-sm">Guía interactiva sobre tendencias de comportamiento del xoloitzcuintle.</p>
+            <p class="text-xs mt-2 text-stone-600">Contenido educativo general; no sustituye una evaluación veterinaria o etológica individual.</p>
         </div>
     </footer>
 
@@ -420,13 +487,13 @@
             puppy: {
                 label: 'Cachorro (0-12 meses)',
                 data: [90, 40, 60, 85, 30], // [Energy, Reserve, Independence, NeedForAttention, Protection]
-                description: "Como cachorro, el Xolo es **altamente energético y destructor** si se aburre. Requiere mucha atención y socialización constante. Su instinto protector es bajo aún.",
+                description: "Durante la etapa de cachorro puede haber mucha exploración y actividad. El acompañamiento, el descanso y la socialización gradual ayudan a orientar su aprendizaje.",
                 btnClass: "bg-stone-200 text-stone-800"
             },
             adult: {
                 label: 'Adulto (2+ años)',
                 data: [40, 85, 70, 60, 90], // Lower energy, High reserve, Higher Independence, Balanced Attention, High Protection
-                description: "En la adultez, el Xolo se calma notablemente. Su energía baja, pero su **instinto de guardia y reserva con extraños** alcanza el máximo. Es independiente pero profundamente apegado a su dueño.",
+                description: "En la adultez pueden consolidarse rutinas y preferencias. Algunos ejemplares muestran reserva con desconocidos y un vínculo cercano con sus personas, con variaciones individuales.",
                 btnClass: "bg-stone-800 text-white"
             }
         };
@@ -438,19 +505,19 @@
         const tips = {
             skin: {
                 title: "Cuidado Dermatológico",
-                content: "Usa exfoliante suave una vez al mes para retirar células muertas. Aplica aceite de coco o cremas libres de lanolina después del baño. ¡Usa bloqueador solar (FPS 50) si van a estar al sol directo!"
+                content: "Evita rutinas universales. Usa productos formulados para perros y consulta al veterinario si aparecen lesiones, inflamación o resequedad persistente. La protección solar debe ser apta para uso veterinario."
             },
             climate: {
                 title: "Regulación Térmica",
-                content: "Su piel se oscurece con el sol (bronceado) para protegerse. En invierno, su falta de pelo hace que pierdan calor corporal muy rápido. Un buen abrigo no es un lujo, es una necesidad médica."
+                content: "La exposición solar puede cambiar temporalmente la pigmentación y también causar daño. Ajusta tiempo al exterior, sombra y abrigo a la respuesta del ejemplar y al clima."
             },
             teeth: {
                 title: "Genética Dental",
-                content: "No te alarmes si a tu Xolo 'sin pelo' le faltan premolares; es genéticamente normal. Sin embargo, los Xolos 'con pelo' deben tener la dentadura completa. Mantén una higiene dental rigurosa."
+                content: "La variedad sin pelo puede presentar ausencia de algunas piezas dentales. Un examen veterinario permite documentar la dentición y adaptar higiene, textura del alimento y seguimiento."
             },
             social: {
                 title: "Socialización Crítica",
-                content: "Llévalo a lugares concurridos, deja que gente diferente le de premios (sin forzar contacto) y preséntale otros perros amigables. El Xolo no socializado tiende a ser miedoso-agresivo, no solo tímido."
+                content: "Expón al cachorro de forma gradual y segura a personas, sonidos, superficies y perros compatibles. No fuerces el contacto; si hay miedo o reactividad, busca apoyo profesional."
             }
         };
 
@@ -619,19 +686,19 @@
 
             if (score >= 25) {
                 resultBox.classList.add('border-green-500', 'bg-green-50');
-                title.textContent = "Alta Compatibilidad (Aprobado)";
+                title.textContent = "Varios puntos compatibles";
                 title.className = "text-xl font-bold mb-2 text-green-800";
-                p.textContent = "Entiendes la naturaleza del Xolo. Tienes el liderazgo y el estilo de vida activo necesarios para que prospere.";
+                p.textContent = "Tus respuestas muestran condiciones favorables. El siguiente paso es conocer al ejemplar y conversar sobre necesidades, rutinas y acompañamiento.";
             } else if (score >= 15) {
                 resultBox.classList.add('border-yellow-500', 'bg-yellow-50');
-                title.textContent = "Compatibilidad Media (Precaución)";
+                title.textContent = "Aspectos por conversar";
                 title.className = "text-xl font-bold mb-2 text-yellow-800";
-                p.textContent = "Podrías tener un Xolo, pero necesitas ajustar tus expectativas sobre su nivel de socialización o ejercicio. Considera un adulto en lugar de un cachorro.";
+                p.textContent = "Hay temas de ejercicio, educación o expectativas que conviene revisar. La edad y personalidad del ejemplar pueden influir en el ajuste.";
             } else {
                 resultBox.classList.add('border-red-500', 'bg-red-50');
-                title.textContent = "Baja Compatibilidad";
+                title.textContent = "Hace falta revisar el contexto";
                 title.className = "text-xl font-bold mb-2 text-red-800";
-                p.textContent = "El Xoloitzcuintle podría ser frustrante para ti. Requieren más liderazgo y actividad de la que pareces poder ofrecer actualmente. ¡Hay otras razas maravillosas!";
+                p.textContent = "Tus respuestas señalan posibles desajustes de tiempo, actividad o manejo. Antes de decidir, conversa con un profesional y conoce las necesidades del ejemplar real.";
             }
         }
 


### PR DESCRIPTION
## Alcance

Primera etapa del trabajo aprobado. Modifica únicamente seis artículos en español. No cambia páginas en inglés, `en/blog/index.html`, `sitemap.xml` ni el generador de sitemap.

## Inventario inicial

| Página | GTM | Canonical | Descripción | OG/Twitter | Schema | hreflang | Situación de enlazado/editorial |
|---|---|---|---|---|---|---|---|
| Guía de tallas | Presente | Presente | Ausente | Ausente | Ausente | Ausente | Dos rutas a disponibilidad; orientación demasiado determinista |
| Precio | Presente | Presente | Presente | Ausente | Ausente | Ausente | CTA general; menú duplicado y afirmaciones absolutas sobre salud, pureza y NFT |
| Alimentación | Ausente | Ausente | Ausente | Ausente | Ausente | Ausente | Enlaces a inicio con UTM; prescripciones y porcentajes no respaldados |
| Temperamento | Ausente | Presente | Ausente | Ausente | Ausente | Ausente | Un enlace al inicio; perfiles y compatibilidad deterministas |
| Percepción térmica | Ausente | Ausente | Ausente | Ausente | Ausente | Ausente | Sin rutas editoriales; datos simulados y beneficios terapéuticos |
| Morfología de orejas | Ausente | Ausente | Ausente | Ausente | Ausente | Ausente | Sin rutas editoriales; porcentajes genéticos y cronología visual universal |

## Archivos modificados

- `blog/guia-tallas-xoloitzcuintle.html`
- `blog/precio-xoloitzcuintle.html`
- `blog/xoloitzcuintle-alimentacion.html`
- `blog/xoloitzcuintle-temperamento.html`
- `blog/calor-terapeutico-xoloitzcuintle.html`
- `blog/morfologia-orejas-xoloitzcuintle.html`

## Antes / después

- **Guía de tallas:** metadatos completos, schema y rutas a temperamento, precio, alimentación y ejemplares; la calculadora se presenta como orientación, no recomendación garantizada.
- **Precio:** explica factores, documentación, cuidados, acompañamiento y logística sin publicar cifras; corrige afirmaciones sobre salud, pureza y NFT; elimina la entrada duplicada del menú y ofrece orientación por WhatsApp o correo.
- **Alimentación:** elimina UTM internos y pautas universales, porcentajes y suplementos prescriptivos; recalibra gráficas como recursos educativos.
- **Temperamento:** elimina perfiles absolutos y resultados de “aprobado/rechazado”; convierte el cuestionario en orientación para conversar y corrige un desborde móvil.
- **Percepción térmica:** retira mediciones simuladas presentadas como evidencia y afirmaciones terapéuticas; distingue tradición oral de evidencia clínica y aclara que la cercanía de un Xolo no cura ni extrae enfermedades.
- **Morfología de orejas:** elimina porcentajes genéticos y la cronología Mes 1–Mes 8; la visualización usa cuatro etapas cualitativas, barras equivalentes y ninguna curva, edad o promesa de resultado.

También se sustituyó un enlace roto a `../galeria.html` por la ruta existente de Xolos disponibles.

## Ajustes posteriores a revisión

Commit: `560408e43588bf2aabe21d90b4f6aced3aed60d5`

1. Se dejó una sola entrada “Xolos disponibles” en el menú del artículo de precio.
2. Los CTA de WhatsApp y correo incorporan `data-lead-intent="price_inquiry"` y `data-cta-location="article_footer"`.
3. Se reforzó la advertencia médica del artículo de percepción térmica.
4. La gráfica de orejas quedó completamente cualitativa y no cronológica.
5. Los seis artículos muestran `Inicio › Blog › Nombre de la guía`, con enlaces en la misma pestaña, sin `generate_lead` y en concordancia con su `BreadcrumbList`.

## Analítica y GTM

- Se conserva exclusivamente `GTM-MGTMWN7T`.
- GTM se añadió solo a las cuatro páginas donde estaba ausente.
- Cada página tiene una carga de contenedor y su bloque `noscript`, sin duplicados ni otro ID.
- No se añadieron `onclick` de tracking, `gtag()` directo, `dataLayer.push()` inline ni UTM internos.
- `generate_lead` aparece únicamente en WhatsApp y correo del artículo de precio.
- Los enlaces editoriales y breadcrumbs no generan leads.
- El tracking sigue dependiendo del listener delegado de `js/main.js`.

Payload comprobado en navegador para ambos CTA:

```text
lead_channel = whatsapp | email
lead_intent = price_inquiry
cta_location = article_footer
page_type = blog-price
profile = general
profile_status = not_applicable
lang = es
```

## SEO técnico

- Canonical propio único en las seis páginas.
- `hreflang="es-MX"` y `x-default` apuntan a la canonical propia, sin alternates ingleses inexistentes.
- Open Graph y Twitter Cards completos.
- JSON-LD `Article` + `BreadcrumbList` válido.
- Breadcrumb visible coincidente con el JSON-LD en 6/6 páginas.
- La reciprocidad español/inglés se añadirá de forma atómica en PR 2, cuando existan las contrapartes localizadas.

## Validaciones finales

- **HTMLHint:** 6 archivos, 0 errores.
- **Enlaces y anclas:** todos los enlaces locales y anclas resuelven.
- **JSON-LD:** 6/6 bloques válidos.
- **Breadcrumbs:** 6/6 visibles, coincidentes con JSON-LD, misma pestaña y sin `generate_lead`.
- **JavaScript inline:** todos los scripts compilan.
- **Herramientas interactivas:** calculadora, pestañas, cuestionario, simuladores, botones, tarjetas y gráficas probados.
- **Gráfica de orejas:** `bar`, cuatro etapas cualitativas, datos equivalentes `[1,1,1,1]`, sin meses ni curva.
- **Revisión móvil:** Chromium, viewport 390×844; 390 px de contenido en las seis páginas, breadcrumbs de 14 px sobre fondo blanco, sin desbordes ni errores.
- **Gráficas visibles:** tallas 2/2, alimentación 2/2, temperamento 2/2, percepción térmica 2/2 y orejas 3/3.
- **Payload de leads:** WhatsApp y correo producen exactamente los siete valores documentados arriba.
- **Tracking:** `npm run test:generate-lead` aprobado.
- **Diff:** `git diff --check` aprobado.
- **Alcance remoto:** el diff sigue limitado exclusivamente a los seis artículos autorizados.

## Confirmaciones de privacidad y alcance

- No se publicaron precios numéricos, reservas, calendarios de pago, descuentos ni condiciones privadas.
- No se promete disponibilidad, entrega, salud perfecta, beneficio terapéutico, pureza genética ni pedigree probado por NFT.
- El NFT se describe como registro digital documental que acompaña información y evidencias; no sustituye FCM/FCI, genética ni evaluación veterinaria.
- No se modificó `sitemap.xml`; el generador y su resultado reproducible corresponden a PR 3.
- Este PR permanece en **Draft** y no debe fusionarse todavía.
