### PR TITLE
Replace floating email CTA with video call booking

### DIFF
--- a/en/available-xolos.html
+++ b/en/available-xolos.html
@@ -843,12 +843,23 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
   </footer>
 
   <a
-    class="home-email-float cta-lead cta-email"
-    href="mailto:contacto@xolosarmy.xyz?subject=Xoloitzcuintle%20price%20and%20availability&amp;body=Hello%2C%20I%E2%80%99m%20interested%20in%20learning%20about%20the%20price%20and%20current%20availability%20of%20a%20Xoloitzcuintle.%20I%20would%20also%20like%20guidance%20about%20sizes%2C%20documentation%20and%20delivery.%0A%0AMy%20city%20or%20country%20is%3A"
-    data-gtm="email-floating-en"
-    data-cta="email" data-lead-type="generate_lead" data-lead-intent="price_inquiry" data-profile="general" data-page-type="available-xolos" data-lang="en" aria-label="Ask about Xoloitzcuintle price by email" title="Ask about Xoloitzcuintle price by email">
-    <span class="home-email-float__icon" aria-hidden="true">✉️</span>
-    <span class="home-email-float__text">Ask about Xoloitzcuintle price</span>
+    href="https://calendar.app.google/1PXNvJM42iZ3JMHC8"
+    class="home-email-float video-call-float cta-lead"
+    target="_blank"
+    rel="noopener noreferrer"
+    data-cta="video_call"
+    data-lead-type="generate_lead"
+    data-lead-intent="video_call_request"
+    data-cta-location="floating"
+    data-profile="general"
+    data-status="not_applicable"
+    data-page-type="available-xolos"
+    data-lang="en"
+    aria-label="Book a video call with Xolos Ramírez"
+    title="Book a video call with Xolos Ramírez"
+  >
+    <span class="home-email-float__icon" aria-hidden="true">📹</span>
+    <span class="home-email-float__text">Book a video call</span>
   </a>
 
   <script src="https://unpkg.com/aos@2.3.1/dist/aos.js"></script>

--- a/js/main.js
+++ b/js/main.js
@@ -86,6 +86,7 @@ function getLeadChannel(element) {
 
   if (cta === 'whatsapp') return 'whatsapp';
   if (cta === 'email') return 'email';
+  if (cta === 'video_call') return 'video_call';
   if (cta === 'contact-form' || cta === 'form') return 'form';
 
   return 'unknown';

--- a/scripts/test-generate-lead-tracking.mjs
+++ b/scripts/test-generate-lead-tracking.mjs
@@ -22,6 +22,7 @@ function formTag(html) {
 includes(main, "document.addEventListener('click'", 'Expected delegated click listener');
 includes(main, "target.closest('[data-lead-type=\"generate_lead\"]')", 'Expected closest() based lead lookup');
 includes(main, "event: 'generate_lead'", 'Expected generate_lead event push');
+includes(main, "if (cta === 'video_call') return 'video_call';", 'Expected video_call lead channel');
 
 for (const key of [
   'lead_channel',
@@ -77,54 +78,64 @@ for (const path of ['index.html', 'en/index.html']) {
   assert.ok(/class="[^"]*(wa-float|home-email-float)[^"]*"[\s\S]*?data-cta="email"[\s\S]*?data-lead-type="generate_lead"/.test(html), path + ' must keep floating email lead CTA');
 }
 
-const floatingEmailExpectations = [
+const floatingVideoCallExpectations = [
   {
     path: 'xolos-disponibles.html',
-    subject: 'Precio%20y%20disponibilidad%20de%20un%20xoloitzcuintle',
-    body: 'Hola%2C%20me%20interesa%20conocer%20el%20precio%20y%20la%20disponibilidad%20de%20un%20xoloitzcuintle.%20Tambi%C3%A9n%20quisiera%20recibir%20orientaci%C3%B3n%20sobre%20tallas%2C%20documentaci%C3%B3n%20y%20proceso%20de%20entrega.%0A%0AMi%20ciudad%20o%20pa%C3%ADs%20es%3A',
-    visibleText: 'Preguntar precio de un xoloitzcuintle',
-    accessibleText: 'Preguntar precio de un xoloitzcuintle por correo',
+    lang: 'es',
+    visibleText: 'Agendar videollamada',
+    accessibleText: 'Agendar videollamada con Xolos Ramírez',
   },
   {
     path: 'en/available-xolos.html',
-    subject: 'Xoloitzcuintle%20price%20and%20availability',
-    body: 'Hello%2C%20I%E2%80%99m%20interested%20in%20learning%20about%20the%20price%20and%20current%20availability%20of%20a%20Xoloitzcuintle.%20I%20would%20also%20like%20guidance%20about%20sizes%2C%20documentation%20and%20delivery.%0A%0AMy%20city%20or%20country%20is%3A',
-    visibleText: 'Ask about Xoloitzcuintle price',
-    accessibleText: 'Ask about Xoloitzcuintle price by email',
+    lang: 'en',
+    visibleText: 'Book a video call',
+    accessibleText: 'Book a video call with Xolos Ramírez',
   },
 ];
 
-for (const expectation of floatingEmailExpectations) {
+for (const expectation of floatingVideoCallExpectations) {
   const html = read(expectation.path);
 
-  const match = html.match(
-    /<a(?=[^>]*class="[^"]*home-email-float[^"]*")[^>]*>[\s\S]*?<\/a>/
+  const matches = html.match(
+    /<a(?=[^>]*class="[^"]*\bvideo-call-float\b[^"]*")[^>]*>[\s\S]*?<\/a>/g
+  ) || [];
+
+  assert.equal(
+    matches.length,
+    1,
+    expectation.path + ' must have exactly one floating video-call CTA'
   );
 
-  assert.ok(
-    match,
-    expectation.path + ' must keep one floating email CTA'
-  );
-
-  const cta = match[0];
-
-  const expectedHref =
-    'href="mailto:contacto@xolosarmy.xyz?subject=' +
-    expectation.subject +
-    '&amp;body=' +
-    expectation.body +
-    '"';
+  const cta = matches[0];
 
   includes(
     cta,
-    expectedHref,
-    expectation.path + ' must use the exact prefilled mailto'
+    'href="https://calendar.app.google/1PXNvJM42iZ3JMHC8"',
+    expectation.path + ' must use the exact Calendar booking URL'
   );
 
   includes(
     cta,
-    'data-cta="email"',
-    expectation.path + ' must keep email tracking'
+    'class="home-email-float video-call-float cta-lead"',
+    expectation.path + ' must keep the visual class and add the semantic class'
+  );
+
+  includes(
+    cta,
+    'target="_blank"',
+    expectation.path + ' must open the booking page in a new tab'
+  );
+
+  includes(
+    cta,
+    'rel="noopener noreferrer"',
+    expectation.path + ' must isolate the new tab'
+  );
+
+  includes(
+    cta,
+    'data-cta="video_call"',
+    expectation.path + ' must track the video-call channel'
   );
 
   includes(
@@ -135,38 +146,59 @@ for (const expectation of floatingEmailExpectations) {
 
   includes(
     cta,
-    'data-lead-intent="price_inquiry"',
-    expectation.path + ' must declare price intent'
+    'data-lead-intent="video_call_request"',
+    expectation.path + ' must declare booking intent'
   );
+
+  for (const attribute of [
+    'data-cta-location="floating"',
+    'data-profile="general"',
+    'data-status="not_applicable"',
+    'data-page-type="available-xolos"',
+    'data-lang="' + expectation.lang + '"',
+  ]) {
+    includes(cta, attribute, expectation.path + ' must keep ' + attribute);
+  }
 
   includes(
     cta,
-    expectation.visibleText,
-    expectation.path + ' must keep the price keyword'
+    'class="home-email-float__text">' + expectation.visibleText + '</span>',
+    expectation.path + ' must show the localized booking text'
   );
 
   includes(
     cta,
     'aria-label="' + expectation.accessibleText + '"',
-    expectation.path + ' must keep the localized aria-label'
+    expectation.path + ' must use the localized aria-label'
   );
 
   includes(
     cta,
     'title="' + expectation.accessibleText + '"',
-    expectation.path + ' must keep the localized title'
+    expectation.path + ' must use the localized title'
   );
 
-  assert.equal(
-    cta.includes('%25'),
-    false,
-    expectation.path + ' must not double encode the mailto'
+  notMatches(
+    cta,
+    /mailto:|data-cta="email"|data-lead-intent="price_inquiry"/i,
+    expectation.path + ' must not retain floating email behavior'
   );
 
   assert.equal(
     /(?:wa\.me|api\.whatsapp\.com|whatsapp:\/\/)/i.test(cta),
     false,
     expectation.path + ' must not keep floating WhatsApp'
+  );
+
+  includes(
+    html,
+    'href="https://wa.me/525518555993"',
+    expectation.path + ' must keep the non-floating WhatsApp CTA'
+  );
+
+  assert.ok(
+    /mailto:/i.test(html),
+    expectation.path + ' must keep internal email links'
   );
 
   assert.ok(

--- a/xolos-disponibles.html
+++ b/xolos-disponibles.html
@@ -943,12 +943,23 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
     </footer>
 
     <a
-      class="home-email-float cta-lead cta-email"
-      href="mailto:contacto@xolosarmy.xyz?subject=Precio%20y%20disponibilidad%20de%20un%20xoloitzcuintle&amp;body=Hola%2C%20me%20interesa%20conocer%20el%20precio%20y%20la%20disponibilidad%20de%20un%20xoloitzcuintle.%20Tambi%C3%A9n%20quisiera%20recibir%20orientaci%C3%B3n%20sobre%20tallas%2C%20documentaci%C3%B3n%20y%20proceso%20de%20entrega.%0A%0AMi%20ciudad%20o%20pa%C3%ADs%20es%3A"
-      data-gtm="email-floating"
-      data-cta="email" data-lead-type="generate_lead" data-lead-intent="price_inquiry" data-profile="general" data-page-type="available-xolos" data-lang="es" aria-label="Preguntar precio de un xoloitzcuintle por correo" title="Preguntar precio de un xoloitzcuintle por correo">
-      <span class="home-email-float__icon" aria-hidden="true">✉️</span>
-      <span class="home-email-float__text">Preguntar precio de un xoloitzcuintle</span>
+      href="https://calendar.app.google/1PXNvJM42iZ3JMHC8"
+      class="home-email-float video-call-float cta-lead"
+      target="_blank"
+      rel="noopener noreferrer"
+      data-cta="video_call"
+      data-lead-type="generate_lead"
+      data-lead-intent="video_call_request"
+      data-cta-location="floating"
+      data-profile="general"
+      data-status="not_applicable"
+      data-page-type="available-xolos"
+      data-lang="es"
+      aria-label="Agendar videollamada con Xolos Ramírez"
+      title="Agendar videollamada con Xolos Ramírez"
+    >
+      <span class="home-email-float__icon" aria-hidden="true">📹</span>
+      <span class="home-email-float__text">Agendar videollamada</span>
     </a>
 
     <script src="js/main.js" defer></script>


### PR DESCRIPTION
## Context

Replaces only the floating email CTA on the Spanish and English availability pages with a Google Calendar appointment-booking CTA. The link is presented as a way to **schedule a video call**, not as an open or permanent Google Meet room.

- Base `main` SHA: `98d0af550cb7b0238b112c6095b31a10b5a134f9`
- Commit SHA: `9487503ac2fc6cfc07662179ea763175fe6dace6`
- Branch: `agent/video-call-floating-cta`
- Commits ahead of `main`: 1

## Files changed

- `xolos-disponibles.html`
- `en/available-xolos.html`
- `js/main.js`
- `scripts/test-generate-lead-tracking.mjs`

## Summary

- Español: reemplaza el CTA flotante de correo por **“Agendar videollamada”** y abre la página de reservación de Google Calendar en una pestaña nueva.
- English: replaces the floating email CTA with **“Book a video call”** and opens the Google Calendar booking page in a new tab.
- Preserves the existing `home-email-float` visual class and adds `video-call-float`.
- Adds `video_call` support to `getLeadChannel()`.
- Updates the tracking tests to require the exact booking URL, localized accessibility labels, analytics attributes, preserved WhatsApp/profile data, and no floating `mailto:`.

## Final `generate_lead` payload

```text
event: generate_lead
lead_channel: video_call
cta_location: floating
lead_intent: video_call_request
profile: general
profile_status: not_applicable
page_type: available-xolos
lang: es | en
```

The click records an intent to schedule a video call; it does not record a confirmed appointment.

## Validation

- ✅ `npm run lint:html` — 167 HTML files scanned; 0 errors.
- ✅ `npm run test:generate-lead` — `generate_lead tracking checks passed`.
- ✅ `node --check scripts/test-generate-lead-tracking.mjs` — passed.
- ✅ `git diff --check` — passed.
- ✅ Runtime payload harness — verified the exact Spanish and English payloads, one event on activation, the existing 1500 ms deduplication window, and no URL, `href`, `value`, `currency`, or personal data in the payload.
- ✅ Calendar destination — the exact short URL redirects to a Google Calendar appointment schedule and returns HTTP 200.
- ✅ New-tab behavior — exact `target="_blank"` and `rel="noopener noreferrer"` verified.
- ✅ 390×844 responsive review — inherited fixed-position 3.5 rem control remains within the viewport without horizontal overflow; visible text is visually hidden on mobile while the localized accessible name remains available; keyboard focus behavior is preserved through the anchor and existing `:focus-visible` rule.
- ✅ Diff scope — exactly the four authorized files; one commit; branch is 1 commit ahead and 0 behind the base SHA.

## Preserved behavior and scope

- WhatsApp CTAs remain intact in both availability pages.
- Internal email links and every individual profile CTA remain intact.
- GTM `GTM-MGTMWN7T`, delegated `closest()` tracking, `dataLayer` delivery, and 1500 ms deduplication remain intact.
- Sitemap, canonical, `hreflang`, JSON-LD, SEO metadata, WalletConnect, XEC, prices, private conditions, profiles, availability, and xoloitzcuintle statuses remain unchanged.
- No CSS, form, homepage CTA, contact page, deployment, or merge changes are included.