### PR TITLE
Actualizar perfil reservado de Yaretzi a Tonalli Ramírez

### DIFF
--- a/en/available-xolos.html
+++ b/en/available-xolos.html
@@ -229,12 +229,12 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
   <div class="puppy-card__image-wrapper">
     <span class="puppy-card__status status-disponible">Reserved</span>
     <span class="puppy-card__status" style="top: 40px; background-color: #ff4d4d; color: #fff;">Reserved by Allan</span>
-    <div class="puppy-carousel" data-puppy-carousel role="region" aria-roledescription="carousel" aria-label="Yaretzi Ramirez photo carousel">
+    <div class="puppy-carousel" data-puppy-carousel role="region" aria-roledescription="carousel" aria-label="Tonalli Ramírez photo carousel">
       <div class="puppy-carousel__track" tabindex="0">
         <div class="puppy-carousel__slide">
           <img
         src="https://i.imgur.com/bWP6dAu.jpeg"
-        alt="Yaretzi Ramirez, Xoloitzcuintle, photo 1"
+        alt="Tonalli Ramírez, Xoloitzcuintle, photo 1"
         class="puppy-card__image"
 
 
@@ -243,7 +243,7 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
         <div class="puppy-carousel__slide">
           <img
         src="https://i.imgur.com/cZFdJFT.jpeg"
-        alt="Yaretzi Ramirez, Xoloitzcuintle, photo 2"
+        alt="Tonalli Ramírez, Xoloitzcuintle, photo 2"
         class="puppy-card__image"
 
 
@@ -258,7 +258,7 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
   </div>
 
   <div class="puppy-card__content">
-    <h3 class="puppy-card__name">Yaretzi Ramirez</h3>
+    <h3 class="puppy-card__name">Tonalli Ramírez</h3>
 
     <ul class="puppy-card__details">
       <li><strong>Age</strong>Newborn</li>
@@ -268,11 +268,11 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
     </ul>
 
     <div class="puppy-video-container" style="margin: 1rem 0; border-radius: 8px; overflow: hidden; aspect-ratio: 16/9;">
-      <iframe width="100%" height="100%" src="https://www.youtube.com/embed/EyYDj-1bnUU" title="Yaretzi Ramirez" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen loading="lazy"></iframe>
+      <iframe width="100%" height="100%" src="https://www.youtube.com/embed/EyYDj-1bnUU" title="Tonalli Ramírez" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen loading="lazy"></iframe>
     </div>
 
     <div class="puppy-card__actions">
-      <a href="mailto:contacto@xolosarmy.xyz?subject=Inquiry%20about%20Xoloitzcuintles%20similar%20to%20Yaretzi%20Ramirez%20[Ref:%20yaretzi-en-reserved]&body=Hello%2C%0A%0AI%20understand%20that%20Yaretzi%20Ramirez%20is%20currently%20reserved.%0A%0AI%20would%20like%20information%20about%20future%20litters%20or%20a%20Xoloitzcuintle%20with%20similar%20characteristics%2C%20including%20availability%20and%20the%20reservation%20process.%0A%0AThank%20you." class="btn-small btn-primary-small cta-lead cta-email" data-cta="email" data-lead-type="generate_lead" data-profile="yaretzi" data-page-type="available-xolos" data-lang="en" aria-label="Inquire about Xoloitzcuintles similar to Yaretzi" data-status="reserved">Contact via Email</a>
+      <a href="mailto:contacto@xolosarmy.xyz?subject=Inquiry%20about%20Xoloitzcuintles%20similar%20to%20Tonalli%20Ram%C3%ADrez%20%5BRef%3A%20tonalli-en-reserved%5D&body=Hello%2C%0A%0AI%20understand%20that%20Tonalli%20Ram%C3%ADrez%20is%20currently%20reserved.%0A%0AI%20would%20like%20information%20about%20future%20litters%20or%20a%20Xoloitzcuintli%20with%20similar%20characteristics%2C%20including%20availability%20and%20the%20reservation%20process.%0A%0AThank%20you." class="btn-small btn-primary-small cta-lead cta-email" data-cta="email" data-lead-type="generate_lead" data-profile="tonalli" data-page-type="available-xolos" data-lang="en" aria-label="Inquire about Xoloitzcuintles similar to Tonalli" data-status="reserved">Contact via Email</a>
     </div>
   </div>
 </article>

--- a/xolos-disponibles.html
+++ b/xolos-disponibles.html
@@ -292,12 +292,12 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
     <span class="puppy-card__status" style="top: 40px; background-color: #ff4d4d; color: #fff;">por "_"</span>
     <span class="puppy-card__status" style="top: 200px; background-color: #ff4d4d; color: #fff;">🔥 1 personas preguntando</span>
     -->
-    <div class="puppy-carousel" data-puppy-carousel role="region" aria-roledescription="carrusel" aria-label="Carrusel de fotos de Yaretzi Ramirez">
+    <div class="puppy-carousel" data-puppy-carousel role="region" aria-roledescription="carrusel" aria-label="Carrusel de fotos de Tonalli Ramírez">
       <div class="puppy-carousel__track" tabindex="0">
         <div class="puppy-carousel__slide">
           <img
         src="https://i.imgur.com/bWP6dAu.jpeg"
-        alt="Yaretzi Ramirez, Xoloitzcuintle, fotografía 1"
+        alt="Tonalli Ramírez, Xoloitzcuintle, fotografía 1"
         class="puppy-card__image"
 
 
@@ -306,7 +306,7 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
         <div class="puppy-carousel__slide">
           <img
         src="https://i.imgur.com/cZFdJFT.jpeg"
-        alt="Yaretzi Ramirez, Xoloitzcuintle, fotografía 2"
+        alt="Tonalli Ramírez, Xoloitzcuintle, fotografía 2"
         class="puppy-card__image"
 
 
@@ -321,7 +321,7 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
   </div>
 
   <div class="puppy-card__content">
-    <h3 class="puppy-card__name">Yaretzi Ramirez</h3>
+    <h3 class="puppy-card__name">Tonalli Ramírez</h3>
 
     <ul class="puppy-card__details">
       <li><strong>Edad</strong>Recién Nacida</li>
@@ -331,11 +331,11 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
     </ul>
 
     <div class="puppy-video-container" style="margin: 1rem 0; border-radius: 8px; overflow: hidden; aspect-ratio: 16/9;">
-      <iframe width="100%" height="100%" src="https://www.youtube.com/embed/EyYDj-1bnUU" title="Yaretzi Ramirez" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen loading="lazy"></iframe>
+      <iframe width="100%" height="100%" src="https://www.youtube.com/embed/EyYDj-1bnUU" title="Tonalli Ramírez" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen loading="lazy"></iframe>
     </div>
 
     <div class="puppy-card__actions">
-      <a href="mailto:contacto@xolosarmy.xyz?subject=Consulta%20sobre%20ejemplares%20similares%20a%20Yaretzi%20Ramirez%20[Ref:%20yaretzi-es-reserved]&body=Hola%2C%0A%0AS%C3%A9%20que%20Yaretzi%20Ramirez%20est%C3%A1%20reservada.%0A%0AMe%20gustar%C3%ADa%20recibir%20informaci%C3%B3n%20sobre%20futuras%20camadas%20o%20ejemplares%20similares%20a%20Yaretzi%2C%20incluyendo%20sus%20caracter%C3%ADsticas%2C%20disponibilidad%20y%20proceso%20de%20reserva.%0A%0AGracias." class="btn-small btn-primary-small cta-lead cta-email" style="background-color: #25D366; border-color: #25D366; width: 100%; justify-content: center;" data-cta="email" data-lead-type="generate_lead" data-profile="yaretzi" data-page-type="available-xolos" data-lang="es" aria-label="Consultar por ejemplares similares a Yaretzi" data-status="reserved">Correo directo ✉️</a>
+      <a href="mailto:contacto@xolosarmy.xyz?subject=Consulta%20sobre%20ejemplares%20similares%20a%20Tonalli%20Ram%C3%ADrez%20%5BRef%3A%20tonalli-es-reserved%5D&body=Hola%2C%0A%0AS%C3%A9%20que%20Tonalli%20Ram%C3%ADrez%20est%C3%A1%20reservada.%0A%0AMe%20gustar%C3%ADa%20recibir%20informaci%C3%B3n%20sobre%20futuras%20camadas%20o%20ejemplares%20similares%20a%20Tonalli%2C%20incluyendo%20sus%20caracter%C3%ADsticas%2C%20disponibilidad%20y%20proceso%20de%20reserva.%0A%0AGracias." class="btn-small btn-primary-small cta-lead cta-email" style="background-color: #25D366; border-color: #25D366; width: 100%; justify-content: center;" data-cta="email" data-lead-type="generate_lead" data-profile="tonalli" data-page-type="available-xolos" data-lang="es" aria-label="Consultar por ejemplares similares a Tonalli" data-status="reserved">Correo directo ✉️</a>
     </div>
   </div>
 </article>


### PR DESCRIPTION
## Resumen

- Renombra el perfil reservado de **Yaretzi** a **Tonalli Ramírez** en español e inglés.
- Actualiza el nombre visible, accesibilidad del carrusel e imágenes, título del video, correo de contacto e identificadores de analítica.
- Conserva el estado **“Reservada / por Allan”** y **“Reserved / Reserved by Allan”**.
- No cambia imágenes, URL del video, edad, género, talla, color, navegación, GTM, estilos, scripts ni otros perfiles.

## Archivos modificados

- `xolos-disponibles.html`
- `en/available-xolos.html`

## Detalle

- Nombre visible: `Tonalli Ramírez`.
- Identificador técnico y `data-profile`: `tonalli`.
- Referencias de lead: `tonalli-es-reserved` y `tonalli-en-reserved`.
- Los `mailto:` codificados indican que Tonalli está reservada y permiten consultar futuras camadas o ejemplares con características similares.
- Se actualizaron `aria-label`, textos `alt`, título del iframe y CTA de correo únicamente dentro de la ficha objetivo.

## Validación

- `git diff --check` — **PASS**, sin errores.
- `grep -niE 'Yaretzi|yaretzi' xolos-disponibles.html en/available-xolos.html` — **0 coincidencias**.
- `grep -niE 'Tonalli|tonalli' xolos-disponibles.html en/available-xolos.html` — **12 coincidencias esperadas**.
- `npx --yes htmlhint xolos-disponibles.html en/available-xolos.html` — **2 archivos analizados, 0 errores**.
- `npm run test:generate-lead` — **PASS**.
- Validación programática de ambas fichas — **PASS**: medios, características, estado, analítica y decodificación de `mailto:` correctos.
- Comparación `main...agent/rename-yaretzi-tonalli` — **1 commit, 2 archivos**, sin cambios adicionales.

## Revisión visual/estructural

Se revisó manualmente el HTML de ambas fichas: muestran **Tonalli Ramírez**, permanecen reservadas por Allan y conservan el mismo carrusel, las mismas URL de imagen, el mismo ID de YouTube y los botones válidos. El entorno no disponía de un ejecutable de navegador para generar capturas locales, por lo que no se adjuntan imágenes.

Confirmación expresa: **no quedan referencias a `Yaretzi` ni `yaretzi` en las dos subpáginas**.