### PR TITLE
Corregir visualización de fotografías de Xilonen

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -1,21 +1,12 @@
 @import url('./styles-base.css');
 
-/* Xilonen Ramirez: fotografías seleccionadas para su perfil en español e inglés. */
-.puppy-carousel[aria-label*="Xilonen"] .puppy-carousel__slide:nth-child(1),
-.puppy-carousel[aria-label*="Xilonen"] .puppy-carousel__slide:nth-child(2) {
-  background-position: center;
-  background-repeat: no-repeat;
-  background-size: cover;
+/* Xilonen Ramirez: reemplazo visual directo de las dos fotografías del carrusel. */
+.puppy-carousel__slide > img[src="https://i.imgur.com/QeNNg9H.jpeg"] {
+  content: url('../img/xolos/xilonen-ramirez-01.jpg');
+  opacity: 1;
 }
 
-.puppy-carousel[aria-label*="Xilonen"] .puppy-carousel__slide:nth-child(1) {
-  background-image: url('../img/xolos/xilonen-ramirez-01.jpg');
-}
-
-.puppy-carousel[aria-label*="Xilonen"] .puppy-carousel__slide:nth-child(2) {
-  background-image: url('../img/xolos/xilonen-ramirez-02.jpg');
-}
-
-.puppy-carousel[aria-label*="Xilonen"] .puppy-carousel__slide:nth-child(-n+2) > img {
-  opacity: 0;
+.puppy-carousel__slide > img[src="https://i.imgur.com/QN6BMnO.jpeg"] {
+  content: url('../img/xolos/xilonen-ramirez-02.jpg');
+  opacity: 1;
 }


### PR DESCRIPTION
## Problema

El PR #281 incorporó correctamente los dos archivos de imagen, pero intentó mostrarlos mediante selectores basados en el `aria-label` del carrusel. Esos selectores no coincidieron con la estructura real de las páginas, por lo que el navegador siguió mostrando las fotografías anteriores.

## Corrección

- Sustituye el selector dependiente del `aria-label` por selectores dirigidos a las dos rutas antiguas de imagen del perfil de Xilonen.
- Muestra directamente los archivos locales ya incorporados:
  - `img/xolos/xilonen-ramirez-01.jpg`
  - `img/xolos/xilonen-ramirez-02.jpg`
- Fuerza nuevamente la opacidad visible de ambas imágenes.
- Funciona en las versiones española e inglesa porque ambas comparten la misma hoja de estilos.

## Alcance

- Solo modifica `css/styles.css`.
- No afecta los carruseles ni fotografías de otros perfiles.
- Mantiene intactas las dos páginas HTML y el comportamiento del carrusel.