### PR TITLE
Fix Teyolia article desktop hero overlap

### DIFF
--- a/blog/2026-08-13-entrega-xoloitzcuintle-teyolia-ramirez.html
+++ b/blog/2026-08-13-entrega-xoloitzcuintle-teyolia-ramirez.html
@@ -295,6 +295,30 @@
       color: #ffffff;
     }
 
+    @media (min-width: 768px) {
+      .delivery-masthead {
+        padding: 2.25rem 1.25rem 2.75rem;
+        position: static;
+        top: auto;
+        z-index: auto;
+      }
+
+      .delivery-kicker {
+        margin-bottom: 0.75rem;
+      }
+
+      .delivery-masthead h1 {
+        font-size: clamp(2.1rem, 3.5vw, 2.75rem);
+        line-height: 1.12;
+      }
+
+      .delivery-deck {
+        font-size: 1.08rem;
+        line-height: 1.55;
+        margin-top: 1rem;
+      }
+    }
+
     @media (max-width: 640px) {
       .delivery-facts {
         grid-template-columns: 1fr;


### PR DESCRIPTION
## Summary

- Stop the Teyolia article masthead from inheriting the global sticky `header` behavior on tablet/desktop (`min-width: 768px`).
- Reduce desktop/tablet hero padding, title size/line-height, kicker spacing, and deck spacing.
- Preserve the existing mobile/base visual rules below 768px.

## Root cause

The article hero uses a semantic `<header>` element. The global `header` rule applies `position: sticky; top: 0; z-index: 10`, so the 712 px-tall masthead remained over the delivery photo while scrolling on laptop screens.

## Validation

- Reproduced the live issue in a 1363 px-wide desktop browser: 712 px hero and 705 px overlap with the photo after scrolling.
- `git diff --check`
- HTML structure parsed successfully.
- Inline CSS braces/strings/comments validated and desktop cascade override asserted.
- All local article assets resolve.
- Local HTTP request returned 200.
- Responsive values checked at 390, 768, 1024, and 1366 px.
- Remote branch is one commit ahead of `main`, zero behind, and changes only the article HTML.

No repository CI workflows or commit status checks are configured for this commit.