### PR TITLE
Ordenar perfiles disponibles antes de los reservados

### DIFF
--- a/en/available-xolos.html
+++ b/en/available-xolos.html
@@ -227,58 +227,6 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
 
 <article class="puppy-card" data-aos="fade-up" data-aos-duration="800" data-aos-delay="200">
   <div class="puppy-card__image-wrapper">
-    <span class="puppy-card__status status-disponible">Reserved</span>
-    <span class="puppy-card__status" style="top: 40px; background-color: #ff4d4d; color: #fff;">Reserved by Allan</span>
-    <div class="puppy-carousel" data-puppy-carousel role="region" aria-roledescription="carousel" aria-label="Tonalli Ramírez photo carousel">
-      <div class="puppy-carousel__track" tabindex="0">
-        <div class="puppy-carousel__slide">
-          <img
-        src="https://i.imgur.com/bWP6dAu.jpeg"
-        alt="Tonalli Ramírez, Xoloitzcuintle, photo 1"
-        class="puppy-card__image"
-
-
-      width="1500" height="1000" loading="lazy" decoding="async" draggable="false">
-        </div>
-        <div class="puppy-carousel__slide">
-          <img
-        src="https://i.imgur.com/cZFdJFT.jpeg"
-        alt="Tonalli Ramírez, Xoloitzcuintle, photo 2"
-        class="puppy-card__image"
-
-
-      width="1500" height="1000" loading="lazy" decoding="async" draggable="false">
-        </div>
-      </div>
-      <button class="puppy-carousel__button puppy-carousel__button--previous" type="button" aria-label="Previous photo">&#8592;</button>
-      <button class="puppy-carousel__button puppy-carousel__button--next" type="button" aria-label="Next photo">&#8594;</button>
-      <div class="puppy-carousel__dots" aria-label="Select photo"></div>
-      <p class="puppy-carousel__live" aria-live="polite" aria-atomic="true"></p>
-    </div>
-  </div>
-
-  <div class="puppy-card__content">
-    <h3 class="puppy-card__name">Tonalli Ramírez</h3>
-
-    <ul class="puppy-card__details">
-      <li><strong>Age</strong>Newborn</li>
-      <li><strong>Gender</strong>Female</li>
-      <li><strong>Size</strong>Standard</li>
-      <li><strong>Color</strong>Black</li>
-    </ul>
-
-    <div class="puppy-video-container" style="margin: 1rem 0; border-radius: 8px; overflow: hidden; aspect-ratio: 16/9;">
-      <iframe width="100%" height="100%" src="https://www.youtube.com/embed/EyYDj-1bnUU" title="Tonalli Ramírez" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen loading="lazy"></iframe>
-    </div>
-
-    <div class="puppy-card__actions">
-      <a href="mailto:contacto@xolosarmy.xyz?subject=Inquiry%20about%20Xoloitzcuintles%20similar%20to%20Tonalli%20Ram%C3%ADrez%20%5BRef%3A%20tonalli-en-reserved%5D&body=Hello%2C%0A%0AI%20understand%20that%20Tonalli%20Ram%C3%ADrez%20is%20currently%20reserved.%0A%0AI%20would%20like%20information%20about%20future%20litters%20or%20a%20Xoloitzcuintli%20with%20similar%20characteristics%2C%20including%20availability%20and%20the%20reservation%20process.%0A%0AThank%20you." class="btn-small btn-primary-small cta-lead cta-email" data-cta="email" data-lead-type="generate_lead" data-profile="tonalli" data-page-type="available-xolos" data-lang="en" aria-label="Inquire about Xoloitzcuintles similar to Tonalli" data-status="reserved">Contact via Email</a>
-    </div>
-  </div>
-</article>
-
-<article class="puppy-card" data-aos="fade-up" data-aos-duration="800" data-aos-delay="200">
-  <div class="puppy-card__image-wrapper">
     <span class="puppy-card__status status-disponible">Available</span>
     <div class="puppy-carousel" data-puppy-carousel role="region" aria-roledescription="carousel" aria-label="Iztli Ramirez photo carousel">
       <div class="puppy-carousel__track" tabindex="0">
@@ -338,9 +286,6 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
     </div>
   </div>
 </article>
-
-
-
 
 <article class="puppy-card" data-aos="fade-up" data-aos-duration="800" data-aos-delay="200">
   <div class="puppy-card__image-wrapper">
@@ -408,90 +353,8 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
 
 
 
-        <article class="puppy-card" data-aos="fade-up" data-aos-duration="800" data-aos-delay="200">
-          <div class="puppy-card__image-wrapper">
-            <span class="puppy-card__status status-disponible">Reserved</span>
-            <span class="puppy-card__status" style="top: 40px; background-color: #ff4d4d; color: #fff;">by Román Morales</span>
-            <div class="puppy-carousel" data-puppy-carousel role="region" aria-roledescription="carousel" aria-label="Nox Ramírez photo carousel">
-              <div class="puppy-carousel__track" tabindex="0">
-                <div class="puppy-carousel__slide">
-                  <img src="https://i.imgur.com/jLNvtQk.jpeg" alt="Nox Ramírez Xoloitzcuintle" class="puppy-card__image" loading="lazy" decoding="async" draggable="false" />
-                </div>
-                <div class="puppy-carousel__slide">
-                  <img src="https://i.imgur.com/WilqbGs.jpeg" alt="Nox Ramírez Xoloitzcuintle" class="puppy-card__image" loading="lazy" decoding="async" draggable="false" />
-                </div>
-                <div class="puppy-carousel__slide">
-                  <img src="https://i.imgur.com/tvovZ8K.jpeg" alt="Nox Ramírez Xoloitzcuintle" class="puppy-card__image" loading="lazy" decoding="async" draggable="false" />
-                </div>
-              </div>
-              <button class="puppy-carousel__button puppy-carousel__button--previous" type="button" aria-label="Previous photo">&#8592;</button>
-              <button class="puppy-carousel__button puppy-carousel__button--next" type="button" aria-label="Next photo">&#8594;</button>
-              <div class="puppy-carousel__dots" aria-label="Select photo"></div>
-              <p class="puppy-carousel__live" aria-live="polite" aria-atomic="true"></p>
-            </div>
-          </div>
-          <div class="puppy-card__content">
-            <h3 class="puppy-card__name">Nox Ramírez</h3>
-            <ul class="puppy-card__details">
-              <li><strong>Age</strong>6 months</li>
-              <li><strong>Gender</strong>Male</li>
-              <li><strong>Size</strong>Standard</li>
-              <li><strong>Color</strong>Black</li>
-              <li><strong>Coat</strong>Hairless</li>
-            </ul>
-            <div class="puppy-video-container" style="margin: 1rem 0; border-radius: 8px; overflow: hidden; aspect-ratio: 16/9;">
-              <iframe width="100%" height="100%" src="https://www.youtube.com/embed/oxsIzDwxZKw" title="Nox Ramírez" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen loading="lazy"></iframe>
-            </div>
-            <div class="puppy-card__actions">
-              <a href="mailto:contacto@xolosarmy.xyz?subject=Inquiry%20about%20a%20Xoloitzcuintle%20similar%20to%20Nox%20Ram%C3%ADrez%20%5BRef%3A%20nox-en-reserved%5D&amp;body=Hello%2C%0A%0AI%20saw%20Nox%20Ram%C3%ADrez%27s%20profile%20and%20understand%20this%20Xoloitzcuintle%20is%20currently%20reserved.%0A%0AI%20am%20interested%20in%20future%20litters%20or%20a%20Xoloitzcuintle%20with%20similar%20characteristics." class="btn-small btn-primary-small cta-lead cta-email" data-cta="email" data-lead-type="generate_lead" data-profile="nox" data-page-type="available-xolos" data-lang="en" aria-label="Contact by email about Xolos similar to Nox" data-status="reserved">Contact via Email</a>
-            </div>
-          </div>
-        </article>
 
 <article class="puppy-card" data-aos="fade-up" data-aos-duration="800" data-aos-delay="200">
-          <div class="puppy-card__image-wrapper">
-    <span class="puppy-card__status status-disponible">Reserved</span>
-    <div class="puppy-carousel" data-puppy-carousel role="region" aria-roledescription="carousel" aria-label="Xochitl Ramirez photo carousel">
-      <div class="puppy-carousel__track" tabindex="0">
-        <div class="puppy-carousel__slide">
-          <img
-                src="https://i.imgur.com/vnboKks.jpeg"
-                alt="Xoloitzcuintle Xochitl Ramirez"
-                class="puppy-card__image"
-                loading="lazy"
-
-              />
-        </div>
-      </div>
-      <button class="puppy-carousel__button puppy-carousel__button--previous" type="button" aria-label="Previous photo">&#8592;</button>
-      <button class="puppy-carousel__button puppy-carousel__button--next" type="button" aria-label="Next photo">&#8594;</button>
-      <div class="puppy-carousel__dots" aria-label="Select photo"></div>
-      <p class="puppy-carousel__live" aria-live="polite" aria-atomic="true"></p>
-    </div>
-  </div>
-          <div class="puppy-card__content">
-            <h3 class="puppy-card__name">Xochitl Ramirez</h3>
-            <ul class="puppy-card__details">
-              <li><strong>Age</strong>Newborn</li>
-              <li><strong>Gender</strong>Female</li>
-              <li><strong>Size</strong>Intermediate / Medium</li>
-              <li><strong>Color</strong>Red</li>
-            </ul>
-
-             <div class="puppy-video-container" style="margin: 1rem 0; border-radius: 8px; overflow: hidden; aspect-ratio: 16/9;">
-    <iframe width="100%" height="100%" src="https://www.youtube.com/embed/FyBc9vMsCGQ" title="Xochitl Ramirez" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen loading="lazy"></iframe>
-  </div>
-
-  <div class="puppy-card__actions">
-              <a href="mailto:contacto@xolosarmy.xyz?subject=Inquiry%20about%20a%20Xoloitzcuintle%20similar%20to%20Xochitl%20Ramirez%20[Ref:%20xochitl-en-reserved]&body=Hello%2C%0A%0AI%20saw%20Xochitl%20Ramirez's%20profile%20and%20understand%20this%20Xoloitzcuintle%20is%20currently%20reserved.%0A%0AI%20am%20interested%20in%20future%20litters%20or%20a%20Xoloitzcuintle%20with%20similar%20characteristics.%0A%0AI%20would%20like%20to%20receive%20information%20about%3A%0A%0A-%20future%20puppies%20or%20litters%3B%0A-%20size%2C%20sex%2C%20and%20temperament%3B%0A-%20documentation%20and%20care%3B%0A-%20price%20and%20process%20conditions%3B%0A-%20delivery%20options%20for%20our%20location.%0A%0ATo%20help%20you%20guide%20us%20better%2C%20here%20is%20some%20information%3A%0A%0ACity%20or%20country%3A%0ACharacteristics%20we%20are%20looking%20for%3A%0APrevious%20experience%20with%20dogs%3A%0AWhatsApp%20contact%20number%3A%0A%0AThank%20you." class="btn-small btn-primary-small cta-lead cta-email" data-cta="email" data-lead-type="generate_lead" data-profile="xochitl" data-page-type="available-xolos" data-lang="en" aria-label="Contact by email about Xochitl" data-status="reserved">Contact via Email</a>
-            </div>
-          </div>
-        </article>
-
-
-
-
-       <article class="puppy-card" data-aos="fade-up" data-aos-duration="800" data-aos-delay="200">
           <div class="puppy-card__image-wrapper">
     <span class="puppy-card__status status-disponible">Available</span>
     <div class="puppy-carousel" data-puppy-carousel role="region" aria-roledescription="carousel" aria-label="Yohualli Ramirez photo carousel">
@@ -540,6 +403,143 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
 
   <div class="puppy-card__actions">
               <a href="mailto:contacto@xolosarmy.xyz?subject=Inquiry%20about%20Yohualli%20Ramirez%20[Ref:%20yohualli-en-available]&body=Hello%2C%0A%0AI%20saw%20Yohualli%20Ramirez's%20profile%20on%20the%20Xolos%20Ram%C3%ADrez%20website%20and%20I%20am%20interested%20in%20learning%20more.%0A%0AI%20would%20like%20to%20know%20whether%20this%20Xoloitzcuintle%20could%20be%20a%20good%20fit%20for%20our%20family%20and%20receive%20information%20about%3A%0A%0A-%20personality%20and%20temperament%3B%0A-%20current%20availability%3B%0A-%20documentation%20and%20care%3B%0A-%20price%20and%20process%20conditions%3B%0A-%20delivery%20options%20for%20our%20location.%0A%0ATo%20help%20you%20guide%20us%20better%2C%20here%20is%20some%20information%3A%0A%0ACity%20or%20country%3A%0AType%20of%20home%3A%0APrevious%20experience%20with%20dogs%3A%0AWhatsApp%20contact%20number%3A%0A%0AThank%20you." class="btn-small btn-primary-small cta-lead cta-email" data-cta="email" data-lead-type="generate_lead" data-profile="yohualli" data-page-type="available-xolos" data-lang="en" aria-label="Contact by email about Yohualli" data-status="available">Contact via Email</a>
+            </div>
+          </div>
+        </article>
+
+
+
+        <article class="puppy-card" data-aos="fade-up" data-aos-duration="800" data-aos-delay="200">
+  <div class="puppy-card__image-wrapper">
+    <span class="puppy-card__status status-disponible">Reserved</span>
+    <span class="puppy-card__status" style="top: 40px; background-color: #ff4d4d; color: #fff;">Reserved by Allan</span>
+    <div class="puppy-carousel" data-puppy-carousel role="region" aria-roledescription="carousel" aria-label="Tonalli Ramírez photo carousel">
+      <div class="puppy-carousel__track" tabindex="0">
+        <div class="puppy-carousel__slide">
+          <img
+        src="https://i.imgur.com/bWP6dAu.jpeg"
+        alt="Tonalli Ramírez, Xoloitzcuintle, photo 1"
+        class="puppy-card__image"
+
+
+      width="1500" height="1000" loading="lazy" decoding="async" draggable="false">
+        </div>
+        <div class="puppy-carousel__slide">
+          <img
+        src="https://i.imgur.com/cZFdJFT.jpeg"
+        alt="Tonalli Ramírez, Xoloitzcuintle, photo 2"
+        class="puppy-card__image"
+
+
+      width="1500" height="1000" loading="lazy" decoding="async" draggable="false">
+        </div>
+      </div>
+      <button class="puppy-carousel__button puppy-carousel__button--previous" type="button" aria-label="Previous photo">&#8592;</button>
+      <button class="puppy-carousel__button puppy-carousel__button--next" type="button" aria-label="Next photo">&#8594;</button>
+      <div class="puppy-carousel__dots" aria-label="Select photo"></div>
+      <p class="puppy-carousel__live" aria-live="polite" aria-atomic="true"></p>
+    </div>
+  </div>
+
+  <div class="puppy-card__content">
+    <h3 class="puppy-card__name">Tonalli Ramírez</h3>
+
+    <ul class="puppy-card__details">
+      <li><strong>Age</strong>Newborn</li>
+      <li><strong>Gender</strong>Female</li>
+      <li><strong>Size</strong>Standard</li>
+      <li><strong>Color</strong>Black</li>
+    </ul>
+
+    <div class="puppy-video-container" style="margin: 1rem 0; border-radius: 8px; overflow: hidden; aspect-ratio: 16/9;">
+      <iframe width="100%" height="100%" src="https://www.youtube.com/embed/EyYDj-1bnUU" title="Tonalli Ramírez" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen loading="lazy"></iframe>
+    </div>
+
+    <div class="puppy-card__actions">
+      <a href="mailto:contacto@xolosarmy.xyz?subject=Inquiry%20about%20Xoloitzcuintles%20similar%20to%20Tonalli%20Ram%C3%ADrez%20%5BRef%3A%20tonalli-en-reserved%5D&body=Hello%2C%0A%0AI%20understand%20that%20Tonalli%20Ram%C3%ADrez%20is%20currently%20reserved.%0A%0AI%20would%20like%20information%20about%20future%20litters%20or%20a%20Xoloitzcuintli%20with%20similar%20characteristics%2C%20including%20availability%20and%20the%20reservation%20process.%0A%0AThank%20you." class="btn-small btn-primary-small cta-lead cta-email" data-cta="email" data-lead-type="generate_lead" data-profile="tonalli" data-page-type="available-xolos" data-lang="en" aria-label="Inquire about Xoloitzcuintles similar to Tonalli" data-status="reserved">Contact via Email</a>
+    </div>
+  </div>
+</article>
+
+<article class="puppy-card" data-aos="fade-up" data-aos-duration="800" data-aos-delay="200">
+          <div class="puppy-card__image-wrapper">
+            <span class="puppy-card__status status-disponible">Reserved</span>
+            <span class="puppy-card__status" style="top: 40px; background-color: #ff4d4d; color: #fff;">by Román Morales</span>
+            <div class="puppy-carousel" data-puppy-carousel role="region" aria-roledescription="carousel" aria-label="Nox Ramírez photo carousel">
+              <div class="puppy-carousel__track" tabindex="0">
+                <div class="puppy-carousel__slide">
+                  <img src="https://i.imgur.com/jLNvtQk.jpeg" alt="Nox Ramírez Xoloitzcuintle" class="puppy-card__image" loading="lazy" decoding="async" draggable="false" />
+                </div>
+                <div class="puppy-carousel__slide">
+                  <img src="https://i.imgur.com/WilqbGs.jpeg" alt="Nox Ramírez Xoloitzcuintle" class="puppy-card__image" loading="lazy" decoding="async" draggable="false" />
+                </div>
+                <div class="puppy-carousel__slide">
+                  <img src="https://i.imgur.com/tvovZ8K.jpeg" alt="Nox Ramírez Xoloitzcuintle" class="puppy-card__image" loading="lazy" decoding="async" draggable="false" />
+                </div>
+              </div>
+              <button class="puppy-carousel__button puppy-carousel__button--previous" type="button" aria-label="Previous photo">&#8592;</button>
+              <button class="puppy-carousel__button puppy-carousel__button--next" type="button" aria-label="Next photo">&#8594;</button>
+              <div class="puppy-carousel__dots" aria-label="Select photo"></div>
+              <p class="puppy-carousel__live" aria-live="polite" aria-atomic="true"></p>
+            </div>
+          </div>
+          <div class="puppy-card__content">
+            <h3 class="puppy-card__name">Nox Ramírez</h3>
+            <ul class="puppy-card__details">
+              <li><strong>Age</strong>6 months</li>
+              <li><strong>Gender</strong>Male</li>
+              <li><strong>Size</strong>Standard</li>
+              <li><strong>Color</strong>Black</li>
+              <li><strong>Coat</strong>Hairless</li>
+            </ul>
+            <div class="puppy-video-container" style="margin: 1rem 0; border-radius: 8px; overflow: hidden; aspect-ratio: 16/9;">
+              <iframe width="100%" height="100%" src="https://www.youtube.com/embed/oxsIzDwxZKw" title="Nox Ramírez" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen loading="lazy"></iframe>
+            </div>
+            <div class="puppy-card__actions">
+              <a href="mailto:contacto@xolosarmy.xyz?subject=Inquiry%20about%20a%20Xoloitzcuintle%20similar%20to%20Nox%20Ram%C3%ADrez%20%5BRef%3A%20nox-en-reserved%5D&amp;body=Hello%2C%0A%0AI%20saw%20Nox%20Ram%C3%ADrez%27s%20profile%20and%20understand%20this%20Xoloitzcuintle%20is%20currently%20reserved.%0A%0AI%20am%20interested%20in%20future%20litters%20or%20a%20Xoloitzcuintle%20with%20similar%20characteristics." class="btn-small btn-primary-small cta-lead cta-email" data-cta="email" data-lead-type="generate_lead" data-profile="nox" data-page-type="available-xolos" data-lang="en" aria-label="Contact by email about Xolos similar to Nox" data-status="reserved">Contact via Email</a>
+            </div>
+          </div>
+        </article>
+
+
+
+
+       <article class="puppy-card" data-aos="fade-up" data-aos-duration="800" data-aos-delay="200">
+          <div class="puppy-card__image-wrapper">
+    <span class="puppy-card__status status-disponible">Reserved</span>
+    <div class="puppy-carousel" data-puppy-carousel role="region" aria-roledescription="carousel" aria-label="Xochitl Ramirez photo carousel">
+      <div class="puppy-carousel__track" tabindex="0">
+        <div class="puppy-carousel__slide">
+          <img
+                src="https://i.imgur.com/vnboKks.jpeg"
+                alt="Xoloitzcuintle Xochitl Ramirez"
+                class="puppy-card__image"
+                loading="lazy"
+
+              />
+        </div>
+      </div>
+      <button class="puppy-carousel__button puppy-carousel__button--previous" type="button" aria-label="Previous photo">&#8592;</button>
+      <button class="puppy-carousel__button puppy-carousel__button--next" type="button" aria-label="Next photo">&#8594;</button>
+      <div class="puppy-carousel__dots" aria-label="Select photo"></div>
+      <p class="puppy-carousel__live" aria-live="polite" aria-atomic="true"></p>
+    </div>
+  </div>
+          <div class="puppy-card__content">
+            <h3 class="puppy-card__name">Xochitl Ramirez</h3>
+            <ul class="puppy-card__details">
+              <li><strong>Age</strong>Newborn</li>
+              <li><strong>Gender</strong>Female</li>
+              <li><strong>Size</strong>Intermediate / Medium</li>
+              <li><strong>Color</strong>Red</li>
+            </ul>
+
+             <div class="puppy-video-container" style="margin: 1rem 0; border-radius: 8px; overflow: hidden; aspect-ratio: 16/9;">
+    <iframe width="100%" height="100%" src="https://www.youtube.com/embed/FyBc9vMsCGQ" title="Xochitl Ramirez" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen loading="lazy"></iframe>
+  </div>
+
+  <div class="puppy-card__actions">
+              <a href="mailto:contacto@xolosarmy.xyz?subject=Inquiry%20about%20a%20Xoloitzcuintle%20similar%20to%20Xochitl%20Ramirez%20[Ref:%20xochitl-en-reserved]&body=Hello%2C%0A%0AI%20saw%20Xochitl%20Ramirez's%20profile%20and%20understand%20this%20Xoloitzcuintle%20is%20currently%20reserved.%0A%0AI%20am%20interested%20in%20future%20litters%20or%20a%20Xoloitzcuintle%20with%20similar%20characteristics.%0A%0AI%20would%20like%20to%20receive%20information%20about%3A%0A%0A-%20future%20puppies%20or%20litters%3B%0A-%20size%2C%20sex%2C%20and%20temperament%3B%0A-%20documentation%20and%20care%3B%0A-%20price%20and%20process%20conditions%3B%0A-%20delivery%20options%20for%20our%20location.%0A%0ATo%20help%20you%20guide%20us%20better%2C%20here%20is%20some%20information%3A%0A%0ACity%20or%20country%3A%0ACharacteristics%20we%20are%20looking%20for%3A%0APrevious%20experience%20with%20dogs%3A%0AWhatsApp%20contact%20number%3A%0A%0AThank%20you." class="btn-small btn-primary-small cta-lead cta-email" data-cta="email" data-lead-type="generate_lead" data-profile="xochitl" data-page-type="available-xolos" data-lang="en" aria-label="Contact by email about Xochitl" data-status="reserved">Contact via Email</a>
             </div>
           </div>
         </article>

--- a/xolos-disponibles.html
+++ b/xolos-disponibles.html
@@ -285,63 +285,6 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
 
 <article class="puppy-card" data-aos="fade-up" data-aos-duration="800" data-aos-delay="200">
   <div class="puppy-card__image-wrapper">
-    <span class="puppy-card__status status-disponible">Reservada</span>
-    <span class="puppy-card__status" style="top: 40px; background-color: #ff4d4d; color: #fff;">por Allan</span>
-
-    <!--
-    <span class="puppy-card__status" style="top: 40px; background-color: #ff4d4d; color: #fff;">por "_"</span>
-    <span class="puppy-card__status" style="top: 200px; background-color: #ff4d4d; color: #fff;">🔥 1 personas preguntando</span>
-    -->
-    <div class="puppy-carousel" data-puppy-carousel role="region" aria-roledescription="carrusel" aria-label="Carrusel de fotos de Tonalli Ramírez">
-      <div class="puppy-carousel__track" tabindex="0">
-        <div class="puppy-carousel__slide">
-          <img
-        src="https://i.imgur.com/bWP6dAu.jpeg"
-        alt="Tonalli Ramírez, Xoloitzcuintle, fotografía 1"
-        class="puppy-card__image"
-
-
-      width="1500" height="1000" loading="lazy" decoding="async" draggable="false">
-        </div>
-        <div class="puppy-carousel__slide">
-          <img
-        src="https://i.imgur.com/cZFdJFT.jpeg"
-        alt="Tonalli Ramírez, Xoloitzcuintle, fotografía 2"
-        class="puppy-card__image"
-
-
-      width="1500" height="1000" loading="lazy" decoding="async" draggable="false">
-        </div>
-      </div>
-      <button class="puppy-carousel__button puppy-carousel__button--previous" type="button" aria-label="Foto anterior">&#8592;</button>
-      <button class="puppy-carousel__button puppy-carousel__button--next" type="button" aria-label="Foto siguiente">&#8594;</button>
-      <div class="puppy-carousel__dots" aria-label="Seleccionar foto"></div>
-      <p class="puppy-carousel__live" aria-live="polite" aria-atomic="true"></p>
-    </div>
-  </div>
-
-  <div class="puppy-card__content">
-    <h3 class="puppy-card__name">Tonalli Ramírez</h3>
-
-    <ul class="puppy-card__details">
-      <li><strong>Edad</strong>Recién Nacida</li>
-      <li><strong>Género</strong>Hembra</li>
-      <li><strong>Talla</strong>Estándar</li>
-      <li><strong>Color</strong>Negro</li>
-    </ul>
-
-    <div class="puppy-video-container" style="margin: 1rem 0; border-radius: 8px; overflow: hidden; aspect-ratio: 16/9;">
-      <iframe width="100%" height="100%" src="https://www.youtube.com/embed/EyYDj-1bnUU" title="Tonalli Ramírez" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen loading="lazy"></iframe>
-    </div>
-
-    <div class="puppy-card__actions">
-      <a href="mailto:contacto@xolosarmy.xyz?subject=Consulta%20sobre%20ejemplares%20similares%20a%20Tonalli%20Ram%C3%ADrez%20%5BRef%3A%20tonalli-es-reserved%5D&body=Hola%2C%0A%0AS%C3%A9%20que%20Tonalli%20Ram%C3%ADrez%20est%C3%A1%20reservada.%0A%0AMe%20gustar%C3%ADa%20recibir%20informaci%C3%B3n%20sobre%20futuras%20camadas%20o%20ejemplares%20similares%20a%20Tonalli%2C%20incluyendo%20sus%20caracter%C3%ADsticas%2C%20disponibilidad%20y%20proceso%20de%20reserva.%0A%0AGracias." class="btn-small btn-primary-small cta-lead cta-email" style="background-color: #25D366; border-color: #25D366; width: 100%; justify-content: center;" data-cta="email" data-lead-type="generate_lead" data-profile="tonalli" data-page-type="available-xolos" data-lang="es" aria-label="Consultar por ejemplares similares a Tonalli" data-status="reserved">Correo directo ✉️</a>
-    </div>
-  </div>
-</article>
-
-<article class="puppy-card" data-aos="fade-up" data-aos-duration="800" data-aos-delay="200">
-  <div class="puppy-card__image-wrapper">
     <span class="puppy-card__status status-disponible">Disponible</span>
     <div class="puppy-carousel" data-puppy-carousel role="region" aria-roledescription="carrusel" aria-label="Carrusel de fotos de Iztli Ramirez">
       <div class="puppy-carousel__track" tabindex="0">
@@ -401,9 +344,6 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
     </div>
   </div>
 </article>
-
-
-
 
 <article class="puppy-card" data-aos="fade-up" data-aos-duration="800" data-aos-delay="200">
   <div class="puppy-card__image-wrapper">
@@ -470,99 +410,9 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
 </article>
 
 
-   <article class="puppy-card" data-aos="fade-up" data-aos-duration="800" data-aos-delay="200">
-    <div class="puppy-card__image-wrapper">
-      <span class="puppy-card__status status-disponible">Reservado</span>
-      <span class="puppy-card__status" style="top: 40px; background-color: #ff4d4d; color: #fff;">por Román Morales</span>
-      <div class="puppy-carousel" data-puppy-carousel role="region" aria-roledescription="carrusel" aria-label="Carrusel de fotos de Nox Ramírez">
-        <div class="puppy-carousel__track" tabindex="0">
-          <div class="puppy-carousel__slide">
-            <img src="https://i.imgur.com/jLNvtQk.jpeg" alt="Xoloitzcuintle Nox Ramírez" class="puppy-card__image" loading="lazy" decoding="async" draggable="false" />
-          </div>
-          <div class="puppy-carousel__slide">
-            <img src="https://i.imgur.com/WilqbGs.jpeg" alt="Xoloitzcuintle Nox Ramírez" class="puppy-card__image" loading="lazy" decoding="async" draggable="false" />
-          </div>
-          <div class="puppy-carousel__slide">
-            <img src="https://i.imgur.com/tvovZ8K.jpeg" alt="Xoloitzcuintle Nox Ramírez" class="puppy-card__image" loading="lazy" decoding="async" draggable="false" />
-          </div>
-        </div>
-        <button class="puppy-carousel__button puppy-carousel__button--previous" type="button" aria-label="Foto anterior">&#8592;</button>
-        <button class="puppy-carousel__button puppy-carousel__button--next" type="button" aria-label="Foto siguiente">&#8594;</button>
-        <div class="puppy-carousel__dots" aria-label="Seleccionar foto"></div>
-        <p class="puppy-carousel__live" aria-live="polite" aria-atomic="true"></p>
-      </div>
-    </div>
-    <div class="puppy-card__content">
-      <h3 class="puppy-card__name">Nox Ramírez</h3>
-      <ul class="puppy-card__details">
-        <li><strong>Edad</strong>6 meses</li>
-        <li><strong>Género</strong>Macho</li>
-        <li><strong>Talla</strong>Estándar</li>
-        <li><strong>Color</strong>Negro</li>
-        <li><strong>Variedad</strong>Sin pelo</li>
-      </ul>
-      <div class="puppy-video-container" style="margin: 1rem 0; border-radius: 8px; overflow: hidden; aspect-ratio: 16/9;">
-        <iframe width="100%" height="100%" src="https://www.youtube.com/embed/oxsIzDwxZKw" title="Nox Ramírez" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen loading="lazy"></iframe>
-      </div>
-      <div class="puppy-card__actions">
-        <a href="mailto:contacto@xolosarmy.xyz?subject=Consulta%20sobre%20ejemplar%20similar%20a%20Nox%20Ram%C3%ADrez%20%5BRef%3A%20nox-es-reserved%5D&amp;body=Hola%2C%0A%0AVi%20el%20perfil%20de%20Nox%20Ram%C3%ADrez%20y%20entiendo%20que%20actualmente%20est%C3%A1%20reservado.%0A%0AMe%20interesa%20conocer%20futuras%20camadas%20o%20alg%C3%BAn%20xoloitzcuintle%20con%20caracter%C3%ADsticas%20similares." class="btn-small btn-primary-small cta-lead cta-email" style="background-color: #25D366; border-color: #25D366; width: 100%; justify-content: center;" data-cta="email" data-lead-type="generate_lead" data-profile="nox" data-page-type="available-xolos" data-lang="es" aria-label="Escribir por correo sobre ejemplares similares a Nox" data-status="reserved">Correo directo ✉️</a>
-      </div>
-    </div>
-  </article>
+
 
 <article class="puppy-card" data-aos="fade-up" data-aos-duration="800" data-aos-delay="200">
-    <div class="puppy-card__image-wrapper">
-    <span class="puppy-card__status status-disponible">Reservada</span>
-
-<span class="puppy-card__status" style="top: 40px; background-color: #ff4d4d; color: #fff;">por Gustavo Lomelí</span>
-
-<!--
-
-<span class="puppy-card__status" style="top: 40px; background-color: #ff4d4d; color: #fff;">por "_"</span>
-
-
-      <span class="puppy-card__status" style="top: 200px; background-color: #ff4d4d; color: #fff;">🔥 1 personas preguntando</span>
-      -->
-    <div class="puppy-carousel" data-puppy-carousel role="region" aria-roledescription="carrusel" aria-label="Carrusel de fotos de Xochitl Ramirez">
-      <div class="puppy-carousel__track" tabindex="0">
-        <div class="puppy-carousel__slide">
-          <img
-          src="https://i.imgur.com/vnboKks.jpeg"
-          alt="Xoloitzcuintle Xochitl Ramirez"
-          class="puppy-card__image"
-          loading="lazy"
-
-          />
-        </div>
-      </div>
-      <button class="puppy-carousel__button puppy-carousel__button--previous" type="button" aria-label="Foto anterior">&#8592;</button>
-      <button class="puppy-carousel__button puppy-carousel__button--next" type="button" aria-label="Foto siguiente">&#8594;</button>
-      <div class="puppy-carousel__dots" aria-label="Seleccionar foto"></div>
-      <p class="puppy-carousel__live" aria-live="polite" aria-atomic="true"></p>
-    </div>
-  </div>
-    <div class="puppy-card__content">
-      <h3 class="puppy-card__name">Xochitl Ramirez</h3>
-      <ul class="puppy-card__details">
-        <li><strong>Edad</strong>Recién Nacida</li>
-        <li><strong>Género</strong>Hembra</li>
-        <li><strong>Talla</strong>Intermedia</li>
-        <li><strong>Color</strong>Bermejo</li>
-      </ul>
-
-      <div class="puppy-video-container" style="margin: 1rem 0; border-radius: 8px; overflow: hidden; aspect-ratio: 16/9;">
-    <iframe width="100%" height="100%" src="https://www.youtube.com/embed/FyBc9vMsCGQ" title="Xochitl Ramirez" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen loading="lazy"></iframe>
-  </div>
-
-  <div class="puppy-card__actions">
-    <a href="mailto:contacto@xolosarmy.xyz?subject=Consulta%20sobre%20ejemplar%20similar%20a%20Xochitl%20Ramirez%20[Ref:%20xochitl-es-reserved]&body=Hola%2C%0A%0AVi%20el%20perfil%20de%20Xochitl%20Ramirez%20y%20entiendo%20que%20actualmente%20est%C3%A1%20reservado.%0A%0AMe%20interesa%20conocer%20futuras%20camadas%20o%20alg%C3%BAn%20xoloitzcuintle%20con%20caracter%C3%ADsticas%20similares.%0A%0AQuisiera%20recibir%20informaci%C3%B3n%20sobre%3A%0A%0A-%20ejemplares%20o%20camadas%20futuras%3B%0A-%20talla%2C%20sexo%20y%20temperamento%3B%0A-%20documentaci%C3%B3n%20y%20cuidados%3B%0A-%20precio%20y%20condiciones%20del%20proceso%3B%0A-%20opciones%20de%20entrega%20para%20nuestra%20ubicaci%C3%B3n.%0A%0APara%20que%20puedan%20orientarme%20mejor%2C%20comparto%20estos%20datos%3A%0A%0ACiudad%20o%20pa%C3%ADs%3A%0ACaracter%C3%ADsticas%20que%20buscamos%3A%0AExperiencia%20previa%20con%20perros%3A%0AN%C3%BAmero%20de%20WhatsApp%20de%20contacto%3A%0A%0AGracias." class="btn-small btn-primary-small cta-lead cta-email" style="background-color: #25D366; border-color: #25D366; width: 100%; justify-content: center;" data-cta="email" data-lead-type="generate_lead" data-profile="xochitl" data-page-type="available-xolos" data-lang="es" aria-label="Escribir por correo sobre Xochitl" data-status="reserved">Correo directo ✉️</a>
-  </div>
-</div>
-  </article>
-
-
-
-   <article class="puppy-card" data-aos="fade-up" data-aos-duration="800" data-aos-delay="200">
     <div class="puppy-card__image-wrapper">
     <span class="puppy-card__status status-disponible">Disponible</span>
 
@@ -618,6 +468,156 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
 
   <div class="puppy-card__actions">
     <a href="mailto:contacto@xolosarmy.xyz?subject=Consulta%20sobre%20Yohualli%20Ramirez%20[Ref:%20yohualli-es-available]&body=Hola%2C%0A%0AVi%20el%20perfil%20de%20Yohualli%20Ramirez%20en%20el%20sitio%20de%20Xolos%20Ram%C3%ADrez%20y%20me%20interesa%20conocer%20m%C3%A1s%20sobre%20sus%20caracter%C3%ADsticas.%0A%0AQuisiera%20saber%20si%20podr%C3%ADa%20integrarse%20bien%20a%20nuestra%20familia%20y%20recibir%20informaci%C3%B3n%20sobre%3A%0A%0A-%20su%20personalidad%20y%20temperamento%3B%0A-%20su%20disponibilidad%20actual%3B%0A-%20documentaci%C3%B3n%20y%20cuidados%20correspondientes%3B%0A-%20precio%20y%20condiciones%20del%20proceso%3B%0A-%20opciones%20de%20entrega%20para%20nuestra%20ubicaci%C3%B3n.%0A%0APara%20que%20puedan%20orientarme%20mejor%2C%20comparto%20estos%20datos%3A%0A%0ACiudad%20o%20pa%C3%ADs%3A%0ATipo%20de%20hogar%20(casa%2Fdepartamento)%3A%0AExperiencia%20previa%20con%20perros%3A%0AN%C3%BAmero%20de%20WhatsApp%20de%20contacto%3A%0A%0AGracias." class="btn-small btn-primary-small cta-lead cta-email" style="background-color: #25D366; border-color: #25D366; width: 100%; justify-content: center;" data-cta="email" data-lead-type="generate_lead" data-profile="yohualli" data-page-type="available-xolos" data-lang="es" aria-label="Escribir por correo sobre Yohualli" data-status="available">Correo directo ✉️</a>
+  </div>
+</div>
+  </article>
+
+
+   <article class="puppy-card" data-aos="fade-up" data-aos-duration="800" data-aos-delay="200">
+  <div class="puppy-card__image-wrapper">
+    <span class="puppy-card__status status-disponible">Reservada</span>
+    <span class="puppy-card__status" style="top: 40px; background-color: #ff4d4d; color: #fff;">por Allan</span>
+
+    <!--
+    <span class="puppy-card__status" style="top: 40px; background-color: #ff4d4d; color: #fff;">por "_"</span>
+    <span class="puppy-card__status" style="top: 200px; background-color: #ff4d4d; color: #fff;">🔥 1 personas preguntando</span>
+    -->
+    <div class="puppy-carousel" data-puppy-carousel role="region" aria-roledescription="carrusel" aria-label="Carrusel de fotos de Tonalli Ramírez">
+      <div class="puppy-carousel__track" tabindex="0">
+        <div class="puppy-carousel__slide">
+          <img
+        src="https://i.imgur.com/bWP6dAu.jpeg"
+        alt="Tonalli Ramírez, Xoloitzcuintle, fotografía 1"
+        class="puppy-card__image"
+
+
+      width="1500" height="1000" loading="lazy" decoding="async" draggable="false">
+        </div>
+        <div class="puppy-carousel__slide">
+          <img
+        src="https://i.imgur.com/cZFdJFT.jpeg"
+        alt="Tonalli Ramírez, Xoloitzcuintle, fotografía 2"
+        class="puppy-card__image"
+
+
+      width="1500" height="1000" loading="lazy" decoding="async" draggable="false">
+        </div>
+      </div>
+      <button class="puppy-carousel__button puppy-carousel__button--previous" type="button" aria-label="Foto anterior">&#8592;</button>
+      <button class="puppy-carousel__button puppy-carousel__button--next" type="button" aria-label="Foto siguiente">&#8594;</button>
+      <div class="puppy-carousel__dots" aria-label="Seleccionar foto"></div>
+      <p class="puppy-carousel__live" aria-live="polite" aria-atomic="true"></p>
+    </div>
+  </div>
+
+  <div class="puppy-card__content">
+    <h3 class="puppy-card__name">Tonalli Ramírez</h3>
+
+    <ul class="puppy-card__details">
+      <li><strong>Edad</strong>Recién Nacida</li>
+      <li><strong>Género</strong>Hembra</li>
+      <li><strong>Talla</strong>Estándar</li>
+      <li><strong>Color</strong>Negro</li>
+    </ul>
+
+    <div class="puppy-video-container" style="margin: 1rem 0; border-radius: 8px; overflow: hidden; aspect-ratio: 16/9;">
+      <iframe width="100%" height="100%" src="https://www.youtube.com/embed/EyYDj-1bnUU" title="Tonalli Ramírez" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen loading="lazy"></iframe>
+    </div>
+
+    <div class="puppy-card__actions">
+      <a href="mailto:contacto@xolosarmy.xyz?subject=Consulta%20sobre%20ejemplares%20similares%20a%20Tonalli%20Ram%C3%ADrez%20%5BRef%3A%20tonalli-es-reserved%5D&body=Hola%2C%0A%0AS%C3%A9%20que%20Tonalli%20Ram%C3%ADrez%20est%C3%A1%20reservada.%0A%0AMe%20gustar%C3%ADa%20recibir%20informaci%C3%B3n%20sobre%20futuras%20camadas%20o%20ejemplares%20similares%20a%20Tonalli%2C%20incluyendo%20sus%20caracter%C3%ADsticas%2C%20disponibilidad%20y%20proceso%20de%20reserva.%0A%0AGracias." class="btn-small btn-primary-small cta-lead cta-email" style="background-color: #25D366; border-color: #25D366; width: 100%; justify-content: center;" data-cta="email" data-lead-type="generate_lead" data-profile="tonalli" data-page-type="available-xolos" data-lang="es" aria-label="Consultar por ejemplares similares a Tonalli" data-status="reserved">Correo directo ✉️</a>
+    </div>
+  </div>
+</article>
+
+<article class="puppy-card" data-aos="fade-up" data-aos-duration="800" data-aos-delay="200">
+    <div class="puppy-card__image-wrapper">
+      <span class="puppy-card__status status-disponible">Reservado</span>
+      <span class="puppy-card__status" style="top: 40px; background-color: #ff4d4d; color: #fff;">por Román Morales</span>
+      <div class="puppy-carousel" data-puppy-carousel role="region" aria-roledescription="carrusel" aria-label="Carrusel de fotos de Nox Ramírez">
+        <div class="puppy-carousel__track" tabindex="0">
+          <div class="puppy-carousel__slide">
+            <img src="https://i.imgur.com/jLNvtQk.jpeg" alt="Xoloitzcuintle Nox Ramírez" class="puppy-card__image" loading="lazy" decoding="async" draggable="false" />
+          </div>
+          <div class="puppy-carousel__slide">
+            <img src="https://i.imgur.com/WilqbGs.jpeg" alt="Xoloitzcuintle Nox Ramírez" class="puppy-card__image" loading="lazy" decoding="async" draggable="false" />
+          </div>
+          <div class="puppy-carousel__slide">
+            <img src="https://i.imgur.com/tvovZ8K.jpeg" alt="Xoloitzcuintle Nox Ramírez" class="puppy-card__image" loading="lazy" decoding="async" draggable="false" />
+          </div>
+        </div>
+        <button class="puppy-carousel__button puppy-carousel__button--previous" type="button" aria-label="Foto anterior">&#8592;</button>
+        <button class="puppy-carousel__button puppy-carousel__button--next" type="button" aria-label="Foto siguiente">&#8594;</button>
+        <div class="puppy-carousel__dots" aria-label="Seleccionar foto"></div>
+        <p class="puppy-carousel__live" aria-live="polite" aria-atomic="true"></p>
+      </div>
+    </div>
+    <div class="puppy-card__content">
+      <h3 class="puppy-card__name">Nox Ramírez</h3>
+      <ul class="puppy-card__details">
+        <li><strong>Edad</strong>6 meses</li>
+        <li><strong>Género</strong>Macho</li>
+        <li><strong>Talla</strong>Estándar</li>
+        <li><strong>Color</strong>Negro</li>
+        <li><strong>Variedad</strong>Sin pelo</li>
+      </ul>
+      <div class="puppy-video-container" style="margin: 1rem 0; border-radius: 8px; overflow: hidden; aspect-ratio: 16/9;">
+        <iframe width="100%" height="100%" src="https://www.youtube.com/embed/oxsIzDwxZKw" title="Nox Ramírez" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen loading="lazy"></iframe>
+      </div>
+      <div class="puppy-card__actions">
+        <a href="mailto:contacto@xolosarmy.xyz?subject=Consulta%20sobre%20ejemplar%20similar%20a%20Nox%20Ram%C3%ADrez%20%5BRef%3A%20nox-es-reserved%5D&amp;body=Hola%2C%0A%0AVi%20el%20perfil%20de%20Nox%20Ram%C3%ADrez%20y%20entiendo%20que%20actualmente%20est%C3%A1%20reservado.%0A%0AMe%20interesa%20conocer%20futuras%20camadas%20o%20alg%C3%BAn%20xoloitzcuintle%20con%20caracter%C3%ADsticas%20similares." class="btn-small btn-primary-small cta-lead cta-email" style="background-color: #25D366; border-color: #25D366; width: 100%; justify-content: center;" data-cta="email" data-lead-type="generate_lead" data-profile="nox" data-page-type="available-xolos" data-lang="es" aria-label="Escribir por correo sobre ejemplares similares a Nox" data-status="reserved">Correo directo ✉️</a>
+      </div>
+    </div>
+  </article>
+
+
+
+   <article class="puppy-card" data-aos="fade-up" data-aos-duration="800" data-aos-delay="200">
+    <div class="puppy-card__image-wrapper">
+    <span class="puppy-card__status status-disponible">Reservada</span>
+
+<span class="puppy-card__status" style="top: 40px; background-color: #ff4d4d; color: #fff;">por Gustavo Lomelí</span>
+
+<!--
+
+<span class="puppy-card__status" style="top: 40px; background-color: #ff4d4d; color: #fff;">por "_"</span>
+
+
+      <span class="puppy-card__status" style="top: 200px; background-color: #ff4d4d; color: #fff;">🔥 1 personas preguntando</span>
+      -->
+    <div class="puppy-carousel" data-puppy-carousel role="region" aria-roledescription="carrusel" aria-label="Carrusel de fotos de Xochitl Ramirez">
+      <div class="puppy-carousel__track" tabindex="0">
+        <div class="puppy-carousel__slide">
+          <img
+          src="https://i.imgur.com/vnboKks.jpeg"
+          alt="Xoloitzcuintle Xochitl Ramirez"
+          class="puppy-card__image"
+          loading="lazy"
+
+          />
+        </div>
+      </div>
+      <button class="puppy-carousel__button puppy-carousel__button--previous" type="button" aria-label="Foto anterior">&#8592;</button>
+      <button class="puppy-carousel__button puppy-carousel__button--next" type="button" aria-label="Foto siguiente">&#8594;</button>
+      <div class="puppy-carousel__dots" aria-label="Seleccionar foto"></div>
+      <p class="puppy-carousel__live" aria-live="polite" aria-atomic="true"></p>
+    </div>
+  </div>
+    <div class="puppy-card__content">
+      <h3 class="puppy-card__name">Xochitl Ramirez</h3>
+      <ul class="puppy-card__details">
+        <li><strong>Edad</strong>Recién Nacida</li>
+        <li><strong>Género</strong>Hembra</li>
+        <li><strong>Talla</strong>Intermedia</li>
+        <li><strong>Color</strong>Bermejo</li>
+      </ul>
+
+      <div class="puppy-video-container" style="margin: 1rem 0; border-radius: 8px; overflow: hidden; aspect-ratio: 16/9;">
+    <iframe width="100%" height="100%" src="https://www.youtube.com/embed/FyBc9vMsCGQ" title="Xochitl Ramirez" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen loading="lazy"></iframe>
+  </div>
+
+  <div class="puppy-card__actions">
+    <a href="mailto:contacto@xolosarmy.xyz?subject=Consulta%20sobre%20ejemplar%20similar%20a%20Xochitl%20Ramirez%20[Ref:%20xochitl-es-reserved]&body=Hola%2C%0A%0AVi%20el%20perfil%20de%20Xochitl%20Ramirez%20y%20entiendo%20que%20actualmente%20est%C3%A1%20reservado.%0A%0AMe%20interesa%20conocer%20futuras%20camadas%20o%20alg%C3%BAn%20xoloitzcuintle%20con%20caracter%C3%ADsticas%20similares.%0A%0AQuisiera%20recibir%20informaci%C3%B3n%20sobre%3A%0A%0A-%20ejemplares%20o%20camadas%20futuras%3B%0A-%20talla%2C%20sexo%20y%20temperamento%3B%0A-%20documentaci%C3%B3n%20y%20cuidados%3B%0A-%20precio%20y%20condiciones%20del%20proceso%3B%0A-%20opciones%20de%20entrega%20para%20nuestra%20ubicaci%C3%B3n.%0A%0APara%20que%20puedan%20orientarme%20mejor%2C%20comparto%20estos%20datos%3A%0A%0ACiudad%20o%20pa%C3%ADs%3A%0ACaracter%C3%ADsticas%20que%20buscamos%3A%0AExperiencia%20previa%20con%20perros%3A%0AN%C3%BAmero%20de%20WhatsApp%20de%20contacto%3A%0A%0AGracias." class="btn-small btn-primary-small cta-lead cta-email" style="background-color: #25D366; border-color: #25D366; width: 100%; justify-content: center;" data-cta="email" data-lead-type="generate_lead" data-profile="xochitl" data-page-type="available-xolos" data-lang="es" aria-label="Escribir por correo sobre Xochitl" data-status="reserved">Correo directo ✉️</a>
   </div>
 </div>
   </article>


### PR DESCRIPTION
## Objetivo

Reordena las tarjetas de **Perfiles destacados / Featured Profiles** para mostrar primero los cachorros disponibles y después los reservados, sin modificar el contenido interno de ninguna ficha.

## Archivos modificados

- `xolos-disponibles.html`
- `en/available-xolos.html`

## Orden resultante

En ambas páginas:

1. Iztli Ramirez — Disponible / Available
2. Xilonen Ramirez — Disponible / Available
3. Yohualli Ramirez — Disponible / Available
4. Tonalli Ramírez — Reservada / Reserved
5. Nox Ramírez — Reservado / Reserved
6. Xochitl Ramirez — Reservada / Reserved
7. Teyolia Ramirez — Reservada / Reserved
8. Chimalma Ramirez — Reservada / Reserved

El bloque comentado de Tonatiuh permanece intacto.

## Garantías de alcance

- Se movieron bloques `<article class="puppy-card">` completos.
- Se conservó el orden relativo original entre disponibles.
- Se conservó el orden relativo original entre reservados.
- Cada tarjeta conserva exactamente sus mismos bytes internos: nombre, estado, imágenes, video, enlaces, botones, atributos, analítica y textos.
- Los ocho perfiles activos continúan dentro del mismo contenedor `.puppy-grid`.
- No se modificó contenido fuera de `.puppy-grid` ni archivos adicionales.

## Validación

- `git diff --check` — **PASS**.
- HTMLHint sobre ambos archivos — **2 archivos analizados, 0 errores**.
- `npm run test:generate-lead` — **PASS**.
- Validación estructural programática — **PASS** en ambos idiomas.
- Comparación SHA-256 por tarjeta contra `main` — **PASS**; ninguna tarjeta cambió internamente.
- Integridad de bloques comentados — **PASS**.
- Diff remoto — **1 commit, 2 archivos**, sin cambios adicionales.

El volumen de líneas añadidas/eliminadas corresponde exclusivamente al movimiento de tarjetas completas.