### PR TITLE
Reemplazar botones flotantes de WhatsApp por correo

### DIFF
--- a/en/available-xolos.html
+++ b/en/available-xolos.html
@@ -843,14 +843,12 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
   </footer>
 
   <a
-    class="wa-float cta-lead cta-whatsapp"
-    href="https://wa.me/525518555993?text=Hello%2C%20I%E2%80%99m%20interested%20in%20learning%20about%20the%20price%20and%20current%20availability%20of%20a%20Xoloitzcuintle.%20I%20would%20also%20like%20guidance%20about%20sizes%2C%20documentation%20and%20delivery.%20My%20city%20or%20country%20is%3A"
-    target="_blank"
-    rel="noopener noreferrer"
-    data-gtm="whatsapp-floating-en"
-    data-cta="whatsapp" data-lead-type="generate_lead" data-profile="general" data-page-type="available-xolos" data-lang="en" aria-label="Talk to Xolos Ramírez on WhatsApp">
-    <span class="wa-float__icon" aria-hidden="true">💬</span>
-    <span class="wa-float__text">Ask about Xoloitzcuintle price</span>
+    class="home-email-float cta-lead cta-email"
+    href="mailto:contacto@xolosarmy.xyz"
+    data-gtm="email-floating-en"
+    data-cta="email" data-lead-type="generate_lead" data-profile="general" data-page-type="available-xolos" data-lang="en" aria-label="Email Xolos Ramírez" title="Email Xolos Ramírez">
+    <span class="home-email-float__icon" aria-hidden="true">✉️</span>
+    <span class="home-email-float__text">Email Xolos Ramírez</span>
   </a>
 
   <script src="https://unpkg.com/aos@2.3.1/dist/aos.js"></script>

--- a/scripts/test-generate-lead-tracking.mjs
+++ b/scripts/test-generate-lead-tracking.mjs
@@ -79,7 +79,8 @@ for (const path of ['index.html', 'en/index.html']) {
 
 for (const path of ['xolos-disponibles.html', 'en/available-xolos.html']) {
   const html = read(path);
-  assert.ok(/class="[^"]*wa-float[^"]*"[\s\S]*?data-cta="whatsapp"[\s\S]*?data-lead-type="generate_lead"/.test(html), path + ' must keep floating WhatsApp lead CTA');
+  assert.ok(/class="[^"]*home-email-float[^"]*"[\s\S]*?href="mailto:contacto@xolosarmy\.xyz"[\s\S]*?data-cta="email"[\s\S]*?data-lead-type="generate_lead"/.test(html), path + ' must keep floating email lead CTA');
+  assert.equal(/class="[^"]*(?:wa-float|whatsapp-float)[^"]*"[\s\S]*?href="(?:https?:\/\/(?:wa\.me|api\.whatsapp\.com)|whatsapp:\/\/)/i.test(html), false, path + ' must not keep a floating WhatsApp link');
   assert.ok(/data-profile="(?!general)[^"]+"/.test(html), path + ' must keep profile slugs');
   assert.ok(/data-status="(?:available|reserved|delivered|teyolia)"/.test(html), path + ' must keep profile statuses');
 }

--- a/xolos-disponibles.html
+++ b/xolos-disponibles.html
@@ -943,14 +943,12 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
     </footer>
 
     <a
-      class="wa-float cta-lead cta-whatsapp"
-      href="https://wa.me/525518555993?text=Hola%2C%20me%20interesa%20conocer%20el%20precio%20y%20la%20disponibilidad%20de%20un%20xoloitzcuintle.%20Tambi%C3%A9n%20quisiera%20recibir%20orientaci%C3%B3n%20sobre%20tallas%2C%20documentaci%C3%B3n%20y%20proceso%20de%20entrega.%20Mi%20ciudad%20o%20pa%C3%ADs%20es%3A"
-      target="_blank"
-      rel="noopener noreferrer"
-      data-gtm="whatsapp-floating"
-      data-cta="whatsapp" data-lead-type="generate_lead" data-profile="general" data-page-type="available-xolos" data-lang="es" aria-label="Hablar con Xolos Ramírez por WhatsApp">
-      <span class="wa-float__icon" aria-hidden="true">💬</span>
-      <span class="wa-float__text">Preguntar precio de un xoloitzcuintle</span>
+      class="home-email-float cta-lead cta-email"
+      href="mailto:contacto@xolosarmy.xyz"
+      data-gtm="email-floating"
+      data-cta="email" data-lead-type="generate_lead" data-profile="general" data-page-type="available-xolos" data-lang="es" aria-label="Enviar correo a Xolos Ramírez" title="Enviar correo a Xolos Ramírez">
+      <span class="home-email-float__icon" aria-hidden="true">✉️</span>
+      <span class="home-email-float__text">Enviar correo a Xolos Ramírez</span>
     </a>
 
     <script src="js/main.js" defer></script>


### PR DESCRIPTION
## Objetivo

Reemplaza exclusivamente los dos botones flotantes que todavía abrían WhatsApp por botones flotantes de correo dirigidos al destino canónico:

`mailto:contacto@xolosarmy.xyz`

La rama parte del HEAD de `main` `69c250c1c2ffe08eb595163656abbf22f3c9dce4`.

## Archivos modificados

- `xolos-disponibles.html`
- `en/available-xolos.html`
- `scripts/test-generate-lead-tracking.mjs`

## Cambios

- Reutiliza el componente visual `home-email-float` ya presente en las páginas principales.
- Sustituye `wa-float`, `cta-whatsapp`, `data-cta="whatsapp"`, los identificadores GTM de WhatsApp, el icono de conversación y los nombres accesibles de WhatsApp.
- Añade semántica de correo, icono ✉️ y etiquetas localizadas:
  - Español: `Enviar correo a Xolos Ramírez`
  - Inglés: `Email Xolos Ramírez`
- Conserva `generate_lead`, `profile="general"`, `page-type="available-xolos"` e idioma.
- Actualiza la prueba de tracking para exigir el botón flotante de correo y rechazar destinos flotantes de WhatsApp.

## Enlaces anteriores encontrados

- Español: `https://wa.me/525518555993?text=...`
- Inglés: `https://wa.me/525518555993?text=...`

## Destino final

- `mailto:contacto@xolosarmy.xyz`
- Sin número telefónico, asunto ni cuerpo prellenado.

## WhatsApp conservado por no ser flotante

Se conservaron cuatro CTA normales dentro del contenido:

- Selector de contacto en `xolos-disponibles.html`.
- Selector de contacto en `en/available-xolos.html`.
- CTA editorial en `blog/precio-xoloitzcuintle.html`.
- CTA editorial en `en/blog/xoloitzcuintli-price.html`.

## Validación

- `npm run test:generate-lead`: PASS.
- HTMLHint en ambos HTML modificados: 0 errores.
- `node --check scripts/test-generate-lead-tracking.mjs`: PASS.
- `node --check js/main.js`: PASS.
- `git diff --check`: PASS.
- Validador estructural: un único botón `home-email-float` por página, destino exacto, icono de correo, nombres accesibles localizados y ausencia de semántica WhatsApp: PASS.
- Responsive: conserva posición fija, dimensiones, hover, focus y regla móvil del componente compartido `home-email-float` ya usado en `index.html`. La comprobación estática del CSS compartido pasó; no se generaron capturas porque el entorno no dispone de navegador ejecutable.

## Alcance

No se modificaron contenido editorial, SEO, fotografías, navegación, perfiles, CSS ni JavaScript de producción. El diff está limitado a los dos botones flotantes y su prueba automatizada.

Este PR permanece como **Draft** y no debe fusionarse sin revisión humana.