### PR TITLE
Add bilingual Xoloitzcuintli biocultural essay

### DIFF
--- a/blog/index.html
+++ b/blog/index.html
@@ -185,6 +185,19 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
    <section aria-label="Listado de artículos del blog" class="grid" data-aos="fade-up" data-aos-duration="1000">
 
     <article class="blog-card" data-aos="fade-up">
+     <div class="card-image">
+      <img src="../assets/images/blog/2025/12/01/xolos-criptos-y-cosmovision-nuestro-ultimo-weekly-update-con-ehecatl-ramirez/58ce8f376f.jpg" alt="Xoloitzcuintle adulto, archivo biocultural vivo de México" loading="lazy" width="768" height="1024">
+      <span class="category">Cultura y linaje</span>
+     </div>
+     <div class="card-content">
+      <span class="post-date">11 de agosto de 2026</span>
+      <h3>El Xoloitzcuintle: pirámide viviente y guardián de la memoria de México</h3>
+      <p>Un ensayo visual sobre arqueología, cosmovisión, biología, arte y la preservación documental del xoloitzcuintle.</p>
+      <a href="xoloitzcuintle-piramide-viviente-memoria-mexico.html" class="read-more">Leer ensayo &rarr;</a>
+     </div>
+    </article>
+
+    <article class="blog-card" data-aos="fade-up">
     <div class="card-image">
         <img src="https://img.youtube.com/vi/I0GRiJ_fNtw/hqdefault.jpg" alt="Entrega de Chimalma Ramírez a su familia en Tijuana" loading="lazy">
         <span class="category">Entrega Xoloitzcuintle a su familia</span>

--- a/blog/xoloitzcuintle-piramide-viviente-memoria-mexico.html
+++ b/blog/xoloitzcuintle-piramide-viviente-memoria-mexico.html
@@ -1,0 +1,276 @@
+<!DOCTYPE html>
+<html lang="es-MX">
+<head>
+  <!-- Google Tag Manager -->
+  <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
+  new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
+  j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
+  'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
+  })(window,document,'script','dataLayer','GTM-MGTMWN7T');</script>
+  <!-- End Google Tag Manager -->
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>El Xoloitzcuintle: pirámide viviente y guardián de la memoria de México | Xolos Ramírez</title>
+  <meta name="description" content="Ensayo visual sobre el xoloitzcuintle como patrimonio biocultural: arqueología, Xólotl, biología, arte, linaje y memoria digital verificable.">
+  <link rel="canonical" href="https://xolosramirez.com/blog/xoloitzcuintle-piramide-viviente-memoria-mexico.html">
+  <link rel="alternate" hreflang="es-MX" href="https://xolosramirez.com/blog/xoloitzcuintle-piramide-viviente-memoria-mexico.html">
+  <link rel="alternate" hreflang="en" href="https://xolosramirez.com/en/blog/xoloitzcuintli-living-pyramid-mexicos-memory.html">
+  <link rel="alternate" hreflang="x-default" href="https://xolosramirez.com/blog/xoloitzcuintle-piramide-viviente-memoria-mexico.html">
+  <meta property="og:type" content="article">
+  <meta property="og:locale" content="es_MX">
+  <meta property="og:site_name" content="Xolos Ramírez">
+  <meta property="og:title" content="El Xoloitzcuintle: pirámide viviente y guardián de la memoria de México">
+  <meta property="og:description" content="Un recorrido visual por la arqueología, cosmovisión, biología, arte y preservación contemporánea del xoloitzcuintle.">
+  <meta property="og:url" content="https://xolosramirez.com/blog/xoloitzcuintle-piramide-viviente-memoria-mexico.html">
+  <meta property="og:image" content="https://xolosramirez.com/assets/images/blog/2025/12/01/xolos-criptos-y-cosmovision-nuestro-ultimo-weekly-update-con-ehecatl-ramirez/58ce8f376f.jpg">
+  <meta property="article:published_time" content="2026-08-11">
+  <meta property="article:modified_time" content="2026-08-11">
+  <meta name="twitter:card" content="summary_large_image">
+  <meta name="twitter:title" content="El Xoloitzcuintle: pirámide viviente y guardián de la memoria de México">
+  <meta name="twitter:description" content="El xoloitzcuintle como archivo biocultural vivo y puente entre memoria ancestral, organismo, linaje y documentación digital.">
+  <meta name="twitter:image" content="https://xolosramirez.com/assets/images/blog/2025/12/01/xolos-criptos-y-cosmovision-nuestro-ultimo-weekly-update-con-ehecatl-ramirez/58ce8f376f.jpg">
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Cinzel:wght@400;700&amp;family=Poppins:wght@400;600;700&amp;display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="../css/styles.css">
+  <link rel="stylesheet" href="../css/biocultural-essay.css">
+  <link rel="icon" type="image/x-icon" href="../assets/xolosramirez.ico">
+  <script type="application/ld+json">
+  {
+    "@context": "https://schema.org",
+    "@graph": [
+      {
+        "@type": "Article",
+        "headline": "El Xoloitzcuintle: pirámide viviente y guardián de la memoria de México",
+        "description": "Ensayo visual sobre el xoloitzcuintle como patrimonio biocultural: arqueología, Xólotl, biología, arte, linaje y memoria digital verificable.",
+        "inLanguage": "es-MX",
+        "datePublished": "2026-08-11",
+        "dateModified": "2026-08-11",
+        "mainEntityOfPage": "https://xolosramirez.com/blog/xoloitzcuintle-piramide-viviente-memoria-mexico.html",
+        "author": { "@type": "Organization", "name": "Xolos Ramírez" },
+        "publisher": { "@type": "Organization", "name": "Xolos Ramírez" },
+        "image": "https://xolosramirez.com/assets/images/blog/2025/12/01/xolos-criptos-y-cosmovision-nuestro-ultimo-weekly-update-con-ehecatl-ramirez/58ce8f376f.jpg"
+      },
+      {
+        "@type": "BreadcrumbList",
+        "itemListElement": [
+          { "@type": "ListItem", "position": 1, "name": "Inicio", "item": "https://xolosramirez.com/" },
+          { "@type": "ListItem", "position": 2, "name": "Blog", "item": "https://xolosramirez.com/blog/index.html" },
+          { "@type": "ListItem", "position": 3, "name": "Pirámide viviente", "item": "https://xolosramirez.com/blog/xoloitzcuintle-piramide-viviente-memoria-mexico.html" }
+        ]
+      }
+    ]
+  }
+  </script>
+</head>
+<body>
+  <!-- Google Tag Manager (noscript) -->
+  <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-MGTMWN7T" height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
+  <!-- End Google Tag Manager (noscript) -->
+  <a class="skip-link" href="#contenido-principal">Saltar al contenido principal</a>
+
+  <header class="site-header">
+    <div class="container header-row">
+      <a class="brand" href="../index.html">
+        <img src="../img/brand/logo-xolos-ramirez.svg" alt="Xolos Ramírez" width="44" height="44">
+        <span>Xolos Ramírez</span>
+      </a>
+      <button class="hamburger" aria-expanded="false" aria-controls="menu">☰</button>
+      <nav id="menu" class="nav-menu" data-visible="false" aria-label="Navegación principal">
+        <ul>
+          <li><a href="../index.html">Inicio</a></li>
+          <li><a href="../xolos-disponibles.html">Xolos disponibles</a></li>
+          <li><a href="../testimonios.html">Testimonios</a></li>
+          <li><a href="index.html">Blog</a></li>
+          <li><a href="../contacto.html">Contacto</a></li>
+          <li><a href="../en/blog/xoloitzcuintli-living-pyramid-mexicos-memory.html" lang="en">English</a></li>
+        </ul>
+      </nav>
+    </div>
+  </header>
+
+  <main id="contenido-principal">
+    <header class="essay-hero">
+      <img class="essay-hero__image" src="../assets/images/blog/2025/12/01/xolos-criptos-y-cosmovision-nuestro-ultimo-weekly-update-con-ehecatl-ramirez/58ce8f376f.jpg" alt="Xoloitzcuintle adulto recostado, una presencia viva de la raza mexicana" width="768" height="1024">
+      <div class="essay-hero__veil" aria-hidden="true"></div>
+      <div class="essay-hero__content">
+        <p class="essay-kicker">Ensayo-reportaje · Patrimonio biocultural</p>
+        <h1>El Xoloitzcuintle: pirámide viviente y guardián de la memoria de México</h1>
+        <p class="essay-deck">Antes que símbolo, documento o registro, el xoloitzcuintle es un animal real. En su cuerpo convergen una historia biológica, una presencia arqueológica y una memoria cultural que México sigue reinterpretando.</p>
+      </div>
+    </header>
+
+    <div class="essay-shell">
+      <div class="essay-meta">
+        <time datetime="2026-08-11">11 de agosto de 2026</time>
+        <span>Redacción Xolos Ramírez</span>
+        <span>Lectura aproximada: 14 minutos</span>
+      </div>
+      <div class="essay-tools">
+        <a href="index.html">← Volver al blog</a>
+        <a href="../en/blog/xoloitzcuintli-living-pyramid-mexicos-memory.html" lang="en">Read the international edition in English</a>
+      </div>
+
+      <div class="essay-grid">
+        <article class="essay-body">
+          <p>Un xoloitzcuintle no es una pieza de museo, aunque su silueta aparezca en objetos arqueológicos. Tampoco es una metáfora que haya aprendido a respirar. Es un perro: nace, crece, aprende, se relaciona, necesita cuidados y desarrolla una personalidad propia. Precisamente por eso puede entenderse como un <strong>archivo biocultural vivo</strong>. Su existencia conecta procesos biológicos con prácticas humanas, relatos de la cosmovisión mesoamericana con escenas de la vida cotidiana, y la historia del arte con las familias que hoy comparten su hogar con él.</p>
+
+          <p>La tesis de este ensayo parte de esa materialidad. La historia no está colocada encima del xolo como un disfraz: se conserva y cambia alrededor de organismos vivos, generación tras generación. Desde Xolos Ramírez proponemos una lectura contemporánea de esa continuidad mediante crianza documentada, identificación física y memoria digital. La tecnología puede ayudar a ordenar y verificar información, pero nunca sustituye al animal, su linaje biológico, el pedigree ni los documentos veterinarios y canófilos.</p>
+
+          <blockquote class="essay-quote">
+            “Cada Xoloitzcuintle es una pirámide viviente.”
+            <cite>Concepto editorial contemporáneo de Xolos Ramírez</cite>
+          </blockquote>
+
+          <p>La frase no pretende atribuir a los pueblos prehispánicos una categoría que no utilizaron. Es una metáfora desarrollada por Xolos Ramírez: así como una construcción conserva capas de tiempo, cada xolo reúne una genealogía corporal, una historia de convivencia y una memoria que continúa mientras vive y deja descendencia.</p>
+
+          <h2 id="presencia">Una presencia biocultural, no una reliquia inmóvil</h2>
+
+          <p>El Museo Nacional de Antropología ha presentado al xolo y a otros perros originarios de México como parte del <strong>patrimonio biocultural</strong>: seres vinculados a la domesticación, a la dispersión de los perros por América, a prácticas sociales y a formas de comprender la vida y la muerte. Esa mirada evita dos extremos. El xolo no es solamente una raza canina separada de la historia humana, pero tampoco puede reducirse a una leyenda.</p>
+
+          <p>La evidencia se construye con objetos, restos óseos, imágenes, documentos y estudios. Las interpretaciones culturales se apoyan en esas huellas, aunque no todas poseen el mismo grado de certeza. Cuando hablamos de un acompañante del Mictlán entramos en el territorio de las fuentes históricas, la arqueología y la tradición religiosa; cuando hablamos de dentición o herencia, entramos en el de la biología. Ambos planos dialogan, pero no deben confundirse.</p>
+
+          <figure class="essay-figure">
+            <img src="../assets/images/blog/2025/11/26/el-secreto-del-calor-del-xoloitzcuintle-tonalli-y-medicina-ancestral/3d0cba22d4.jpg" alt="Fernando Ramírez sostiene a un cachorro xoloitzcuintle durante una conversación para la comunidad" width="455" height="455" loading="lazy">
+            <figcaption>El patrimonio biocultural también se mantiene en escenas contemporáneas: cuidado, observación, conversación y convivencia con un animal vivo. Archivo Xolos Ramírez.</figcaption>
+          </figure>
+
+          <h2 id="xolotl-mictlan">Xólotl, los perros y el tránsito hacia el Mictlán</h2>
+
+          <p>En distintas tradiciones mesoamericanas, los perros participaron en imaginarios sobre la muerte y el tránsito al inframundo. El INAH resume fuentes históricas en las que el perro ayuda al difunto durante el viaje al Mictlán y al cruzar un río. El Museo Nacional de Antropología conserva, además, representaciones del dios <strong>Xólotl</strong>, asociado con el inframundo y presentado en las fuentes como gemelo de Quetzalcóatl.</p>
+
+          <p>Hablar de este viaje exige precisión. No se trata de afirmar que un animal haya cruzado físicamente un mundo sobrenatural, sino de reconocer una concepción religiosa documentada y su poder simbólico. Tampoco conviene usar <em>tonalli</em> como traducción directa de “alma”. En el pensamiento nahua, el término participa en una concepción más compleja de la vitalidad, el calor, el destino y la identidad calendárica; reducirlo a una sola categoría occidental borra esa complejidad.</p>
+
+          <p>La relación con Xólotl y el Mictlán sigue siendo una de las puertas de entrada más poderosas a la <a href="xoloitzcuintle-en-el-mictlan.html">dimensión cultural del xoloitzcuintle</a>. Su fuerza no depende de presentarla como prueba sobrenatural. Al contrario: crece cuando distinguimos con claridad la tradición, la evidencia arqueológica y nuestra lectura actual.</p>
+
+          <h2 id="arqueologia">Arqueología de una convivencia</h2>
+
+          <p>Figurillas, vasijas, esculturas y restos óseos permiten rastrear la presencia de perros mexicanos en contextos ceremoniales y cotidianos. La exposición <em>Xolos, compañeros de viaje</em> reunió materiales de tradiciones del Occidente de México, así como piezas mexicas y mayas. El conjunto revela que el perro no ocupó un único lugar: acompañó a las personas en vida, apareció en contextos funerarios, participó en economías y rituales, y quedó convertido en imagen.</p>
+
+          <p>La UNAM propone una antigüedad claramente documentada de alrededor de dos mil años para el perro sin pelo en México, a partir de materiales arqueológicos y del trabajo arqueozoológico. Existen narrativas que le atribuyen una antigüedad mucho mayor, pero no conviene presentar una cifra de siete mil años como si fuera indiscutible. La formulación prudente no empobrece la historia: dos mil años de presencia documentada ya describen una continuidad extraordinaria.</p>
+
+          <div class="essay-note">
+            <strong>Cómo leer las fechas.</strong> “Presencia documentada” no significa que el primer xolo naciera exactamente hace dos mil años. Significa que las evidencias disponibles permiten sostener con claridad su existencia para ese periodo. Hallazgos futuros pueden ampliar o matizar esa cronología.
+          </div>
+
+          <h2 id="biologia">La biología del perro sin pelo</h2>
+
+          <p>La apariencia del xolo sin pelo tiene una base heredable. La investigación sobre perros sin pelo relaciona una variante del gen <strong>FOXI3</strong> con una forma de displasia ectodérmica canina que afecta el desarrollo del pelo y también la dentición. Esto ayuda a explicar por qué la variedad sin pelo puede presentar ausencia o forma distinta de algunas piezas dentales. No es un defecto narrativo que deba ocultarse ni una señal mística: es parte de su biología.</p>
+
+          <p>La piel expuesta requiere cuidados acordes con el clima, la actividad y cada ejemplar. No necesita explicarse mediante mitos fisiológicos. El xolo se siente más caliente al tacto porque no existe una capa de pelo que separe nuestra mano de su piel; no porque posea una temperatura corporal extraordinaria. Tampoco es correcto atribuir su termorregulación a una supuesta sudoración por el abdomen. Como ocurre con otros perros, la regulación térmica depende principalmente de mecanismos caninos normales, incluido el jadeo, y de su relación con el ambiente.</p>
+
+          <p>Las fuentes tradicionales mencionan usos terapéuticos y la sensación de calor del perro junto al cuerpo humano. Esos relatos forman parte de la historia cultural, pero no equivalen a evidencia clínica de que el xolo cure enfermedades. La mejor manera de honrar el conocimiento tradicional es describirlo como tal, sin transformarlo en una promesa médica.</p>
+
+          <p>La genética tampoco dicta por sí sola el carácter. No todos los xolos responden igual ante desconocidos, otros animales o nuevos espacios. Edad, salud, socialización, aprendizaje y experiencias influyen en cada individuo. Por eso, cualquier explicación responsable debe volver siempre al perro concreto.</p>
+
+          <h2 id="supervivencia">Supervivencia, rescate y reconocimiento moderno</h2>
+
+          <p>El recorrido histórico del xolo no fue una línea continua de prestigio. El Museo Nacional de Antropología describe una casi extinción durante el periodo virreinal y un resurgimiento posterior. En el siglo XX, el nacionalismo cultural, el muralismo y artistas de la Escuela de Pintura Mexicana recuperaron su figura como emblema de una identidad que buscaba dialogar con el pasado indígena.</p>
+
+          <p>Ese rescate cultural coincidió con procesos de reconocimiento canófilo. La Fédération Cynologique Internationale identifica a México como país de origen de la raza, registra su aceptación definitiva en 1961 y reconoce las variedades de talla miniatura, intermedia y estándar. El estándar moderno no es una supervivencia intacta de una norma prehispánica: es una herramienta canófila contemporánea para describir y conservar características de la raza.</p>
+
+          <p>Del mismo modo, la presencia del xolo en la obra y el entorno de artistas como <a href="xoloitzcuinlte-frida-kahlo.html">Frida Kahlo</a> pertenece a la historia moderna de su transformación en símbolo nacional. El xolo que vemos hoy reúne, por tanto, varias capas: continuidad biológica, rescate organizado, cultura visual e intimidad doméstica.</p>
+
+          <h2 id="piramide">La pirámide viviente: una idea de Xolos Ramírez</h2>
+
+          <p>Cuando Xolos Ramírez llama a cada ejemplar una “pirámide viviente”, no afirma que los antiguos nahuas usaran esa expresión. La propone como una imagen de trabajo para el presente. Una pirámide conserva estratos, exige cuidado y orienta la mirada hacia una duración que excede a una sola persona. El xolo hace algo semejante, pero desde la vida: transmite genes, porta rasgos visibles, crea vínculos y acumula una historia familiar.</p>
+
+          <p>De esa metáfora nacen otros conceptos contemporáneos del proyecto: <strong>Archivo del Linaje Vivo</strong>, <strong>xolosArmy Network</strong> y <strong>Civilización Tonalli</strong>. Son nombres actuales para una propuesta comunitaria y tecnológica de preservación; no categorías arqueológicas ni instituciones heredadas del México prehispánico. Su legitimidad no depende de fingir antigüedad, sino de explicar con transparencia qué hacen hoy.</p>
+
+          <p>En esta lectura, preservar no significa congelar. Significa criar con responsabilidad, documentar sin exagerar, cuidar la diversidad de los linajes y entregar a cada familia herramientas para comprender la procedencia y la historia de su xolo.</p>
+
+          <h2 id="linaje">Del organismo al registro: el orden de la memoria</h2>
+
+          <p>Una genealogía confiable comienza en el mundo físico. El registro digital solo tiene sentido cuando se conecta con una cadena de información previa y verificable. Para Xolos Ramírez, el orden conceptual es el siguiente:</p>
+
+          <ol class="memory-chain" aria-label="Capas de identidad y memoria del xoloitzcuintle">
+            <li><strong>Animal real.</strong> Un individuo vivo con necesidades, salud, conducta y desarrollo propios.</li>
+            <li><strong>Linaje biológico.</strong> La relación genealógica con sus padres y las generaciones que lo preceden.</li>
+            <li><strong>Identificación física.</strong> El microchip vincula un número único con el ejemplar que puede ser leído presencialmente.</li>
+            <li><strong>Documentación canófila y veterinaria.</strong> Pedigree, registro, vacunas, certificados y expediente respaldan aspectos distintos de identidad, genealogía y salud.</li>
+            <li><strong>Registro digital complementario.</strong> El NFT de Linaje relaciona referencias y archivos para facilitar su consulta y trazabilidad.</li>
+          </ol>
+
+          <figure class="essay-figure essay-figure--portrait">
+            <img src="../assets/images/blog/2025/12/18/xolos-ramirez-registra-nuevos-xoloitzcuintles-ante-la-federacion-canofila-mexicana/f569f20325.jpg" alt="Una cachorra xoloitzcuintle durante una jornada de registro ante la Federación Canófila Mexicana" width="1600" height="1600" loading="lazy">
+            <figcaption>La identidad documentada comienza con el ejemplar y su identificación física; el registro canófilo y el expediente veterinario cumplen funciones que una capa digital no reemplaza. Archivo Xolos Ramírez.</figcaption>
+          </figure>
+
+          <p>El pedigree documenta una genealogía dentro del sistema canófilo correspondiente. El microchip ayuda a identificar físicamente al ejemplar. Los documentos veterinarios registran procedimientos y condiciones de salud en momentos concretos. Ninguno de estos elementos debe confundirse con los demás. Su fuerza aparece cuando se relacionan sin borrar sus límites.</p>
+
+          <h2 id="nft">NFT de Linaje: memoria adicional, no sustitución</h2>
+
+          <p>El <a href="nft-linaje-xoloitzcuintle.html">NFT de Linaje Xoloitzcuintle</a> de Xolos Ramírez se concibe como una ficha digital única que puede reunir identidad, microchip, genealogía documentada, fotografías y referencias a otros archivos. El registro en la red eCash permite verificar que una emisión ocurrió, asociarla con una fecha y una dirección, y seguir transferencias entre wallets.</p>
+
+          <p>Los archivos relacionados pueden usar IPFS. Allí, un identificador de contenido o <strong>CID</strong> se deriva criptográficamente del contenido: si el archivo cambia, cambia también su referencia. Esto permite comprobar integridad, pero no garantiza disponibilidad eterna. Para que un archivo siga accesible deben mantenerse copias o servicios de <em>pinning</em>. Por eso hablamos de memoria verificable y resistente a modificaciones, no de “permanencia” automática.</p>
+
+          <div class="essay-note">
+            <p><strong>Lo que esta capa digital no demuestra por sí sola:</strong> pureza genética, validez de un pedigree, estado de salud actual ni propiedad legal absoluta del perro.</p>
+            <p>El NFT tampoco se presenta como activo especulativo. Su valor dentro de este modelo está en conectar referencias y facilitar la trazabilidad de una historia documental.</p>
+          </div>
+
+          <p>La <a href="preservacion-linaje-xoloitzcuintle-xolosarmy.html">preservación del linaje en xolosArmy</a> parte, entonces, de una regla sencilla: la cadena digital debe apuntar hacia evidencia que exista fuera de ella. Una transacción puede demostrar la integridad y procedencia del registro digital; la certeza de los datos biológicos depende del ejemplar, de su identificación y de las instituciones y profesionales que producen los documentos.</p>
+
+          <h2 id="memoria-digital">Una comunidad para continuar la memoria</h2>
+
+          <p>El Archivo del Linaje Vivo imagina una memoria que no termina en el día de la entrega. Las familias pueden seguir produciendo fotografías, relatos, encuentros y momentos significativos. En la visión de <a href="civilizacion-tonalli.html">Civilización Tonalli</a>, esa continuidad puede convertirse en un archivo comunitario donde la historia de cada xolo crece sin dejar de distinguir entre recuerdo familiar, documento oficial y registro técnico.</p>
+
+          <p>Esta propuesta no reconstruye una institución prehispánica. Es una respuesta contemporánea a un problema contemporáneo: los expedientes se dispersan, las fotografías se pierden, las plataformas desaparecen y las genealogías familiares pueden romperse. La combinación de custodia responsable, archivos replicados y referencias verificables ofrece una manera de cuidar mejor esa memoria, siempre que la infraestructura se mantenga y que las afirmaciones sigan siendo auditables.</p>
+
+          <h2 id="puente">El guardián vuelve a ser puente</h2>
+
+          <p>En la tradición mesoamericana, el perro fue representado como acompañante en el tránsito entre mundos. En la lectura contemporánea de Xolos Ramírez, el puente cambia de escala: une <strong>memoria ancestral → organismo vivo → generaciones futuras → documentación digital</strong>.</p>
+
+          <p>La metáfora funciona porque conserva una diferencia esencial. El relato del Mictlán pertenece a una tradición religiosa e histórica; el microchip, el pedigree, el CID y la blockchain pertenecen a sistemas modernos de identificación y verificación. No son equivalentes. Se encuentran únicamente en nuestra forma actual de narrar y proteger una continuidad.</p>
+
+          <p>El xoloitzcuintle es el centro porque está vivo. Antes de cualquier símbolo está su cuerpo; antes de cualquier token, su genealogía; antes de cualquier archivo, la relación concreta entre un animal y las personas que lo cuidan. Si la memoria digital sirve para algo, es para volver visible esa cadena de responsabilidades, no para reemplazarla.</p>
+
+          <section class="essay-sources" aria-labelledby="fuentes">
+            <h2 id="fuentes">Fuentes consultadas</h2>
+            <ol>
+              <li><a href="https://inah.gob.mx/foto-del-dia/xoloitzcuintle-companero-en-el-viaje-al-mictlan" target="_blank" rel="noopener noreferrer">INAH: “Xoloitzcuintle: compañero en el viaje al Mictlán”</a>.</li>
+              <li><a href="https://mna.inah.gob.mx/deviaje.php?pl=Xolos_Companeros_de_viaje_1" target="_blank" rel="noopener noreferrer">Museo Nacional de Antropología: “Xolos, compañeros de viaje”</a>.</li>
+              <li><a href="https://www.gaceta.unam.mx/el-xoloitzcuintle-un-sobreviviente-de-dos-mil-anos-de-edad/" target="_blank" rel="noopener noreferrer">Gaceta UNAM: “El xoloitzcuintle: un sobreviviente de dos mil años de edad”</a>.</li>
+              <li><a href="https://www.nature.com/articles/s41598-017-05764-5" target="_blank" rel="noopener noreferrer">Kupczik et al. (2017): “The dental phenotype of hairless dogs with FOXI3 haploinsufficiency”, Scientific Reports</a>.</li>
+              <li><a href="https://www.fci.be/EN/nomenclature/XOLOITZCUINTLE-234.html" target="_blank" rel="noopener noreferrer">Fédération Cynologique Internationale: Xoloitzcuintle (234)</a>.</li>
+              <li><a href="https://docs.ipfs.tech/concepts/content-addressing/" target="_blank" rel="noopener noreferrer">IPFS Docs: Content Identifiers (CIDs)</a> y <a href="https://docs.ipfs.tech/how-to/best-practices-for-nft-data/" target="_blank" rel="noopener noreferrer">buenas prácticas para datos NFT</a>.</li>
+              <li><a href="nft-linaje-xoloitzcuintle.html">Xolos Ramírez: NFT de Linaje Xoloitzcuintle</a>, documento conceptual sobre identidad, genealogía y memoria digital.</li>
+            </ol>
+          </section>
+
+          <section class="essay-cta" aria-labelledby="continuar">
+            <h2 id="continuar">Continuar el recorrido</h2>
+            <p>Explora la historia de la raza o conoce cómo Xolos Ramírez documenta a sus ejemplares y acompaña a sus familias.</p>
+            <div class="essay-cta__links">
+              <a class="essay-button" href="historia-xoloitzcuintle.html">Historia del xoloitzcuintle</a>
+              <a class="essay-button essay-button--secondary" href="../xolos-disponibles.html">Conocer Xolos disponibles</a>
+            </div>
+          </section>
+        </article>
+
+        <aside class="essay-toc" aria-label="Contenido del ensayo">
+          <h2>En este ensayo</h2>
+          <ol>
+            <li><a href="#presencia">Presencia biocultural</a></li>
+            <li><a href="#xolotl-mictlan">Xólotl y Mictlán</a></li>
+            <li><a href="#arqueologia">Arqueología</a></li>
+            <li><a href="#biologia">Biología sin mitos</a></li>
+            <li><a href="#supervivencia">Rescate moderno</a></li>
+            <li><a href="#piramide">Pirámide viviente</a></li>
+            <li><a href="#linaje">Orden de la memoria</a></li>
+            <li><a href="#nft">NFT de Linaje</a></li>
+            <li><a href="#puente">El puente</a></li>
+          </ol>
+        </aside>
+      </div>
+    </div>
+  </main>
+
+  <footer class="site-footer">
+    <div class="container">
+      <p>© 2026 Xolos Ramírez. Crianza documentada, memoria viva.</p>
+    </div>
+  </footer>
+  <script src="../js/main.js" defer></script>
+</body>
+</html>

--- a/css/biocultural-essay.css
+++ b/css/biocultural-essay.css
@@ -1,0 +1,427 @@
+:root {
+  --essay-ink: #211c18;
+  --essay-muted: #6b625a;
+  --essay-paper: #fffdf9;
+  --essay-sand: #f3eadf;
+  --essay-clay: #9a4f2e;
+  --essay-clay-dark: #65321f;
+  --essay-line: #dfd2c4;
+}
+
+html {
+  scroll-behavior: smooth;
+}
+
+body {
+  background: #f8f4ee;
+  color: var(--essay-ink);
+}
+
+.essay-hero {
+  position: relative;
+  min-height: min(76vh, 760px);
+  display: grid;
+  align-items: end;
+  overflow: hidden;
+  background: #241b16;
+  color: #fff;
+}
+
+.essay-hero__image,
+.essay-hero__veil {
+  position: absolute;
+  inset: 0;
+}
+
+.essay-hero__image {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+  object-position: center 42%;
+}
+
+.essay-hero__veil {
+  background: linear-gradient(180deg, rgba(22, 15, 11, 0.12) 8%, rgba(22, 15, 11, 0.55) 54%, rgba(22, 15, 11, 0.94) 100%);
+}
+
+.essay-hero__content {
+  position: relative;
+  z-index: 1;
+  width: min(1120px, calc(100% - 2rem));
+  margin: 0 auto;
+  padding: clamp(5rem, 14vw, 9rem) 0 clamp(2.5rem, 7vw, 5rem);
+}
+
+.essay-kicker {
+  margin: 0 0 0.8rem;
+  color: #f1c9a9;
+  font-size: 0.82rem;
+  font-weight: 700;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+}
+
+.essay-hero h1 {
+  max-width: 980px;
+  margin: 0;
+  color: #fff;
+  font-family: Cinzel, Georgia, serif;
+  font-size: clamp(2.15rem, 6.1vw, 4.8rem);
+  line-height: 1.04;
+  text-wrap: balance;
+}
+
+.essay-deck {
+  max-width: 780px;
+  margin: 1.25rem 0 0;
+  color: rgba(255, 255, 255, 0.9);
+  font-size: clamp(1.05rem, 2.1vw, 1.32rem);
+  line-height: 1.6;
+}
+
+.essay-shell {
+  width: min(1120px, calc(100% - 2rem));
+  margin: 0 auto;
+  padding: 2rem 0 5rem;
+}
+
+.essay-meta {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.55rem 1.25rem;
+  padding: 1rem 0 1.6rem;
+  border-bottom: 1px solid var(--essay-line);
+  color: var(--essay-muted);
+  font-size: 0.93rem;
+}
+
+.essay-tools {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: space-between;
+  gap: 0.75rem 1.5rem;
+  padding: 1rem 0 0;
+  font-size: 0.93rem;
+}
+
+.essay-tools a,
+.essay-body a,
+.essay-sources a {
+  color: var(--essay-clay-dark);
+  font-weight: 600;
+  text-decoration-thickness: 0.08em;
+  text-underline-offset: 0.18em;
+}
+
+.essay-grid {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) 260px;
+  gap: clamp(2rem, 5vw, 4.5rem);
+  align-items: start;
+  margin-top: 2.5rem;
+}
+
+.essay-body {
+  min-width: 0;
+  max-width: 760px;
+  font-family: Georgia, "Times New Roman", serif;
+  font-size: clamp(1.08rem, 1.6vw, 1.19rem);
+  line-height: 1.82;
+}
+
+.essay-body > p:first-child::first-letter {
+  float: left;
+  margin: 0.12em 0.1em 0 0;
+  color: var(--essay-clay);
+  font-family: Cinzel, Georgia, serif;
+  font-size: 4.15rem;
+  font-weight: 700;
+  line-height: 0.78;
+}
+
+.essay-body h2 {
+  margin: 3.3rem 0 1rem;
+  color: var(--essay-clay-dark);
+  font-family: Cinzel, Georgia, serif;
+  font-size: clamp(1.65rem, 3.2vw, 2.35rem);
+  line-height: 1.2;
+  text-wrap: balance;
+}
+
+.essay-body h3 {
+  margin: 2rem 0 0.7rem;
+  color: var(--essay-ink);
+  font-family: Poppins, Arial, sans-serif;
+  font-size: 1.13rem;
+  line-height: 1.35;
+}
+
+.essay-body p,
+.essay-body li {
+  color: #3f3934;
+}
+
+.essay-body p {
+  margin: 0 0 1.4rem;
+}
+
+.essay-body strong {
+  color: var(--essay-ink);
+}
+
+.essay-toc {
+  position: sticky;
+  top: 5.5rem;
+  padding: 1.25rem;
+  border: 1px solid var(--essay-line);
+  border-radius: 14px;
+  background: rgba(255, 253, 249, 0.92);
+  box-shadow: 0 12px 30px rgba(52, 38, 28, 0.06);
+}
+
+.essay-toc h2 {
+  margin: 0 0 0.8rem;
+  font-family: Poppins, Arial, sans-serif;
+  font-size: 0.88rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.essay-toc ol {
+  margin: 0;
+  padding-left: 1.15rem;
+}
+
+.essay-toc li + li {
+  margin-top: 0.55rem;
+}
+
+.essay-toc a {
+  color: #51473f;
+  font-size: 0.9rem;
+  line-height: 1.35;
+  text-decoration: none;
+}
+
+.essay-toc a:hover,
+.essay-toc a:focus-visible {
+  color: var(--essay-clay);
+  text-decoration: underline;
+}
+
+.essay-figure {
+  margin: 2.5rem 0;
+}
+
+.essay-figure img {
+  display: block;
+  width: 100%;
+  max-height: 580px;
+  object-fit: cover;
+  border-radius: 14px;
+  box-shadow: 0 14px 34px rgba(50, 34, 24, 0.12);
+}
+
+.essay-figure--portrait img {
+  max-width: 520px;
+  margin: 0 auto;
+  aspect-ratio: 3 / 4;
+  object-position: center;
+}
+
+.essay-figure figcaption {
+  margin-top: 0.75rem;
+  color: var(--essay-muted);
+  font-family: Poppins, Arial, sans-serif;
+  font-size: 0.82rem;
+  line-height: 1.55;
+}
+
+.essay-quote {
+  margin: 2.7rem 0;
+  padding: 1.7rem clamp(1.3rem, 4vw, 2.4rem);
+  border-left: 5px solid var(--essay-clay);
+  background: var(--essay-sand);
+  color: var(--essay-clay-dark);
+  font-family: Cinzel, Georgia, serif;
+  font-size: clamp(1.25rem, 2.7vw, 1.75rem);
+  line-height: 1.48;
+}
+
+.essay-quote cite {
+  display: block;
+  margin-top: 0.8rem;
+  color: var(--essay-muted);
+  font-family: Poppins, Arial, sans-serif;
+  font-size: 0.78rem;
+  font-style: normal;
+  letter-spacing: 0.04em;
+}
+
+.essay-note {
+  margin: 2rem 0;
+  padding: 1.25rem 1.35rem;
+  border: 1px solid var(--essay-line);
+  border-radius: 12px;
+  background: var(--essay-paper);
+  font-family: Poppins, Arial, sans-serif;
+  font-size: 0.94rem;
+  line-height: 1.65;
+}
+
+.essay-note p:last-child {
+  margin-bottom: 0;
+}
+
+.memory-chain {
+  display: grid;
+  gap: 0.75rem;
+  margin: 2rem 0 2.4rem;
+  padding: 0;
+  list-style: none;
+  counter-reset: memory-step;
+}
+
+.memory-chain li {
+  position: relative;
+  padding: 1rem 1rem 1rem 3.55rem;
+  border: 1px solid var(--essay-line);
+  border-radius: 12px;
+  background: var(--essay-paper);
+  font-family: Poppins, Arial, sans-serif;
+  font-size: 0.95rem;
+  line-height: 1.55;
+  counter-increment: memory-step;
+}
+
+.memory-chain li::before {
+  content: counter(memory-step);
+  position: absolute;
+  top: 0.9rem;
+  left: 1rem;
+  display: grid;
+  place-items: center;
+  width: 1.8rem;
+  height: 1.8rem;
+  border-radius: 50%;
+  background: var(--essay-clay);
+  color: #fff;
+  font-weight: 700;
+}
+
+.essay-sources {
+  margin-top: 4rem;
+  padding: 2rem;
+  border-radius: 16px;
+  background: #271d17;
+  color: #f7efe7;
+  font-family: Poppins, Arial, sans-serif;
+}
+
+.essay-sources h2 {
+  margin: 0 0 1rem;
+  color: #fff;
+  font-family: Cinzel, Georgia, serif;
+  font-size: 1.5rem;
+}
+
+.essay-sources ol {
+  margin: 0;
+  padding-left: 1.25rem;
+}
+
+.essay-sources li {
+  color: #e7d8cb;
+  font-size: 0.88rem;
+  line-height: 1.55;
+}
+
+.essay-sources li + li {
+  margin-top: 0.7rem;
+}
+
+.essay-sources a {
+  color: #ffd1ad;
+}
+
+.essay-cta {
+  margin-top: 2.5rem;
+  padding: 1.8rem;
+  border: 1px solid var(--essay-line);
+  border-radius: 16px;
+  background: var(--essay-sand);
+  text-align: center;
+}
+
+.essay-cta h2 {
+  margin-top: 0;
+}
+
+.essay-cta__links {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: center;
+  gap: 0.75rem;
+}
+
+.essay-button {
+  display: inline-block;
+  padding: 0.75rem 1.05rem;
+  border-radius: 999px;
+  background: var(--essay-clay-dark);
+  color: #fff !important;
+  font-family: Poppins, Arial, sans-serif;
+  font-size: 0.9rem;
+  text-decoration: none;
+}
+
+.essay-button--secondary {
+  border: 1px solid var(--essay-clay-dark);
+  background: transparent;
+  color: var(--essay-clay-dark) !important;
+}
+
+@media (max-width: 860px) {
+  .essay-grid {
+    grid-template-columns: minmax(0, 1fr);
+  }
+
+  .essay-toc {
+    position: static;
+    order: -1;
+  }
+}
+
+@media (max-width: 600px) {
+  .essay-hero {
+    min-height: 650px;
+  }
+
+  .essay-hero__image {
+    object-position: 43% center;
+  }
+
+  .essay-shell {
+    width: min(100% - 1.25rem, 1120px);
+    padding-bottom: 3.5rem;
+  }
+
+  .essay-body {
+    font-size: 1.05rem;
+    line-height: 1.74;
+  }
+
+  .essay-body h2 {
+    scroll-margin-top: 5.5rem;
+  }
+
+  .essay-quote,
+  .essay-sources,
+  .essay-cta {
+    padding: 1.25rem;
+  }
+
+  .essay-figure img {
+    max-height: 460px;
+  }
+}

--- a/en/blog/index.html
+++ b/en/blog/index.html
@@ -46,42 +46,48 @@
       },
       {
         "@type": "ItemList",
-        "name": "Xoloitzcuintli care and family guides",
-        "numberOfItems": 6,
+        "name": "Xoloitzcuintli essays and family guides",
+        "numberOfItems": 7,
         "itemListElement": [
           {
             "@type": "ListItem",
             "position": 1,
+            "name": "The Xoloitzcuintli: A Living Pyramid and Guardian of Mexico’s Memory",
+            "url": "https://xolosramirez.com/en/blog/xoloitzcuintli-living-pyramid-mexicos-memory.html"
+          },
+          {
+            "@type": "ListItem",
+            "position": 2,
             "name": "Xoloitzcuintli size guide",
             "url": "https://xolosramirez.com/blog/sizes-in-xoloitzcuintli.html"
           },
           {
             "@type": "ListItem",
-            "position": 2,
+            "position": 3,
             "name": "Xoloitzcuintli cost and process",
             "url": "https://xolosramirez.com/en/blog/xoloitzcuintli-price.html"
           },
           {
             "@type": "ListItem",
-            "position": 3,
+            "position": 4,
             "name": "Xoloitzcuintli nutrition by life stage",
             "url": "https://xolosramirez.com/en/blog/xoloitzcuintli-nutrition.html"
           },
           {
             "@type": "ListItem",
-            "position": 4,
+            "position": 5,
             "name": "Xoloitzcuintli temperament and family life",
             "url": "https://xolosramirez.com/en/blog/xoloitzcuintli-temperament.html"
           },
           {
             "@type": "ListItem",
-            "position": 5,
+            "position": 6,
             "name": "Why Xoloitzcuintli feel warm",
             "url": "https://xolosramirez.com/en/blog/why-xoloitzcuintli-feel-warm.html"
           },
           {
             "@type": "ListItem",
-            "position": 6,
+            "position": 7,
             "name": "Xoloitzcuintli ear development",
             "url": "https://xolosramirez.com/en/blog/xoloitzcuintli-ear-development.html"
           }
@@ -131,6 +137,13 @@
     <section class="container" aria-labelledby="bilingual-guides">
       <h2 id="bilingual-guides">Bilingual Xoloitzcuintli guides</h2>
       <div class="grid grid-2">
+        <article class="card">
+          <img src="../../assets/images/blog/2025/12/01/xolos-criptos-y-cosmovision-nuestro-ultimo-weekly-update-con-ehecatl-ramirez/58ce8f376f.jpg" alt="An adult Xoloitzcuintli, a living archive of Mexico’s biocultural memory" loading="lazy" width="768" height="1024" style="width:100%;height:auto;border-radius:0.5rem;">
+          <p><time datetime="2026-08-11">August 11, 2026</time> · Visual essay</p>
+          <h3><a href="xoloitzcuintli-living-pyramid-mexicos-memory.html">The Xoloitzcuintli: A Living Pyramid and Guardian of Mexico’s Memory</a></h3>
+          <p>Archaeology, worldview, biology, art and the careful progression from living lineage to complementary digital memory.</p>
+        </article>
+
         <article class="card">
           <img src="../../img/hero/site-hero.jpg" alt="" loading="lazy" width="640" height="360" style="width:100%;height:auto;border-radius:0.5rem;">
           <h3><a href="../../blog/sizes-in-xoloitzcuintli.html">Xoloitzcuintli size guide</a></h3>

--- a/en/blog/xoloitzcuintli-living-pyramid-mexicos-memory.html
+++ b/en/blog/xoloitzcuintli-living-pyramid-mexicos-memory.html
@@ -1,0 +1,275 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <!-- Google Tag Manager -->
+  <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
+  new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
+  j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
+  'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
+  })(window,document,'script','dataLayer','GTM-MGTMWN7T');</script>
+  <!-- End Google Tag Manager -->
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>The Xoloitzcuintli: A Living Pyramid and Guardian of Mexico’s Memory | Xolos Ramírez</title>
+  <meta name="description" content="A visual essay on the Xoloitzcuintli as living biocultural heritage: archaeology, Xólotl, biology, art, lineage and verifiable digital memory.">
+  <link rel="canonical" href="https://xolosramirez.com/en/blog/xoloitzcuintli-living-pyramid-mexicos-memory.html">
+  <link rel="alternate" hreflang="es-MX" href="https://xolosramirez.com/blog/xoloitzcuintle-piramide-viviente-memoria-mexico.html">
+  <link rel="alternate" hreflang="en" href="https://xolosramirez.com/en/blog/xoloitzcuintli-living-pyramid-mexicos-memory.html">
+  <link rel="alternate" hreflang="x-default" href="https://xolosramirez.com/blog/xoloitzcuintle-piramide-viviente-memoria-mexico.html">
+  <meta property="og:type" content="article">
+  <meta property="og:locale" content="en_US">
+  <meta property="og:site_name" content="Xolos Ramírez">
+  <meta property="og:title" content="The Xoloitzcuintli: A Living Pyramid and Guardian of Mexico’s Memory">
+  <meta property="og:description" content="A journey through the archaeology, worldview, biology, art and contemporary preservation of Mexico’s Xoloitzcuintli.">
+  <meta property="og:url" content="https://xolosramirez.com/en/blog/xoloitzcuintli-living-pyramid-mexicos-memory.html">
+  <meta property="og:image" content="https://xolosramirez.com/assets/images/blog/2025/12/01/xolos-criptos-y-cosmovision-nuestro-ultimo-weekly-update-con-ehecatl-ramirez/58ce8f376f.jpg">
+  <meta property="article:published_time" content="2026-08-11">
+  <meta property="article:modified_time" content="2026-08-11">
+  <meta name="twitter:card" content="summary_large_image">
+  <meta name="twitter:title" content="The Xoloitzcuintli: A Living Pyramid and Guardian of Mexico’s Memory">
+  <meta name="twitter:description" content="The Xoloitzcuintli as a living biocultural archive and a bridge between ancestral memory, living bodies, lineage and digital documentation.">
+  <meta name="twitter:image" content="https://xolosramirez.com/assets/images/blog/2025/12/01/xolos-criptos-y-cosmovision-nuestro-ultimo-weekly-update-con-ehecatl-ramirez/58ce8f376f.jpg">
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Cinzel:wght@400;700&amp;family=Poppins:wght@400;600;700&amp;display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="../../css/styles.css">
+  <link rel="stylesheet" href="../../css/biocultural-essay.css">
+  <link rel="icon" type="image/x-icon" href="../../assets/xolosramirez.ico">
+  <script type="application/ld+json">
+  {
+    "@context": "https://schema.org",
+    "@graph": [
+      {
+        "@type": "Article",
+        "headline": "The Xoloitzcuintli: A Living Pyramid and Guardian of Mexico’s Memory",
+        "description": "A visual essay on the Xoloitzcuintli as living biocultural heritage: archaeology, Xólotl, biology, art, lineage and verifiable digital memory.",
+        "inLanguage": "en",
+        "datePublished": "2026-08-11",
+        "dateModified": "2026-08-11",
+        "mainEntityOfPage": "https://xolosramirez.com/en/blog/xoloitzcuintli-living-pyramid-mexicos-memory.html",
+        "author": { "@type": "Organization", "name": "Xolos Ramírez" },
+        "publisher": { "@type": "Organization", "name": "Xolos Ramírez" },
+        "image": "https://xolosramirez.com/assets/images/blog/2025/12/01/xolos-criptos-y-cosmovision-nuestro-ultimo-weekly-update-con-ehecatl-ramirez/58ce8f376f.jpg"
+      },
+      {
+        "@type": "BreadcrumbList",
+        "itemListElement": [
+          { "@type": "ListItem", "position": 1, "name": "Home", "item": "https://xolosramirez.com/en/index.html" },
+          { "@type": "ListItem", "position": 2, "name": "Blog", "item": "https://xolosramirez.com/en/blog/index.html" },
+          { "@type": "ListItem", "position": 3, "name": "Living pyramid", "item": "https://xolosramirez.com/en/blog/xoloitzcuintli-living-pyramid-mexicos-memory.html" }
+        ]
+      }
+    ]
+  }
+  </script>
+</head>
+<body>
+  <!-- Google Tag Manager (noscript) -->
+  <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-MGTMWN7T" height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
+  <!-- End Google Tag Manager (noscript) -->
+  <a class="skip-link" href="#main-content">Skip to main content</a>
+
+  <header class="site-header">
+    <div class="container header-row">
+      <a class="brand" href="../index.html">
+        <img src="../../img/brand/logo-xolos-ramirez.svg" alt="Xolos Ramírez" width="44" height="44">
+        <span>Xolos Ramírez</span>
+      </a>
+      <button class="hamburger" aria-expanded="false" aria-controls="menu">☰</button>
+      <nav id="menu" class="nav-menu" data-visible="false" aria-label="Main navigation">
+        <ul>
+          <li><a href="../index.html">Home</a></li>
+          <li><a href="../available-xolos.html">Available Xolos</a></li>
+          <li><a href="index.html">Blog</a></li>
+          <li><a href="../contact.html">Contact</a></li>
+          <li><a href="../../blog/xoloitzcuintle-piramide-viviente-memoria-mexico.html" lang="es-MX">Español</a></li>
+        </ul>
+      </nav>
+    </div>
+  </header>
+
+  <main id="main-content">
+    <header class="essay-hero">
+      <img class="essay-hero__image" src="../../assets/images/blog/2025/12/01/xolos-criptos-y-cosmovision-nuestro-ultimo-weekly-update-con-ehecatl-ramirez/58ce8f376f.jpg" alt="An adult Xoloitzcuintli at rest, embodying the living presence of this Mexican breed" width="768" height="1024">
+      <div class="essay-hero__veil" aria-hidden="true"></div>
+      <div class="essay-hero__content">
+        <p class="essay-kicker">Visual essay · Living biocultural heritage</p>
+        <h1>The Xoloitzcuintli: A Living Pyramid and Guardian of Mexico’s Memory</h1>
+        <p class="essay-deck">Before it becomes a symbol, a pedigree or a digital record, the Xoloitzcuintli is a living animal. Its body carries a biological history while Mexican culture has surrounded it with archaeology, art and stories of passage.</p>
+      </div>
+    </header>
+
+    <div class="essay-shell">
+      <div class="essay-meta">
+        <time datetime="2026-08-11">August 11, 2026</time>
+        <span>Xolos Ramírez Editorial Team</span>
+        <span>Approx. 14-minute read</span>
+      </div>
+      <div class="essay-tools">
+        <a href="index.html">← Back to the English blog</a>
+        <a href="../../blog/xoloitzcuintle-piramide-viviente-memoria-mexico.html" lang="es-MX">Leer la edición principal en español</a>
+      </div>
+
+      <div class="essay-grid">
+        <article class="essay-body">
+          <p>The Nahuatl name <em>Xoloitzcuintli</em> can feel formidable to an international reader; many families simply say “Xolo.” Yet the animal behind the name is more important than the aura around it. A Xolo is a dog that grows, learns, forms attachments and needs individual care. It is not an archaeological object that somehow survived intact, nor a myth brought to life.</p>
+
+          <p>It can, however, be understood as a <strong>living biocultural archive</strong>. The phrase describes a relationship: biological inheritance continues through living bodies, while human communities preserve, forget and reinterpret what those bodies mean. Archaeological remains, funerary traditions, twentieth-century art, modern canine records and family photographs all belong to the Xolo’s story, but they do not all provide the same kind of evidence.</p>
+
+          <p>Xolos Ramírez approaches that continuity through documented breeding, physical identification and a complementary digital record. The hierarchy matters. Technology can connect and verify references; it cannot replace the dog, biological lineage, pedigree, veterinary records or the institutions responsible for them.</p>
+
+          <blockquote class="essay-quote">
+            “Every Xoloitzcuintli is a living pyramid.”
+            <cite>A contemporary editorial concept developed by Xolos Ramírez</cite>
+          </blockquote>
+
+          <p>This is not presented as a pre-Hispanic expression. It is our present-day metaphor. A pyramid holds accumulated layers of time; a Xolo carries ancestry in a body that is never static. The comparison is valuable only when its modern origin remains explicit.</p>
+
+          <h2 id="living-presence">A living presence, not a frozen relic</h2>
+
+          <p>Mexico’s National Museum of Anthropology has described native dogs as part of the country’s <strong>biocultural heritage</strong>. That term brings biology and culture together without collapsing one into the other. Xolos and other Mexican dogs were participants in domestic life, economic practices, ritual worlds and funerary contexts. People also turned them into images: ceramic figures, vessels, sculptures and later paintings.</p>
+
+          <p>An object in a museum can document an ancient representation. A bone can support an archaeological identification. A colonial account can preserve an observer’s description, along with that observer’s assumptions. A religious narrative tells us how a community understood existence; it does not function as scientific proof of the supernatural. Responsible cultural writing keeps those categories visible.</p>
+
+          <figure class="essay-figure">
+            <img src="../../assets/images/blog/2025/11/26/el-secreto-del-calor-del-xoloitzcuintle-tonalli-y-medicina-ancestral/3d0cba22d4.jpg" alt="Fernando Ramírez holding a Xoloitzcuintli puppy while speaking with the community" width="455" height="455" loading="lazy">
+            <figcaption>Biocultural heritage continues in ordinary acts of care, observation, conversation and life shared with a real animal. Xolos Ramírez archive.</figcaption>
+          </figure>
+
+          <h2 id="xolotl-mictlan">Xólotl, Mictlán and a dog that crosses boundaries</h2>
+
+          <p>In Mesoamerican traditions, dogs appear in accounts of death and the journey to the underworld. Mexico’s National Institute of Anthropology and History, or INAH, summarizes historical sources in which a dog assists the deceased on the way to <strong>Mictlán</strong>, including a difficult river crossing. Museum collections also preserve representations of <strong>Xólotl</strong>, a deity associated with the underworld and described as the twin of Quetzalcóatl.</p>
+
+          <p>For readers outside Mexico, this distinction is essential: Mictlán belongs to documented religious worldviews, not to a claim that a supernatural passage can be scientifically observed. The image of the guiding dog matters because communities used it to think about mortality, companionship and transition.</p>
+
+          <p>The Nahuatl word <em>tonalli</em> also resists easy translation. It participates in ideas of vital force, warmth, calendrical identity and destiny, but it is not a simple equivalent of the Western “soul.” Xolos Ramírez uses Tonalli as the name of a contemporary technological and community project; that choice is an interpretation inspired by Mexican cultural vocabulary, not a claim of direct institutional continuity with the Nahua past.</p>
+
+          <h2 id="archaeology">What archaeology can — and cannot — tell us</h2>
+
+          <p>The exhibition <em>Xolos, compañeros de viaje</em> (“Xolos, Traveling Companions”) brought together archaeological, ethnographic and artistic objects as well as skeletal remains. The materials point to dogs in both ceremonial and everyday settings across different regions and cultures. There was no single, timeless “Mesoamerican view of the dog”; meanings varied across place, period and community.</p>
+
+          <p>A UNAM review describes approximately two thousand years of clearly documented presence for the Mexican hairless dog, drawing on archaeological materials and archaeozoological study. Popular accounts sometimes repeat a seven-thousand-year history as settled fact. The available sources warrant more careful wording. “Documented for roughly two millennia” does not identify an exact first birth; it names the chronological range the cited evidence can support with confidence.</p>
+
+          <div class="essay-note">
+            <strong>Evidence and interpretation.</strong> Archaeology can document remains, contexts and representations. It can support interpretations of practice, but it does not turn every later story about the Xolo into an equally ancient fact. New discoveries may also refine the timeline.
+          </div>
+
+          <h2 id="biology">The hairless body, explained without folklore</h2>
+
+          <p>The hairless Xolo’s appearance has a heritable basis. Research on hairless dogs links a variant involving the <strong>FOXI3</strong> gene to canine ectodermal dysplasia, affecting hair development and dentition. This helps explain why hairless individuals may be missing certain teeth or have different tooth shapes. These dental patterns are biological traits, not mystical markers and not details that responsible breed education should hide.</p>
+
+          <p>Exposed skin calls for care adapted to weather, activity and the individual dog. It does not require exotic physiology. A Xolo often feels warmer to the human hand because there is no coat insulating direct contact with the skin, not because its internal temperature is extraordinary. Claims that the breed regulates heat by sweating through the abdomen are also inaccurate. Normal canine thermoregulation, especially panting and environmental exchange, remains the relevant framework.</p>
+
+          <p>Traditional accounts sometimes describe the Xolo’s warmth as therapeutic. Those practices and beliefs belong to cultural history; they should not be turned into unproven medical claims. A dog’s comforting presence can be meaningful without being marketed as a clinical treatment.</p>
+
+          <p>Biology does not produce one universal temperament, either. Some Xolos may be reserved, others more immediately social; learning, age, health and experience all shape behavior. A cultural portrait of the breed should never erase the individual standing in front of us.</p>
+
+          <h2 id="survival">Near disappearance and modern recognition</h2>
+
+          <p>The Xolo’s survival was not a smooth procession from antiquity to the present. The National Museum of Anthropology describes a period of near extinction under colonial rule, followed by a modern resurgence. In the twentieth century, Mexican muralism and the broader nationalist art movement reclaimed the dog as a visible link to Indigenous heritage. Artists of the Mexican School of Painting placed Xolos in canvases and in their homes, helping transform the breed into a national cultural emblem.</p>
+
+          <p>Cultural rescue was accompanied by modern canine institutions. The Fédération Cynologique Internationale lists Mexico as the country of origin, records definitive recognition in 1961 and recognizes Miniature, Intermediate and Standard sizes. This formal standard is not an untouched pre-Hispanic rulebook. It is a modern canine framework developed to describe and conserve the breed.</p>
+
+          <p>The contemporary Xolo therefore holds several histories at once: biological descent, organized recovery, artistic reinvention and everyday family life. None makes the others unnecessary.</p>
+
+          <h2 id="living-pyramid">Why Xolos Ramírez calls the Xolo a living pyramid</h2>
+
+          <p>“Living pyramid” is a way of thinking about stewardship. Monumental architecture outlives individual builders and demands ongoing care. A lineage also exceeds a single household, but it continues through vulnerable organisms rather than stone. Every breeding decision, health record and family experience adds a layer to what later generations will be able to know.</p>
+
+          <p>This metaphor has led Xolos Ramírez to other modern concepts: the <strong>Living Lineage Archive</strong>, <strong>xolosArmy Network</strong> and <strong>Tonalli Civilization</strong>. They are contemporary names for a breeding, documentation and community vision. They are not archaeological categories or revived pre-Hispanic institutions. Their credibility must come from transparent present-day practice.</p>
+
+          <h2 id="lineage">From living body to digital reference</h2>
+
+          <p>A trustworthy record begins in the physical world. The digital layer becomes meaningful only when it points back to identification and documentation produced elsewhere. For Xolos Ramírez, the sequence is deliberate:</p>
+
+          <ol class="memory-chain" aria-label="Layers of Xoloitzcuintli identity and memory">
+            <li><strong>The living dog.</strong> An individual with its own health, development, behavior and welfare needs.</li>
+            <li><strong>Biological lineage.</strong> Genealogical relationships to parents and preceding generations.</li>
+            <li><strong>Physical identification.</strong> A readable microchip number connects the record to the dog in the real world.</li>
+            <li><strong>Canine and veterinary documentation.</strong> Pedigree, registration, vaccines, certificates and clinical records support different claims.</li>
+            <li><strong>A complementary digital record.</strong> A Lineage NFT can connect references and files for consultation and traceability.</li>
+          </ol>
+
+          <figure class="essay-figure essay-figure--portrait">
+            <img src="../../assets/images/blog/2025/12/18/xolos-ramirez-registra-nuevos-xoloitzcuintles-ante-la-federacion-canofila-mexicana/f569f20325.jpg" alt="A Xoloitzcuintli puppy during a registration visit to the Mexican Canine Federation" width="1600" height="1600" loading="lazy">
+            <figcaption>Documented identity starts with the dog and physical identification. Canine registration and veterinary files perform functions a digital layer cannot replace. Xolos Ramírez archive.</figcaption>
+          </figure>
+
+          <p>A pedigree records genealogy within the relevant canine system. A microchip supports physical identification. Veterinary documents record procedures or health observations at specific times. Each answers a different question. Their value increases when they are connected without pretending they are interchangeable.</p>
+
+          <h2 id="lineage-nft">The Lineage NFT: an additional memory layer</h2>
+
+          <p>The Xolos Ramírez Lineage NFT is designed as a unique digital profile that may connect identity, microchip number, documented genealogy, photographs and references to other files. A record on the eCash network can show that a token was issued, associate that event with a date and address, and display transfers between wallets.</p>
+
+          <p>Related files may use IPFS. In that system, a <strong>Content Identifier</strong>, or CID, is derived from the content: altering the file changes its identifier. This supports integrity checks. It does not guarantee eternal availability. Copies or pinning services must continue to host the content. “Verifiable and resistant to silent modification” is therefore more accurate than “permanent.”</p>
+
+          <div class="essay-note">
+            <p><strong>The digital record does not independently prove:</strong> genetic purity, pedigree validity, current health or absolute legal ownership of the dog.</p>
+            <p>It is also not presented as a speculative asset. Its role in this model is to connect references and support the traceability of a documentary history.</p>
+          </div>
+
+          <p>Blockchain can verify properties of the digital record. Confidence in the biological information still depends on the animal, physical identification, source documents and the professionals and institutions that issued them. That boundary is not a weakness; it is the basis of an honest system.</p>
+
+          <h2 id="future-memory">A community that continues the archive</h2>
+
+          <p>The Living Lineage Archive imagines memory continuing after a Xolo joins its family. Photographs, gatherings and milestones can expand the story over time. Tonalli’s community vision may eventually give families a place to preserve those moments while keeping clear distinctions between family memory, official records and technical verification.</p>
+
+          <p>This is not an attempt to recreate a pre-Hispanic institution. It addresses modern forms of loss: scattered files, disappearing platforms, broken links and family histories that become difficult to reconstruct. Responsible custody, replicated storage and verifiable references can help, provided the infrastructure is maintained and every claim remains open to inspection.</p>
+
+          <h2 id="bridge">The guardian becomes a bridge again</h2>
+
+          <p>In Mesoamerican traditions, the dog was represented as a companion across worlds. In the contemporary reading proposed by Xolos Ramírez, the bridge connects <strong>ancestral memory → living organism → future generations → digital documentation</strong>.</p>
+
+          <p>The metaphor works because the differences remain visible. Mictlán belongs to a historical religious tradition. Microchips, pedigrees, CIDs and blockchains belong to modern systems of identification and verification. They meet only in the way we now choose to narrate and protect continuity.</p>
+
+          <p>The Xolo remains at the center because it is alive. Before the symbol comes the body; before the token comes genealogy; before the archive comes the relationship between an animal and the people responsible for its care. Digital memory is useful when it makes that chain of responsibility easier to see — never when it claims to replace it.</p>
+
+          <section class="essay-sources" aria-labelledby="sources">
+            <h2 id="sources">Sources</h2>
+            <ol>
+              <li><a href="https://inah.gob.mx/foto-del-dia/xoloitzcuintle-companero-en-el-viaje-al-mictlan" target="_blank" rel="noopener noreferrer">INAH: “Xoloitzcuintle: compañero en el viaje al Mictlán”</a> (Spanish).</li>
+              <li><a href="https://mna.inah.gob.mx/deviaje.php?pl=Xolos_Companeros_de_viaje_1" target="_blank" rel="noopener noreferrer">National Museum of Anthropology: “Xolos, compañeros de viaje”</a> (Spanish).</li>
+              <li><a href="https://www.gaceta.unam.mx/el-xoloitzcuintle-un-sobreviviente-de-dos-mil-anos-de-edad/" target="_blank" rel="noopener noreferrer">UNAM Gazette: “El xoloitzcuintle: un sobreviviente de dos mil años de edad”</a> (Spanish).</li>
+              <li><a href="https://www.nature.com/articles/s41598-017-05764-5" target="_blank" rel="noopener noreferrer">Kupczik et al. (2017): “The dental phenotype of hairless dogs with FOXI3 haploinsufficiency”, Scientific Reports</a>.</li>
+              <li><a href="https://www.fci.be/EN/nomenclature/XOLOITZCUINTLE-234.html" target="_blank" rel="noopener noreferrer">Fédération Cynologique Internationale: Xoloitzcuintle (234)</a>.</li>
+              <li><a href="https://docs.ipfs.tech/concepts/content-addressing/" target="_blank" rel="noopener noreferrer">IPFS Docs: Content Identifiers (CIDs)</a> and <a href="https://docs.ipfs.tech/how-to/best-practices-for-nft-data/" target="_blank" rel="noopener noreferrer">best practices for NFT data</a>.</li>
+              <li><a href="../../blog/nft-linaje-xoloitzcuintle.html">Xolos Ramírez: NFT de Linaje Xoloitzcuintle</a>, the project’s conceptual document on identity, genealogy and digital memory (Spanish).</li>
+            </ol>
+          </section>
+
+          <section class="essay-cta" aria-labelledby="continue-reading">
+            <h2 id="continue-reading">Continue exploring</h2>
+            <p>Read more about Mexico’s Xolo dog or learn how Xolos Ramírez documents each dog and supports its family.</p>
+            <div class="essay-cta__links">
+              <a class="essay-button" href="../../blog/meet-mexico-xolo-dog.html">Meet Mexico’s Xolo dog</a>
+              <a class="essay-button essay-button--secondary" href="../available-xolos.html">Meet available Xolos</a>
+            </div>
+          </section>
+        </article>
+
+        <aside class="essay-toc" aria-label="Article contents">
+          <h2>In this essay</h2>
+          <ol>
+            <li><a href="#living-presence">Living heritage</a></li>
+            <li><a href="#xolotl-mictlan">Xólotl and Mictlán</a></li>
+            <li><a href="#archaeology">Archaeology</a></li>
+            <li><a href="#biology">Biology without folklore</a></li>
+            <li><a href="#survival">Modern recovery</a></li>
+            <li><a href="#living-pyramid">Living pyramid</a></li>
+            <li><a href="#lineage">Order of memory</a></li>
+            <li><a href="#lineage-nft">Lineage NFT</a></li>
+            <li><a href="#bridge">The bridge</a></li>
+          </ol>
+        </aside>
+      </div>
+    </div>
+  </main>
+
+  <footer class="site-footer">
+    <div class="container">
+      <p>© 2026 Xolos Ramírez. Documented breeding, living memory.</p>
+    </div>
+  </footer>
+  <script src="../../js/main.js" defer></script>
+</body>
+</html>

--- a/sitemap.xml
+++ b/sitemap.xml
@@ -14,6 +14,11 @@
   </url>
   <url>
     <loc>https://xolosramirez.com/blog/index.html</loc>
+    <lastmod>2026-08-11</lastmod>
+  </url>
+  <url>
+    <loc>https://xolosramirez.com/blog/xoloitzcuintle-piramide-viviente-memoria-mexico.html</loc>
+    <lastmod>2026-08-11</lastmod>
   </url>
   <url>
     <loc>https://xolosramirez.com/blog/precio-xoloitzcuintle.html</loc>
@@ -54,7 +59,11 @@
   </url>
   <url>
     <loc>https://xolosramirez.com/en/blog/index.html</loc>
-    <lastmod>2026-07-28</lastmod>
+    <lastmod>2026-08-11</lastmod>
+  </url>
+  <url>
+    <loc>https://xolosramirez.com/en/blog/xoloitzcuintli-living-pyramid-mexicos-memory.html</loc>
+    <lastmod>2026-08-11</lastmod>
   </url>
   <url>
     <loc>https://xolosramirez.com/en/blog/xoloitzcuintli-price.html</loc>


### PR DESCRIPTION
## What changed

- Adds the Spanish essay **“El Xoloitzcuintle: pirámide viviente y guardián de la memoria de México.”**
- Adds an independently adapted English edition, **“The Xoloitzcuintli: A Living Pyramid and Guardian of Mexico’s Memory.”**
- Adds one shared responsive stylesheet for the visual essay format.
- Indexes each edition in its corresponding blog index.
- Adds both canonical URLs to `sitemap.xml` and updates the two blog-index `lastmod` values.

## Editorial approach

The pieces present the Xoloitzcuintli as a living biocultural archive while keeping archaeology, religious tradition, scientific evidence and contemporary Xolos Ramírez concepts clearly differentiated.

The information hierarchy is explicit:

1. living animal;
2. biological lineage;
3. physical identification;
4. canine and veterinary documentation;
5. complementary digital record.

The Lineage NFT is described as an additional traceability layer, not as a replacement for pedigree or microchip, proof of genetic purity, legal title, or speculative asset. IPFS persistence limits are also stated.

## Sources

- INAH and the National Museum of Anthropology
- UNAM
- the peer-reviewed FOXI3 dental phenotype study
- Fédération Cynologique Internationale
- official IPFS documentation
- Xolos Ramírez’s NFT de Linaje document

## Assets

Reuses three existing repository images: an adult Xolo for the hero, a community-care image and an FCM registration image. No new image assets were added.

## Validation

- `npm run lint:html`: 170 HTML files, 0 errors
- `git diff --check`: passed
- JSON-LD parsing: passed
- 330 editorial, SEO, local-reference and responsive-rule assertions: passed
- `sitemap.xml`: parsed with 23 unique URLs
- All local links and assets referenced by both articles and index cards resolve in the repository
- Remote branch re-fetch confirms exact blob SHAs for all six files
- Compare against `main`: 1 commit ahead, 0 behind, exactly six files

## Known limitations

- `npm run test:generate-lead` currently fails on the unchanged `main` implementation because its test slices through later `href` assignments in `js/main.js`. This PR does not modify `js/main.js` or the tracking test.
- Browser-based mobile rendering was not claimed. Chromium was unavailable and the environment blocked installing a headless browser. Mobile review was therefore structural: single-column breakpoints, fluid containers and images, and no oversized fixed widths or forced nowrap.

No merge or deployment is included.