### PR TITLE
Update Xilonen Ramirez video

### DIFF
--- a/en/available-xolos.html
+++ b/en/available-xolos.html
@@ -337,7 +337,7 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
       <iframe
         width="100%"
         height="100%"
-        src="https://www.youtube.com/embed/5ZdM8jbvmu0"
+        src="https://www.youtube.com/embed/BN7eB-H946Q"
         title="Xilonen Ramirez"
         frameborder="0"
         allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"

--- a/xolos-disponibles.html
+++ b/xolos-disponibles.html
@@ -395,7 +395,7 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
       <iframe
         width="100%"
         height="100%"
-        src="https://www.youtube.com/embed/5ZdM8jbvmu0"
+        src="https://www.youtube.com/embed/BN7eB-H946Q"
         title="Xilonen Ramirez"
         frameborder="0"
         allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"


### PR DESCRIPTION
## What changed

- Replaced Xilonen Ramirez's embedded YouTube video in the Spanish availability profile.
- Applied the same video update to the mirrored English profile.
- Preserved all iframe attributes, responsive behavior, photographs, availability, and commercial information.

## Video

- Previous ID: `5ZdM8jbvmu0`
- New ID: `BN7eB-H946Q`

## Validation

- `git diff --check`
- `npm run lint:html` — 170 HTML files scanned, zero errors
- Confirmed the new ID appears exactly once in Xilonen's profile on each page
- Confirmed the previous ID no longer appears in either Xilonen profile
- Confirmed the remote diff contains only `xolos-disponibles.html` and `en/available-xolos.html`
- Verified the embed URL is correctly formed from the official YouTube video ID; direct YouTube fetching is blocked in the execution environment