### PR TITLE
Remove Chimalma Ramírez from available xolos pages

### DIFF
--- a/en/available-xolos.html
+++ b/en/available-xolos.html
@@ -615,61 +615,7 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
         </article>
 
 
-  <article class="puppy-card" data-aos="fade-up" data-aos-duration="800" data-aos-delay="800">
-  <div class="puppy-card__image-wrapper">
-    <span class="puppy-card__status status-disponible">Reserved</span>
-    <div class="puppy-carousel" data-puppy-carousel role="region" aria-roledescription="carousel" aria-label="Chimalma Ramirez photo carousel">
-      <div class="puppy-carousel__track" tabindex="0">
-        <div class="puppy-carousel__slide">
-          <img
-          src="https://i.imgur.com/nC7DWHD.jpeg"
-          alt="Xoloitzcuintle Chimalma Ramirez 1"
-          class="puppy-card__image"
-          loading="lazy"
-
-        />
-        </div>
-        <div class="puppy-carousel__slide">
-          <img
-        src="https://i.imgur.com/ZPCGdKx.jpeg"
-        alt="Xoloitzcuintli Chimalma Ramirez 1"
-        class="puppy-card__image"
-        loading="lazy"
-
-      />
-        </div>
-        <div class="puppy-carousel__slide">
-          <img
-        src="https://i.imgur.com/qtUQqos.jpeg"
-        alt="Xoloitzcuintli Chimalma Ramirez 2"
-        class="puppy-card__image"
-        loading="lazy"
-
-      />
-        </div>
-      </div>
-      <button class="puppy-carousel__button puppy-carousel__button--previous" type="button" aria-label="Previous photo">&#8592;</button>
-      <button class="puppy-carousel__button puppy-carousel__button--next" type="button" aria-label="Next photo">&#8594;</button>
-      <div class="puppy-carousel__dots" aria-label="Select photo"></div>
-      <p class="puppy-carousel__live" aria-live="polite" aria-atomic="true"></p>
-    </div>
-  </div>
-  <div class="puppy-card__content">
-    <h3 class="puppy-card__name">Chimalma Ramirez</h3>
-    <ul class="puppy-card__details">
-      <li><strong>Age</strong> 1 month </li>
-      <li><strong>Gender</strong> Female</li>
-      <li><strong>Size</strong> Standard</li>
-      <li><strong>Color</strong> Red </li>
-    </ul>
-    <div class="puppy-video-container" style="margin: 1rem 0; border-radius: 8px; overflow: hidden; aspect-ratio: 16/9;">
-    <iframe width="100%" height="100%" src="https://www.youtube.com/embed/0qcQvELxVpU" title="Chimalma Ramirez" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen loading="lazy"></iframe>
-  </div>
-  <div class="puppy-card__actions">
-      <a href="mailto:contacto@xolosarmy.xyz?subject=Inquiry%20about%20a%20Xoloitzcuintle%20similar%20to%20Chimalma%20Ramirez%20[Ref:%20chimalma-en-reserved]&body=Hello%2C%0A%0AI%20saw%20Chimalma%20Ramirez's%20profile%20and%20understand%20this%20Xoloitzcuintle%20is%20currently%20reserved.%0A%0AI%20am%20interested%20in%20future%20litters%20or%20a%20Xoloitzcuintle%20with%20similar%20characteristics.%0A%0AI%20would%20like%20to%20receive%20information%20about%3A%0A%0A-%20future%20puppies%20or%20litters%3B%0A-%20size%2C%20sex%2C%20and%20temperament%3B%0A-%20documentation%20and%20care%3B%0A-%20price%20and%20process%20conditions%3B%0A-%20delivery%20options%20for%20our%20location.%0A%0ATo%20help%20you%20guide%20us%20better%2C%20here%20is%20some%20information%3A%0A%0ACity%20or%20country%3A%0ACharacteristics%20we%20are%20looking%20for%3A%0APrevious%20experience%20with%20dogs%3A%0AWhatsApp%20contact%20number%3A%0A%0AThank%20you." class="btn-small btn-primary-small cta-lead cta-email" data-cta="email" data-lead-type="generate_lead" data-profile="chimalma" data-page-type="available-xolos" data-lang="en" aria-label="Contact by email about Chimalma" data-status="reserved">Contact by Email</a>
-    </div>
-  </div>
-</article>
+  
 
       </div>
     </section>

--- a/xolos-disponibles.html
+++ b/xolos-disponibles.html
@@ -701,61 +701,7 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
   </article>
 
 
-            <article class="puppy-card" data-aos="fade-up" data-aos-duration="800" data-aos-delay="800">
-    <div class="puppy-card__image-wrapper">
-    <span class="puppy-card__status status-disponible">Reservada</span>
-
-      <span class="puppy-card__status" style="top: 40px; background-color: #ff4d4d; color: #fff;">por Esmeralda Padilla</span>
-    <div class="puppy-carousel" data-puppy-carousel role="region" aria-roledescription="carrusel" aria-label="Carrusel de fotos de Chimalma Ramirez">
-      <div class="puppy-carousel__track" tabindex="0">
-        <div class="puppy-carousel__slide">
-          <img
-          src="https://i.imgur.com/nC7DWHD.jpeg"
-          alt="Xoloitzcuintle Chimalma Ramirez 1 — fotografía 1"
-          class="puppy-card__image"
-          loading="lazy"
-
-        />
-        </div>
-        <div class="puppy-carousel__slide">
-          <img
-          src="https://i.imgur.com/ZPCGdKx.jpeg"
-          alt="Xoloitzcuintle Chimalma Ramirez 1 — fotografía 2"
-          class="puppy-card__image"
-          loading="lazy"
-
-        />
-        </div>
-        <div class="puppy-carousel__slide">
-          <img
-          src="https://i.imgur.com/qtUQqos.jpeg"
-          alt="Xoloitzcuintle Chimalma Ramirez 2 — fotografía 3"
-          class="puppy-card__image"
-          loading="lazy"
-
-        />
-        </div>
-      </div>
-      <button class="puppy-carousel__button puppy-carousel__button--previous" type="button" aria-label="Foto anterior">&#8592;</button>
-      <button class="puppy-carousel__button puppy-carousel__button--next" type="button" aria-label="Foto siguiente">&#8594;</button>
-      <div class="puppy-carousel__dots" aria-label="Seleccionar foto"></div>
-      <p class="puppy-carousel__live" aria-live="polite" aria-atomic="true"></p>
-    </div>
-  </div>
-    <div class="puppy-card__content">
-      <h3 class="puppy-card__name">Chimalma Ramirez</h3>
-      <ul class="puppy-card__details">
-        <li><strong>Edad</strong> 1 mes</li>
-        <li><strong>Color</strong> Bermejo con copete blanco</li>
-      </ul>
-      <div class="puppy-video-container" style="margin: 1rem 0; border-radius: 8px; overflow: hidden; aspect-ratio: 16/9;">
-    <iframe width="100%" height="100%" src="https://www.youtube.com/embed/0qcQvELxVpU" title="Chimalma Ramirez" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen loading="lazy"></iframe>
-  </div>
-  <div class="puppy-card__actions">
-    <a href="mailto:contacto@xolosarmy.xyz?subject=Consulta%20sobre%20ejemplar%20similar%20a%20Chimalma%20Ramirez%20[Ref:%20chimalma-es-reserved]&body=Hola%2C%0A%0AVi%20el%20perfil%20de%20Chimalma%20Ramirez%20y%20entiendo%20que%20actualmente%20est%C3%A1%20reservado.%0A%0AMe%20interesa%20conocer%20futuras%20camadas%20o%20alg%C3%BAn%20xoloitzcuintle%20con%20caracter%C3%ADsticas%20similares.%0A%0AQuisiera%20recibir%20informaci%C3%B3n%20sobre%3A%0A%0A-%20ejemplares%20o%20camadas%20futuras%3B%0A-%20talla%2C%20sexo%20y%20temperamento%3B%0A-%20documentaci%C3%B3n%20y%20cuidados%3B%0A-%20precio%20y%20condiciones%20del%20proceso%3B%0A-%20opciones%20de%20entrega%20para%20nuestra%20ubicaci%C3%B3n.%0A%0APara%20que%20puedan%20orientarme%20mejor%2C%20comparto%20estos%20datos%3A%0A%0ACiudad%20o%20pa%C3%ADs%3A%0ACaracter%C3%ADsticas%20que%20buscamos%3A%0AExperiencia%20previa%20con%20perros%3A%0AN%C3%BAmero%20de%20WhatsApp%20de%20contacto%3A%0A%0AGracias." class="btn-small btn-primary-small cta-lead cta-email" style="background-color: #25D366; border-color: #25D366; width: 100%; justify-content: center;" data-cta="email" data-lead-type="generate_lead" data-profile="chimalma" data-page-type="available-xolos" data-lang="es" aria-label="Escribir por correo sobre Chimalma" data-status="reserved">Correo directo ✉️</a>
-  </div>
-    </div>
-  </article>
+            
 
 
 


### PR DESCRIPTION
## Summary

- remove Chimalma Ramírez’s complete profile card from `xolos-disponibles.html`
- remove Chimalma Ramírez’s complete profile card from `en/available-xolos.html`
- leave all other profiles and page content unchanged

## Why

Chimalma was delivered to her family in Tijuana on August 8, 2026, so she should no longer appear on the available-xolos pages.

## Validation

- confirmed no Chimalma text, profile metadata, images, video, or CTA remains in either file
- confirmed `<article>` and `<div>` tags remain balanced in both pages
- confirmed the existing `puppy-grid` containers remain intact so the responsive grid reflows without an empty card slot
- confirmed the branch diff contains only the two requested HTML files