### PR TITLE
Stage 3: update bilingual blog sitemap

### DIFF
--- a/sitemap.xml
+++ b/sitemap.xml
@@ -17,15 +17,31 @@
   </url>
   <url>
     <loc>https://xolosramirez.com/blog/precio-xoloitzcuintle.html</loc>
+    <lastmod>2026-07-27</lastmod>
   </url>
   <url>
     <loc>https://xolosramirez.com/blog/guia-tallas-xoloitzcuintle.html</loc>
+    <lastmod>2026-07-27</lastmod>
   </url>
   <url>
     <loc>https://xolosramirez.com/blog/xoloitzcuintle-temperamento.html</loc>
+    <lastmod>2026-07-27</lastmod>
   </url>
   <url>
     <loc>https://xolosramirez.com/blog/xoloitzcuintle-alimentacion.html</loc>
+    <lastmod>2026-07-27</lastmod>
+  </url>
+  <url>
+    <loc>https://xolosramirez.com/blog/calor-terapeutico-xoloitzcuintle.html</loc>
+    <lastmod>2026-07-27</lastmod>
+  </url>
+  <url>
+    <loc>https://xolosramirez.com/blog/morfologia-orejas-xoloitzcuintle.html</loc>
+    <lastmod>2026-07-27</lastmod>
+  </url>
+  <url>
+    <loc>https://xolosramirez.com/blog/sizes-in-xoloitzcuintli.html</loc>
+    <lastmod>2026-07-27</lastmod>
   </url>
   <url>
     <loc>https://xolosramirez.com/en/index.html</loc>
@@ -38,5 +54,26 @@
   </url>
   <url>
     <loc>https://xolosramirez.com/en/blog/index.html</loc>
+    <lastmod>2026-07-28</lastmod>
+  </url>
+  <url>
+    <loc>https://xolosramirez.com/en/blog/xoloitzcuintli-price.html</loc>
+    <lastmod>2026-07-28</lastmod>
+  </url>
+  <url>
+    <loc>https://xolosramirez.com/en/blog/xoloitzcuintli-nutrition.html</loc>
+    <lastmod>2026-07-27</lastmod>
+  </url>
+  <url>
+    <loc>https://xolosramirez.com/en/blog/xoloitzcuintli-temperament.html</loc>
+    <lastmod>2026-07-27</lastmod>
+  </url>
+  <url>
+    <loc>https://xolosramirez.com/en/blog/why-xoloitzcuintli-feel-warm.html</loc>
+    <lastmod>2026-07-27</lastmod>
+  </url>
+  <url>
+    <loc>https://xolosramirez.com/en/blog/xoloitzcuintli-ear-development.html</loc>
+    <lastmod>2026-07-27</lastmod>
   </url>
 </urlset>


### PR DESCRIPTION
## Summary

Stage 3 closes the bilingual editorial rollout after PRs #270, #271, and #272 by updating only `sitemap.xml`. The sitemap now represents all 12 bilingual Xoloitzcuintli guides and records meaningful content-change dates from Git history.

## Existing URLs preserved

The four Spanish guide URLs already present were retained without duplication:

- `https://xolosramirez.com/blog/precio-xoloitzcuintle.html`
- `https://xolosramirez.com/blog/guia-tallas-xoloitzcuintle.html`
- `https://xolosramirez.com/blog/xoloitzcuintle-temperamento.html`
- `https://xolosramirez.com/blog/xoloitzcuintle-alimentacion.html`

## Eight URLs added

- `https://xolosramirez.com/blog/calor-terapeutico-xoloitzcuintle.html`
- `https://xolosramirez.com/blog/morfologia-orejas-xoloitzcuintle.html`
- `https://xolosramirez.com/blog/sizes-in-xoloitzcuintli.html`
- `https://xolosramirez.com/en/blog/xoloitzcuintli-price.html`
- `https://xolosramirez.com/en/blog/xoloitzcuintli-nutrition.html`
- `https://xolosramirez.com/en/blog/xoloitzcuintli-temperament.html`
- `https://xolosramirez.com/en/blog/why-xoloitzcuintli-feel-warm.html`
- `https://xolosramirez.com/en/blog/xoloitzcuintli-ear-development.html`

## `lastmod` updates

Dates were derived per file with `git log -1 --format=%cs -- <path>` rather than assigning one current date globally.

- `2026-07-27`: six Spanish guides, English size guide, English nutrition guide, English temperament guide, English warmth guide, and English ear-development guide.
- `2026-07-28`: `en/blog/index.html` and `en/blog/xoloitzcuintli-price.html`, reflecting the corrective work merged in PR #272.

## Validation

- [x] XML parsed successfully with Python `xml.etree.ElementTree`.
- [x] 21 unique sitemap URLs; no duplicates.
- [x] Every URL is absolute, canonical, parameter-free, and uses HTTPS.
- [x] All 12 bilingual guides are represented.
- [x] Every sitemap URL matches the canonical declared by its local public HTML file.
- [x] HTTP verification: 21/21 URLs returned direct `200` responses without redirects.
- [x] No source paths, Markdown files, imports, test pages, query parameters, `<priority>`, or `<changefreq>` entries were added.
- [x] All 13 `lastmod` values match the latest Git commit that changed the corresponding path.
- [x] `robots.txt` still references `https://xolosramirez.com/sitemap.xml` and was not modified.
- [x] `git diff --check` passed.
- [x] GitHub comparison confirms one modified file: `sitemap.xml` (`+37`, `-0`).

## Scope safeguards

- `robots.txt`, `package.json`, scripts, and dependencies remain unchanged.
- WalletConnect and XEC configuration remain unchanged.
- GTM and analytics remain unchanged.
- No prices, reservation amounts, payment schedules, discounts, or private commercial conditions were published.

This PR must remain Draft and must not be merged without explicit authorization.