### PR TITLE
Feature Teyolia delivery on homepage

### DIFF
--- a/index.html
+++ b/index.html
@@ -286,14 +286,15 @@ NFTs de Linaje Xoloitzcuintle</a></li>
       </section>
 
       <article class="card blog-card" data-aos="zoom-in" data-aos-delay="250">
-  <picture class="card_media">
-    <img src="https://i.imgur.com/cXvaz7b.jpeg" width="600" height="400" loading="lazy" decoding="async" alt="Entregas Xolos Ramirez">
-  </picture>
-  <h2>Entrega del xoloitzcuintle Onix Ramirez a su familia.
-</h2>
-  <p>El día de hoy marca un hito muy especial para la familia de Xolos Ramirez. Tuvimos el inmenso honor de entregar al precioso cachorro Onix Ramirez a su nueva familia: Adrián y su esposa. Fue un momento lleno de emoción, ternura y, sobre todo, una profunda conexión. </p>
-  <a href="blog/2026-07-18-entrega-onix-ramirez.html" aria-label="Entregas Xolos Ramirez">Ver mas aqui:</a>
-</article>
+        <picture class="card_media">
+          <img src="https://i.imgur.com/aftHfMQ.jpeg"
+            width="600" height="400" loading="lazy" decoding="async"
+            alt="Entrega de Teyolia Ramírez a su nueva familia">
+        </picture>
+        <h2>Entrega de Teyolia Ramírez, xoloitzcuintle miniatura, a su nueva familia.</h2>
+        <p>El día de hoy marca un momento muy especial para la familia de Xolos Ramírez. Tuvimos el honor de entregar a Teyolia Ramírez, una hermosa xoloitzcuintle miniatura, a su nueva familia. Una entrega llena de emoción, confianza y continuidad para la memoria viva del xoloitzcuintle mexicano.</p>
+        <a href="blog/2026-08-13-entrega-xoloitzcuintle-teyolia-ramirez.html" aria-label="Entrega de Teyolia Ramírez">Ver más aquí:</a>
+      </article>
 
 
       <section id="testimonios" data-aos="fade-up" data-aos-duration="1000">


### PR DESCRIPTION
## Summary

- Replace the Onix Ramírez delivery card on the global homepage with the Teyolia Ramírez delivery.
- Update the card image, alternative text, title, description, article URL, link label, and Spanish accents.
- Keep the surrounding homepage content unchanged.

## Validation

- Branch created from current `main` (`ebddb1e`).
- Remote comparison: one commit ahead, zero behind.
- Changed files: only `index.html`.
- `git diff --check` passes.
- HTML parsed successfully with exact assertions for every requested card field.
- Old Onix image and article URL are absent from the updated homepage.
- Local homepage and Teyolia article paths return HTTP 200.
- New Imgur image returns HTTP 200 with `content-type: image/jpeg`.
- Remote file blob matches the locally validated file byte-for-byte.

No repository CI workflows or commit status checks are configured for this commit.