### PR TITLE
Restaurar correo global de contacto

### DIFF
--- a/js/main.js
+++ b/js/main.js
@@ -1,5 +1,5 @@
-const LEGACY_CONTACT_EMAIL = 'contacto@xolosarmy.xyz';
-const CURRENT_CONTACT_EMAIL = 'fernando@xolosramirez.com';
+const LEGACY_CONTACT_EMAIL = 'fernando@xolosramirez.com';
+const CURRENT_CONTACT_EMAIL = 'contacto@xolosarmy.xyz';
 
 function updateGlobalContactEmail() {
   document.querySelectorAll('a[href^="mailto:"]').forEach((link) => {


### PR DESCRIPTION
## Cambio

- Restaura el correo global de los enlaces `mailto:` de `fernando@xolosramirez.com` a `contacto@xolosarmy.xyz`.
- Mantiene intactos los asuntos y cuerpos prellenados de cada enlace.
- El cambio se aplica desde `js/main.js` a todos los enlaces de correo del sitio.

## Alcance

- Solo modifica `js/main.js`.
- No altera formularios, botones de WhatsApp, videollamada ni analítica.

## Commit

`3b8a3382026374f628631f5f55b8c22023b40cf4`