### PR TITLE
docs(blog): documenta embudo completo Bitso → Firma → Tonalli → XEC

### DIFF
--- a/blog/index.html
+++ b/blog/index.html
@@ -8,94 +8,29 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Blog y guías | Xolos Ramírez</title>
   <meta name="description" content="Artículos y guías de Xolos Ramírez sobre xoloitzcuintles, cultura mexicana, eCash, Tonalli Wallet y soberanía digital.">
-  <meta name="keywords" content="blog xoloitzcuintle, Tonalli Wallet, eCash, Firma Alpha, cuidados xolo, cultura mexicana">
+  <meta name="keywords" content="blog xoloitzcuintle, Tonalli Wallet, eCash, Firma Alpha, Bitso, USDT Solana, cuidados xolo, cultura mexicana">
   <link rel="canonical" href="https://xolosramirez.com/blog/index.html">
   <link rel="alternate" hreflang="es-MX" href="https://xolosramirez.com/blog/index.html">
   <link rel="alternate" hreflang="en" href="https://xolosramirez.com/en/blog/index.html">
   <link rel="alternate" hreflang="x-default" href="https://xolosramirez.com/blog/index.html">
-  <meta property="og:title" content="Blog y guías | Xolos Ramírez">
-  <meta property="og:description" content="Xoloitzcuintles, cultura, eCash, Tonalli Wallet y soberanía digital desde Xolos Ramírez.">
-  <meta property="og:url" content="https://xolosramirez.com/blog/index.html">
-  <meta property="og:image" content="https://xolosramirez.com/img/hero/site-hero.jpg">
-  <meta property="og:type" content="website">
-  <meta name="twitter:card" content="summary_large_image">
-  <meta name="twitter:title" content="Blog y guías | Xolos Ramírez">
-  <meta name="twitter:description" content="Guías sobre xoloitzcuintles y notas de campo sobre eCash y Tonalli Wallet.">
-  <meta name="twitter:image" content="https://xolosramirez.com/img/hero/site-hero.jpg">
-  <link href="https://fonts.googleapis.com" rel="preconnect">
-  <link crossorigin href="https://fonts.gstatic.com" rel="preconnect">
-  <link href="https://fonts.googleapis.com/css2?family=Cinzel:wght@400;700&amp;family=Poppins:wght@400;600&amp;display=swap" rel="stylesheet">
-  <link href="https://unpkg.com/aos@2.3.1/dist/aos.css" rel="stylesheet">
-  <link href="../css/styles.css" rel="stylesheet">
-  <link href="../assets/xolosramirez.ico" rel="icon" type="image/x-icon">
-  <style>
-    .blog-card{background:#fff;border-radius:12px;overflow:hidden;box-shadow:0 4px 15px rgba(0,0,0,.1);transition:transform .3s ease;max-width:400px;font-family:"Segoe UI",sans-serif}.blog-card:hover{transform:translateY(-5px)}.card-image{position:relative;height:200px}.card-image img{width:100%;height:100%;object-fit:cover}.category{position:absolute;top:15px;left:15px;background:#d35400;color:#fff;padding:5px 12px;border-radius:20px;font-size:.75rem;font-weight:bold}.card-content{padding:20px}.post-date{color:#888;font-size:.85rem;display:block;margin-bottom:8px}.card-content h3{margin:0 0 12px;color:#2c2c2c;font-size:1.25rem;line-height:1.4}.card-content p{color:#555;font-size:.95rem;margin-bottom:20px;display:-webkit-box;-webkit-line-clamp:3;-webkit-box-orient:vertical;overflow:hidden}.read-more{color:#d35400;text-decoration:none;font-weight:bold;font-size:.9rem}.read-more:hover{text-decoration:underline}.blog-load-status{grid-column:1/-1;padding:1rem;text-align:center;color:#666}.featured-tech .card-image{background:linear-gradient(135deg,#111827,#0f766e)}.featured-tech .card-image img{opacity:.42}
-  </style>
-  <script type="application/ld+json">
-  {
-    "@context":"https://schema.org",
-    "@type":"Blog",
-    "name":"Blog Xolos Ramírez",
-    "url":"https://xolosramirez.com/blog/index.html",
-    "inLanguage":"es-MX",
-    "blogPost":{"@type":"BlogPosting","headline":"De Firma Wallet a Tonalli y de FIRMA a XEC: tutorial de principio a fin","url":"https://xolosramirez.com/blog/tutorial-firma-wallet-tonalli-firma-xec.html","datePublished":"2026-08-14"}
-  }
-  </script>
+  <meta property="og:title" content="Blog y guías | Xolos Ramírez"><meta property="og:description" content="Xoloitzcuintles, cultura, eCash, Tonalli Wallet y soberanía digital desde Xolos Ramírez."><meta property="og:url" content="https://xolosramirez.com/blog/index.html"><meta property="og:image" content="https://xolosramirez.com/img/hero/site-hero.jpg"><meta property="og:type" content="website">
+  <meta name="twitter:card" content="summary_large_image"><meta name="twitter:title" content="Blog y guías | Xolos Ramírez"><meta name="twitter:description" content="Guías sobre xoloitzcuintles y notas de campo sobre eCash y Tonalli Wallet."><meta name="twitter:image" content="https://xolosramirez.com/img/hero/site-hero.jpg">
+  <link href="https://fonts.googleapis.com" rel="preconnect"><link crossorigin href="https://fonts.gstatic.com" rel="preconnect"><link href="https://fonts.googleapis.com/css2?family=Cinzel:wght@400;700&amp;family=Poppins:wght@400;600&amp;display=swap" rel="stylesheet"><link href="https://unpkg.com/aos@2.3.1/dist/aos.css" rel="stylesheet"><link href="../css/styles.css" rel="stylesheet"><link href="../assets/xolosramirez.ico" rel="icon" type="image/x-icon">
+  <style>.blog-card{background:#fff;border-radius:12px;overflow:hidden;box-shadow:0 4px 15px rgba(0,0,0,.1);transition:transform .3s ease;max-width:400px;font-family:"Segoe UI",sans-serif}.blog-card:hover{transform:translateY(-5px)}.card-image{position:relative;height:200px}.card-image img{width:100%;height:100%;object-fit:cover}.category{position:absolute;top:15px;left:15px;background:#d35400;color:#fff;padding:5px 12px;border-radius:20px;font-size:.75rem;font-weight:bold}.card-content{padding:20px}.post-date{color:#888;font-size:.85rem;display:block;margin-bottom:8px}.card-content h3{margin:0 0 12px;color:#2c2c2c;font-size:1.25rem;line-height:1.4}.card-content p{color:#555;font-size:.95rem;margin-bottom:20px;display:-webkit-box;-webkit-line-clamp:3;-webkit-box-orient:vertical;overflow:hidden}.read-more{color:#d35400;text-decoration:none;font-weight:bold;font-size:.9rem}.read-more:hover{text-decoration:underline}.blog-load-status{grid-column:1/-1;padding:1rem;text-align:center;color:#666}.featured-tech .card-image{background:linear-gradient(135deg,#111827,#0f766e)}.featured-tech .card-image img{opacity:.42}</style>
+  <script type="application/ld+json">{"@context":"https://schema.org","@type":"Blog","name":"Blog Xolos Ramírez","url":"https://xolosramirez.com/blog/index.html","inLanguage":"es-MX","blogPost":{"@type":"BlogPosting","headline":"De pesos mexicanos a XEC: Bitso → USDT Solana → Firma → Tonalli","url":"https://xolosramirez.com/blog/tutorial-firma-wallet-tonalli-firma-xec.html","datePublished":"2026-08-14"}}</script>
 </head>
 <body>
-  <!-- Google Tag Manager (noscript) -->
   <noscript><iframe height="0" src="https://www.googletagmanager.com/ns.html?id=GTM-MGTMWN7T" style="display:none;visibility:hidden" width="0"></iframe></noscript>
-  <!-- End Google Tag Manager (noscript) -->
   <a class="skip-link" href="#contenido-principal">Saltar al contenido principal</a>
-  <header class="site-header">
-    <div class="container header-row">
-      <a class="brand" href="../index.html"><img alt="Xolos Ramírez Logo" height="44" src="https://i.imgur.com/SbNsa4g.jpeg" style="border-radius:50%;object-fit:cover" width="44"><span>Xolos Ramírez</span></a>
-      <button aria-controls="menu" aria-expanded="false" class="hamburger">☰</button>
-      <nav class="nav-menu" data-visible="false" id="menu" aria-label="Navegación principal">
-        <ul><li><a href="../index.html">Inicio</a></li><li><a href="../xolos-disponibles.html">Xolos disponibles</a></li><li><a href="../testimonios.html">Testimonios</a></li><li><a href="index.html">Blog</a></li><li><a href="../contacto.html">Contacto</a></li><li><a href="../en/blog/index.html" lang="en">English</a></li></ul>
-      </nav>
-    </div>
-  </header>
+  <header class="site-header"><div class="container header-row"><a class="brand" href="../index.html"><img alt="Xolos Ramírez Logo" height="44" src="https://i.imgur.com/SbNsa4g.jpeg" style="border-radius:50%;object-fit:cover" width="44"><span>Xolos Ramírez</span></a><button aria-controls="menu" aria-expanded="false" class="hamburger">☰</button><nav class="nav-menu" data-visible="false" id="menu"><ul><li><a href="../index.html">Inicio</a></li><li><a href="../xolos-disponibles.html">Xolos disponibles</a></li><li><a href="../testimonios.html">Testimonios</a></li><li><a href="index.html">Blog</a></li><li><a href="../contacto.html">Contacto</a></li><li><a href="../en/blog/index.html" lang="en">English</a></li></ul></nav></div></header>
   <main id="contenido-principal">
-    <section class="hero hero-disponibles" data-aos="fade-in" data-aos-duration="1200">
-      <div class="hero__media" style="position:absolute;top:0;left:0;width:100%;height:100%;overflow:hidden;z-index:-1">
-        <iframe src="https://www.youtube.com/embed/lWOCO2wkok8?si=I79unog5VKIjRZxd&autoplay=1&mute=1&loop=1" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" allowfullscreen style="position:absolute;top:50%;left:50%;width:100vw;height:56.25vw;min-height:100vh;min-width:177.77vh;transform:translate(-50%,-50%);pointer-events:none"></iframe>
-      </div>
-      <div class="container"><h1>Blog y guías de Xolos Ramírez</h1><p>Xoloitzcuintles, cultura mexicana, adopción responsable y notas de campo sobre eCash, Tonalli Wallet y soberanía digital.</p></div>
-    </section>
-
+    <section class="hero hero-disponibles" data-aos="fade-in" data-aos-duration="1200"><div class="hero__media" style="position:absolute;top:0;left:0;width:100%;height:100%;overflow:hidden;z-index:-1"><iframe src="https://www.youtube.com/embed/lWOCO2wkok8?si=I79unog5VKIjRZxd&autoplay=1&mute=1&loop=1" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" allowfullscreen style="position:absolute;top:50%;left:50%;width:100vw;height:56.25vw;min-height:100vh;min-width:177.77vh;transform:translate(-50%,-50%);pointer-events:none"></iframe></div><div class="container"><h1>Blog y guías de Xolos Ramírez</h1><p>Xoloitzcuintles, cultura mexicana, adopción responsable y notas de campo sobre eCash, Tonalli Wallet y soberanía digital.</p></div></section>
     <section aria-label="Listado de artículos del blog" class="grid" data-aos="fade-up" data-aos-duration="1000" id="blog-grid">
-      <article class="blog-card featured-tech" data-aos="fade-up">
-        <div class="card-image"><img src="../img/hero/site-hero.jpg" alt="Tutorial Firma Wallet, Tonalli Wallet, Firma Alpha y eCash" loading="lazy" width="640" height="360"><span class="category">Tonalli Wallet · eCash</span></div>
-        <div class="card-content"><span class="post-date">14 de agosto de 2026</span><h3>De Firma Wallet a Tonalli y de FIRMA a XEC: tutorial de principio a fin</h3><p>Respalda la seed de Firma, recupérala con BIP44 1899, verifica Firma Alpha, prepara XEC para fees y redime FIRMA por XEC mediante una oferta Agora on-chain.</p><a href="tutorial-firma-wallet-tonalli-firma-xec.html" class="read-more">Abrir tutorial &rarr;</a></div>
-      </article>
+      <article class="blog-card featured-tech" data-aos="fade-up"><div class="card-image"><img src="../img/hero/site-hero.jpg" alt="Tutorial de pesos mexicanos a XEC con Bitso, Firma y Tonalli" loading="lazy" width="640" height="360"><span class="category">Tonalli Wallet · eCash</span></div><div class="card-content"><span class="post-date">14 de agosto de 2026</span><h3>De pesos a XEC: Bitso → USDT Solana → Firma → Tonalli</h3><p>Embudo probado con fondos reales: deposita MXN, compra USDT, retíralo por Solana a Firma, recupera Firma Alpha con seed 1899 y redímelo por XEC en Agora.</p><a href="tutorial-firma-wallet-tonalli-firma-xec.html" class="read-more">Abrir tutorial &rarr;</a></div></article>
       <p class="blog-load-status" id="blog-load-status">Cargando el archivo editorial…</p>
     </section>
   </main>
   <footer class="site-footer"><div class="container"><p>© 2026 Xolos Ramírez.</p></div></footer>
-  <script>
-    (async function hydrateHistoricalBlogCards(){
-      const grid=document.getElementById('blog-grid');
-      const status=document.getElementById('blog-load-status');
-      if(!grid||!status)return;
-      try{
-        const response=await fetch('index-archivo-2026-08-14.html',{cache:'no-store'});
-        if(!response.ok)throw new Error('archive '+response.status);
-        const html=await response.text();
-        const doc=new DOMParser().parseFromString(html,'text/html');
-        const archiveGrid=doc.querySelector('section.grid[aria-label="Listado de artículos del blog"]');
-        if(!archiveGrid)throw new Error('archive grid missing');
-        archiveGrid.querySelectorAll(':scope > article').forEach((article)=>grid.appendChild(document.importNode(article,true)));
-        status.remove();
-        if(window.AOS&&typeof window.AOS.refreshHard==='function')window.AOS.refreshHard();
-      }catch(error){
-        status.textContent='El tutorial está disponible arriba. El archivo histórico no pudo cargarse temporalmente.';
-        console.error('No se pudo hidratar el índice histórico del blog.',error);
-      }
-    })();
-  </script>
-  <script src="https://unpkg.com/aos@2.3.1/dist/aos.js"></script>
-  <script>if(window.AOS)AOS.init({duration:800,once:true});</script>
-  <script src="../js/main.js" defer></script>
-</body>
-</html>
+  <script>(async function(){const g=document.getElementById('blog-grid'),s=document.getElementById('blog-load-status');if(!g||!s)return;try{const r=await fetch('index-archivo-2026-08-14.html',{cache:'no-store'});if(!r.ok)throw new Error('archive '+r.status);const h=await r.text(),d=new DOMParser().parseFromString(h,'text/html'),a=d.querySelector('section.grid[aria-label="Listado de artículos del blog"]');if(!a)throw new Error('archive grid missing');a.querySelectorAll(':scope > article').forEach(x=>g.appendChild(document.importNode(x,true)));s.remove();if(window.AOS&&typeof window.AOS.refreshHard==='function')window.AOS.refreshHard()}catch(e){s.textContent='El tutorial está disponible arriba. El archivo histórico no pudo cargarse temporalmente.';console.error(e)}})();</script>
+  <script src="https://unpkg.com/aos@2.3.1/dist/aos.js"></script><script>if(window.AOS)AOS.init({duration:800,once:true});</script><script src="../js/main.js" defer></script>
+</body></html>

--- a/blog/tutorial-firma-wallet-tonalli-firma-xec.html
+++ b/blog/tutorial-firma-wallet-tonalli-firma-xec.html
@@ -3,197 +3,71 @@
 <head>
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Tutorial: de Firma Wallet a Tonalli y de FIRMA a XEC | Xolos Ramírez</title>
-  <meta name="description" content="Guía paso a paso para respaldar una seed de Firma Wallet, recuperarla en Tonalli con eCash BIP44 1899, verificar Firma Alpha y redimir FIRMA a XEC mediante Agora.">
+  <title>Tutorial completo: MXN → Bitso → USDT Solana → Firma → Tonalli → XEC | Xolos Ramírez</title>
+  <meta name="description" content="Guía práctica, basada en una prueba mainnet real, para pasar de MXN en Bitso a USDT sobre Solana, fondear Firma, recuperar Firma Alpha en Tonalli y redimirlo por XEC mediante Agora.">
   <link rel="canonical" href="https://xolosramirez.com/blog/tutorial-firma-wallet-tonalli-firma-xec.html">
   <link rel="alternate" hreflang="es-MX" href="https://xolosramirez.com/blog/tutorial-firma-wallet-tonalli-firma-xec.html">
   <link rel="alternate" hreflang="en" href="https://xolosramirez.com/en/blog/firma-wallet-tonalli-firma-xec-tutorial.html">
   <link rel="alternate" hreflang="x-default" href="https://xolosramirez.com/blog/tutorial-firma-wallet-tonalli-firma-xec.html">
   <meta property="og:type" content="article">
-  <meta property="og:locale" content="es_MX">
-  <meta property="og:site_name" content="Xolos Ramírez">
-  <meta property="og:title" content="Firma Wallet → Tonalli → FIRMA → XEC: tutorial de principio a fin">
-  <meta property="og:description" content="Un tutorial basado en una prueba mainnet real: recuperar la misma seed en Tonalli, localizar Firma Alpha y redimirlo por XEC mediante Agora.">
+  <meta property="og:title" content="MXN → Bitso → USDT Solana → Firma → Tonalli → XEC">
+  <meta property="og:description" content="Embudo probado con fondos reales: fiat en México, stablecoin en Solana, Firma Alpha en eCash y redención on-chain a XEC desde Tonalli.">
   <meta property="og:url" content="https://xolosramirez.com/blog/tutorial-firma-wallet-tonalli-firma-xec.html">
   <meta property="og:image" content="https://xolosramirez.com/img/hero/site-hero.jpg">
   <meta name="twitter:card" content="summary_large_image">
-  <meta name="twitter:title" content="Firma Wallet → Tonalli → FIRMA → XEC">
-  <meta name="twitter:description" content="Tutorial didáctico de recuperación de seed, discovery de FIRMA y redención on-chain por XEC.">
-  <meta name="twitter:image" content="https://xolosramirez.com/img/hero/site-hero.jpg">
+  <meta name="twitter:title" content="De pesos a XEC con Firma y Tonalli">
+  <meta name="twitter:description" content="Tutorial mainnet del embudo MXN → USDT Solana → Firma Alpha → Tonalli → XEC.">
   <link rel="stylesheet" href="../css/styles.css">
   <link rel="icon" type="image/x-icon" href="../assets/xolosramirez.ico">
   <script type="application/ld+json">
-  {
-    "@context":"https://schema.org",
-    "@type":"HowTo",
-    "name":"De Firma Wallet a Tonalli y de FIRMA a XEC",
-    "description":"Tutorial para recuperar una seed de Firma Wallet en Tonalli con BIP44 1899, comprobar Firma Alpha y redimir FIRMA por XEC mediante Agora.",
-    "datePublished":"2026-08-14",
-    "dateModified":"2026-08-14",
-    "inLanguage":"es-MX",
-    "url":"https://xolosramirez.com/blog/tutorial-firma-wallet-tonalli-firma-xec.html",
-    "publisher":{"@type":"Organization","name":"Xolos Ramírez","url":"https://xolosramirez.com/"},
-    "step":[
-      {"@type":"HowToStep","name":"Respalda la seed de Firma Wallet","text":"Guarda las 12 palabras fuera de línea y nunca las compartas."},
-      {"@type":"HowToStep","name":"Verifica que el activo sea Firma Alpha","text":"Comprueba el Token ID canónico de FIRMA en eCash antes de seguir."},
-      {"@type":"HowToStep","name":"Restaura la seed en Tonalli","text":"Usa el perfil eCash/Cashtab con BIP44 coin type 1899 y realiza un re-escaneo extendido."},
-      {"@type":"HowToStep","name":"Añade XEC puro para comisiones si hace falta","text":"Los sats asociados a un UTXO token no siempre son combustible XEC libre para una transacción."},
-      {"@type":"HowToStep","name":"Previsualiza la redención","text":"Revisa bid oficial, precio efectivo, XEC esperado, comisión y capacidad del sweeper."},
-      {"@type":"HowToStep","name":"Firma localmente y transmite","text":"Tonalli crea una oferta Agora; al ser aceptada por el sweeper, el saldo XEC se actualiza."}
-    ]
-  }
+  {"@context":"https://schema.org","@type":"HowTo","name":"De MXN a XEC con Bitso, Firma y Tonalli","datePublished":"2026-08-14","dateModified":"2026-08-14","inLanguage":"es-MX","url":"https://xolosramirez.com/blog/tutorial-firma-wallet-tonalli-firma-xec.html","publisher":{"@type":"Organization","name":"Xolos Ramírez"},"step":[{"@type":"HowToStep","name":"Deposita MXN en Bitso y compra USDT","text":"Fondea Bitso con pesos mexicanos y adquiere USDT."},{"@type":"HowToStep","name":"Retira USDT por Solana","text":"Selecciona la red Solana y verifica cuidadosamente la dirección de depósito de Firma."},{"@type":"HowToStep","name":"Fondea firma.cash","text":"Envía el USDT-SPL al flujo de depósito indicado por Firma y espera la acreditación."},{"@type":"HowToStep","name":"Respalda la seed de Firma","text":"Guarda las 12 palabras offline y nunca las compartas."},{"@type":"HowToStep","name":"Restaura en Tonalli con 1899","text":"Importa la misma seed en Tonalli usando eCash/Cashtab BIP44 1899 y re-escanea."},{"@type":"HowToStep","name":"Verifica Firma Alpha","text":"Confirma el Token ID canónico antes de operar."},{"@type":"HowToStep","name":"Redime FIRMA por XEC","text":"Usa el DEX de Tonalli, revisa el preview, firma localmente y espera la aceptación del sweeper."}]}
   </script>
   <style>
-    .guide-wrap{max-width:960px;margin:0 auto;padding:2rem 1rem 4rem}.guide-wrap h1{line-height:1.12}.guide-wrap h2{margin-top:2.4rem}.lede{font-size:1.15rem;line-height:1.7}.flow{display:grid;grid-template-columns:repeat(auto-fit,minmax(145px,1fr));gap:.75rem;margin:1.5rem 0 2rem}.flow div,.callout,.acceptance,.warning{border:1px solid rgba(128,128,128,.35);border-radius:12px;padding:1rem}.flow div{text-align:center;font-weight:600}.arrow{opacity:.65}.callout{background:rgba(30,144,255,.08)}.warning{background:rgba(218,165,32,.10)}.acceptance{background:rgba(46,139,87,.10)}.steps{counter-reset:step}.step{counter-increment:step;margin:1.5rem 0;padding:1.25rem;border-left:4px solid #d4a83f;background:rgba(127,127,127,.06)}.step h3:before{content:counter(step) ". ";color:#b78b24}.code{font-family:ui-monospace,SFMono-Regular,Menlo,monospace;overflow-wrap:anywhere;padding:.75rem;border-radius:8px;background:rgba(0,0,0,.08)}.checklist li{margin:.55rem 0}.meta{opacity:.75;font-size:.95rem}.language-link{margin:1rem 0 2rem}.language-link a{font-weight:600}.small{font-size:.92rem;opacity:.8}
+    .guide-wrap{max-width:980px;margin:0 auto;padding:2rem 1rem 4rem}.guide-wrap h1{line-height:1.12}.guide-wrap h2{margin-top:2.4rem}.lede{font-size:1.15rem;line-height:1.7}.flow{display:grid;grid-template-columns:repeat(auto-fit,minmax(135px,1fr));gap:.7rem;margin:1.5rem 0}.flow div,.callout,.warning,.acceptance{border:1px solid rgba(128,128,128,.35);border-radius:12px;padding:1rem}.flow div{text-align:center;font-weight:600}.warning{background:rgba(218,165,32,.1)}.callout{background:rgba(30,144,255,.08)}.acceptance{background:rgba(46,139,87,.1)}.step{margin:1.5rem 0;padding:1.25rem;border-left:4px solid #d4a83f;background:rgba(127,127,127,.06)}.code{font-family:ui-monospace,monospace;overflow-wrap:anywhere;padding:.75rem;border-radius:8px;background:rgba(0,0,0,.08)}.small{font-size:.92rem;opacity:.8}.meta{opacity:.75}
   </style>
 </head>
 <body>
   <a class="skip-link" href="#contenido-principal">Saltar al contenido principal</a>
-  <header class="site-header">
-    <div class="container header-row">
-      <a class="brand" href="../index.html"><img src="../img/brand/XolosRamirez.jpg" alt="Xolos Ramírez" width="44" height="44"><span>Xolos Ramírez</span></a>
-      <button class="hamburger" aria-expanded="false" aria-controls="menu">☰</button>
-      <nav id="menu" class="nav-menu" data-visible="false" aria-label="Navegación principal"><ul><li><a href="../index.html">Inicio</a></li><li><a href="../xolos-disponibles.html">Xolos disponibles</a></li><li><a href="index.html">Blog</a></li><li><a href="../contacto.html">Contacto</a></li><li><a href="../en/blog/firma-wallet-tonalli-firma-xec-tutorial.html" lang="en">English</a></li></ul></nav>
-    </div>
-  </header>
-
+  <header class="site-header"><div class="container header-row"><a class="brand" href="../index.html"><img src="../img/brand/XolosRamirez.jpg" alt="Xolos Ramírez" width="44" height="44"><span>Xolos Ramírez</span></a><button class="hamburger" aria-expanded="false" aria-controls="menu">☰</button><nav id="menu" class="nav-menu" data-visible="false"><ul><li><a href="../index.html">Inicio</a></li><li><a href="../xolos-disponibles.html">Xolos disponibles</a></li><li><a href="index.html">Blog</a></li><li><a href="../contacto.html">Contacto</a></li><li><a href="../en/blog/firma-wallet-tonalli-firma-xec-tutorial.html" lang="en">English</a></li></ul></nav></div></header>
   <main id="contenido-principal" class="guide-wrap">
-    <p class="meta"><time datetime="2026-08-14">14 de agosto de 2026</time> · Guía técnica · eCash / Firma Alpha / Tonalli Wallet</p>
-    <h1>De Firma Wallet a Tonalli y de FIRMA a XEC: tutorial de principio a fin</h1>
-    <p class="lede">Esta guía reproduce de forma didáctica un embudo que probamos con fondos reales en eCash mainnet: respaldar una seed de Firma Wallet, recuperarla en Tonalli, localizar Firma Alpha bajo el perfil eCash/Cashtab 1899 y redimir FIRMA por XEC mediante una oferta Agora firmada localmente.</p>
-    <p class="language-link"><a href="../en/blog/firma-wallet-tonalli-firma-xec-tutorial.html" hreflang="en">Read this tutorial in English →</a></p>
+    <p class="meta"><time datetime="2026-08-14">14 de agosto de 2026</time> · Tutorial basado en una prueba real sobre mainnet</p>
+    <h1>De pesos mexicanos a XEC: Bitso → USDT Solana → Firma → Tonalli</h1>
+    <p class="lede">Este tutorial documenta un embudo que probamos de principio a fin con fondos reales: depositar MXN en Bitso, comprar USDT, retirarlo por Solana hacia firma.cash, recibir Firma Alpha bajo una seed eCash, recuperar esa misma seed en Tonalli y convertir FIRMA a XEC mediante una oferta Agora on-chain.</p>
 
-    <section class="warning" aria-label="Seguridad">
-      <strong>Regla número uno: tus 12 palabras nunca salen de tus dispositivos.</strong>
-      <p>No pegues la seed en ChatGPT, Telegram, correo, GitHub, formularios, capturas de pantalla ni mensajes de soporte. Para aprender, usa cantidades pequeñas. Si una seed queda expuesta, considérala comprometida.</p>
-    </section>
+    <section class="warning"><strong>Seguridad primero.</strong><p>Nunca compartas tu seed de 12 palabras. Verifica red, dirección, Token ID y cantidades antes de cada envío. Haz la primera prueba con montos pequeños. Las interfaces, requisitos KYC, fees y redes soportadas pueden cambiar con el tiempo.</p></section>
 
-    <h2>El embudo que vamos a construir</h2>
-    <div class="flow" aria-label="Flujo Firma a Tonalli y XEC">
-      <div>Firma Wallet<br><small>seed de 12 palabras</small></div>
-      <div>→</div>
-      <div>eCash 1899<br><small>mismas llaves</small></div>
-      <div>→</div>
-      <div>Tonalli<br><small>scan + autocustodia</small></div>
-      <div>→</div>
-      <div>FIRMA<br><small>ALP on-chain</small></div>
-      <div>→</div>
-      <div>Agora<br><small>oferta de redención</small></div>
-      <div>→</div>
-      <div>XEC<br><small>saldo autocustodiado</small></div>
-    </div>
+    <h2>El embudo completo que quedó probado</h2>
+    <div class="flow"><div>MXN<br><small>Bitso</small></div><div>USDT<br><small>Solana / SPL</small></div><div>firma.cash<br><small>depósito</small></div><div>Firma Alpha<br><small>eCash ALP</small></div><div>Tonalli<br><small>seed 1899</small></div><div>Agora<br><small>redención</small></div><div>XEC<br><small>autocustodia</small></div></div>
 
-    <section class="callout">
-      <strong>Importante: el rail de fondeo y el activo on-chain son dos cosas distintas.</strong>
-      <p>Firma puede presentar métodos de fondeo con stablecoins y otros rails externos. Eso no significa que todo saldo mostrado en la app sea Firma Alpha. Firma Alpha, Firma USD, fCHF y fEUR no deben tratarse como el mismo token. Para seguir esta guía debes comprobar que el activo on-chain es <strong>Firma Alpha (FIRMA)</strong>.</p>
-    </section>
+    <section class="callout"><strong>Qué aprendimos del tramo Solana → eCash.</strong><p>En esta prueba, Solana funcionó como rail de entrada para USDT. Después de enviar USDT-SPL al flujo de firma.cash, el activo que apareció bajo la seed eCash y que Tonalli detectó fue <strong>Firma Alpha</strong>. No hace falta asumir que “FIRMA vive en Solana”: para el usuario, Solana fue el rail de depósito; el activo posteriormente recuperado y gastado por Tonalli fue el token ALP nativo de eCash.</p></section>
 
-    <h2>Antes de empezar</h2>
-    <ul class="checklist">
-      <li>Ten instalada y configurada Firma Wallet.</li>
-      <li>Ten acceso a Tonalli Wallet desde <a href="https://app.tonalli.cash/" rel="noopener">app.tonalli.cash</a> o a la instancia que utilices.</li>
-      <li>Guarda la seed de Firma Wallet en un soporte offline.</li>
-      <li>Empieza con una cantidad que estés dispuesto a usar como prueba.</li>
-      <li>Ten una pequeña cantidad de XEC puro disponible para comisiones.</li>
-    </ul>
+    <h2>Paso a paso</h2>
+    <section class="step"><h3>1. Deposita MXN en Bitso</h3><p>Fondea tu cuenta de Bitso con pesos mexicanos por el método disponible en tu cuenta. Espera a que el saldo quede acreditado.</p></section>
+    <section class="step"><h3>2. Compra USDT</h3><p>Compra USDT con el monto que quieras usar en la prueba. Antes de retirar, confirma que vas a utilizar <strong>Solana</strong> como red de salida y no otra red incompatible.</p></section>
+    <section class="step"><h3>3. Obtén en firma.cash la dirección de depósito correcta</h3><p>En Firma, entra al flujo de fondeo con stablecoins y conecta/selecciona el rail Solana que corresponda. Copia la dirección exactamente como la muestra la aplicación. No reutilices direcciones de pruebas anteriores sin verificar que sigan siendo válidas.</p></section>
+    <section class="step"><h3>4. Envía USDT por Solana desde Bitso</h3><p>En Bitso, retira USDT usando la red Solana hacia la dirección indicada por Firma. Revisa red, dirección y monto antes de confirmar. Espera las confirmaciones necesarias y la acreditación en Firma.</p></section>
+    <section class="step"><h3>5. Respalda las 12 palabras de Firma Wallet</h3><p>Guárdalas offline, en orden exacto. Restaurar esa seed en Tonalli no “mueve” los fondos entre aplicaciones: permite que Tonalli derive las mismas llaves eCash.</p></section>
+    <section class="step"><h3>6. Importa la seed en Tonalli con eCash/Cashtab 1899</h3><div class="code">Perfil: eCash / Cashtab<br>BIP44 coin type: 1899<br>Base: m/44'/1899'/0'/0/0</div><p>Después ejecuta un <strong>re-escaneo extendido</strong>. Si estás recuperando una wallet Tonalli antigua, usa Tonalli Legacy 899; no lo confundas con una seed Firma/Cashtab.</p></section>
+    <section class="step"><h3>7. Verifica que el activo sea Firma Alpha</h3><div class="code">Token ID: 0387947fd575db4fb19a3e322f635dec37fd192b5941625b66bc4b2c3008cbf0<br>Protocolo: ALP · 4 decimales</div><p>No confundas Firma Alpha con Firma USD, fCHF o fEUR.</p></section>
+    <section class="step"><h3>8. Asegura XEC puro para comisiones</h3><p>Los sats ligados a un UTXO token no equivalen siempre a XEC libre para fees. Si Tonalli muestra XEC puro insuficiente, fondea una pequeña cantidad de XEC spendable antes de intentar enviar o redimir FIRMA.</p></section>
+    <section class="step"><h3>9. En el DEX elige “Redimir Firma a XEC”</h3><p>Introduce la cantidad y pulsa <strong>Previsualizar operación</strong>. Revisa FIRMA a bloquear, XEC esperados, precio efectivo, bid oficial, fee estimado y capacidad del sweeper. Tonalli no firma en preview.</p></section>
+    <section class="step"><h3>10. Confirma, firma localmente y transmite</h3><p>Tonalli reconstruye el plan con estado fresco, vuelve a consultar el bid y sólo firma si las condiciones siguen siendo válidas. La transacción crea una oferta Agora on-chain. Cuando el sweeper la acepta, el saldo XEC se actualiza.</p></section>
 
-    <div class="steps">
-      <section class="step">
-        <h3>Crea o abre Firma Wallet y respalda la seed</h3>
-        <p>Cuando Firma Wallet te entregue sus 12 palabras, escríbelas en el orden exacto. No las fotografíes. Esa mnemonic es la raíz criptográfica de la cartera: no estás exportando un “saldo” a Tonalli; estás permitiendo que otra wallet derive las mismas llaves eCash.</p>
-      </section>
-
-      <section class="step">
-        <h3>Fondea Firma por el método compatible con tu versión de la app</h3>
-        <p>Firma puede ofrecer entrada desde fiat o stablecoins y, en determinadas versiones, mostrar una conexión con una wallet de Solana para USDC/USDT/EURC. Sigue siempre el flujo que la aplicación vigente te muestre y completa los requisitos de verificación que correspondan.</p>
-        <p><strong>No avances por nombre o ticker solamente.</strong> Después del fondeo, verifica qué activo terminó bajo tu seed eCash.</p>
-      </section>
-
-      <section class="step">
-        <h3>Comprueba que realmente tienes Firma Alpha</h3>
-        <p>El Firma Alpha usado por Tonalli tiene esta identidad canónica:</p>
-        <div class="code">Token ID: 0387947fd575db4fb19a3e322f635dec37fd192b5941625b66bc4b2c3008cbf0<br>Protocolo: ALP estándar · tipo 0<br>Decimales: 4</div>
-        <p>Si la app o un explorador muestra otro Token ID, no asumas que es el mismo activo.</p>
-      </section>
-
-      <section class="step">
-        <h3>Restaura las mismas 12 palabras en Tonalli</h3>
-        <p>En Tonalli elige restaurar/importar wallet e introduce las mismas 12 palabras <strong>directamente en tu dispositivo</strong>. Para una seed compatible con Firma/Cashtab, el perfil debe ser:</p>
-        <div class="code">eCash / Cashtab<br>BIP44 coin type: 1899<br>Identidad base: m/44'/1899'/0'/0/0</div>
-        <p>Si estás recuperando una wallet histórica creada por Tonalli antes de esta compatibilidad, usa el perfil <strong>Tonalli Legacy 899</strong>. No uses legacy 899 para una seed de Firma/Cashtab sólo porque el número “899” te resulte familiar.</p>
-      </section>
-
-      <section class="step">
-        <h3>Haz un re-escaneo extendido</h3>
-        <p>El saldo puede vivir en otra dirección hija del mismo árbol HD. Pulsa <strong>Re-escanear (extendido)</strong>. Tonalli recorre las ramas de recepción y cambio del perfil activo y suma los UTXOs que realmente controla esa seed.</p>
-        <p>Una comprobación útil es importar la misma seed en Cashtab en un entorno controlado y verificar que ambos clientes encuentran el mismo saldo FIRMA. No es necesario que ambas interfaces estén mostrando en ese momento la misma “dirección de recepción siguiente” para que pertenezcan al mismo árbol HD.</p>
-      </section>
-
-      <section class="step">
-        <h3>Añade XEC puro para dust y comisión si hace falta</h3>
-        <p>Un UTXO que contiene FIRMA también lleva sats, pero esos sats están asociados al output token. Tonalli separa el <strong>XEC puro spendable</strong> de los sats ligados a tokens. Si la wallet indica que no hay XEC puro suficiente, envía una cantidad pequeña de XEC a la dirección eCash canónica de la wallet y espera a que aparezca como spendable.</p>
-      </section>
-
-      <section class="step">
-        <h3>Opcional: prueba primero un envío pequeño de FIRMA</h3>
-        <p>En <strong>Enviar Firma Alpha</strong> puedes enviar una cantidad pequeña a una dirección eCash o alias <code>.xec</code>. Tonalli previsualiza, vuelve a consultar el estado fresco y sólo después deriva los signatories de las rutas HD que poseen los inputs.</p>
-        <p>En nuestra aceptación mainnet previa, una seed de Firma restaurada en Tonalli consiguió descubrir y gastar correctamente el FIRMA que también veía Cashtab.</p>
-      </section>
-
-      <section class="step">
-        <h3>Abre el DEX y elige “Redimir Firma a XEC”</h3>
-        <p>En el mercado XEC ↔ FIRMA, selecciona <strong>Redimir Firma a XEC</strong>, introduce la cantidad y pulsa <strong>Previsualizar operación</strong>. Tonalli no firma durante esta fase.</p>
-        <p>Revisa cinco datos: <strong>FIRMA a bloquear, XEC esperados, precio efectivo, bid oficial y comisión</strong>. Tonalli también consulta la capacidad del sweeper para no crear una redención que no pueda cubrirse.</p>
-      </section>
-
-      <section class="step">
-        <h3>Confirma, firma localmente y transmite</h3>
-        <p>Al confirmar, Tonalli reconstruye el plan con estado fresco. El bid de redención se consulta otra vez; si cambió, la wallet exige una nueva previsualización. Si todo coincide, firma localmente y transmite una <strong>oferta Agora on-chain</strong>.</p>
-        <p>La operación no es un retiro bancario ni una custodia de Tonalli: tus FIRMA quedan bloqueados por el covenant de la oferta hasta que el sweeper la acepta. Al aceptarla, recibes XEC y el saldo de la wallet se actualiza.</p>
-      </section>
-    </div>
-
-    <h2>Prueba mainnet real del 14 de agosto de 2026</h2>
+    <h2>Prueba real del embudo completo</h2>
     <section class="acceptance">
-      <p>Durante la prueba de aceptación de este flujo, Tonalli mostró:</p>
-      <ul>
-        <li><strong>15.2165 FIRMA</strong> a bloquear.</li>
-        <li><strong>2,278,169.6 XEC</strong> estimados a recibir al completarse.</li>
-        <li><strong>149,717.05 XEC/FIRMA</strong> de precio efectivo.</li>
-        <li><strong>149,728.32 XEC/FIRMA</strong> de bid oficial en ese momento.</li>
-        <li><strong>6.68 XEC</strong> de comisión estimada.</li>
-        <li><strong>235,402,964.32 XEC</strong> de capacidad del sweeper mostrada en el preview.</li>
-      </ul>
-      <p>La oferta fue transmitida con:</p>
-      <div class="code">TXID: 1d8a2bd65eed00638ae41d366164df017fecc2d7d69b09d10cd6ae3b4409472a<br>Offer ID: 1d8a2bd65eed00638ae41d366164df017fecc2d7d69b09d10cd6ae3b4409472a:1</div>
-      <p>Después de la aceptación del sweeper, el saldo XEC de la wallet se actualizó. Los precios y la capacidad anteriores son <strong>datos históricos de esa prueba</strong>; no son una cotización para una operación futura.</p>
+      <p>Después de completar MXN → Bitso → USDT Solana → firma.cash → Firma Alpha → Tonalli, realizamos una redención de gran tamaño desde Tonalli:</p>
+      <ul><li><strong>243.328 FIRMA</strong> bloqueados.</li><li><strong>36,385,587.2 XEC</strong> estimados al completarse.</li><li><strong>149,533.08 XEC/FIRMA</strong> de precio efectivo.</li><li><strong>149,578.25 XEC/FIRMA</strong> de bid oficial.</li><li><strong>5.31 XEC</strong> de comisión estimada.</li><li><strong>0.002 FIRMA</strong> de cambio.</li><li><strong>233,453,847.64 XEC</strong> de capacidad del sweeper mostrada.</li></ul>
+      <div class="code">Offer TXID: 49dd6237df7c6574e60440e3709f6293a424c8ce3abd87ee7311ee31ff52e191<br>Offer ID: 49dd6237df7c6574e60440e3709f6293a424c8ce3abd87ee7311ee31ff52e191:1</div>
+      <p>La wallet mostró después un saldo XEC actualizado y conservó <strong>0.0020 FIRMA</strong> de cambio. El saldo total visible de XEC en la wallet no debe confundirse con el payout de esta única redención: podía incluir XEC que ya existía previamente.</p>
+      <p class="small">Todos los precios, fees y capacidades anteriores son datos históricos de la prueba del 14 de agosto de 2026, no una cotización actual.</p>
     </section>
 
-    <h2>Qué está ocurriendo realmente</h2>
-    <p>La parte clave es que <strong>Firma Wallet, Cashtab y Tonalli pueden actuar sobre la misma identidad eCash cuando comparten la misma seed y el mismo esquema de derivación</strong>. Restaurar una seed no mueve los fondos. Los UTXOs permanecen en la blockchain; lo que cambia es la interfaz desde la que derivamos las llaves que los controlan.</p>
-    <p>La redención FIRMA → XEC es otra etapa: Tonalli crea una oferta Agora al bid de redención vigente. El sweeper acepta esa oferta y la liquidación ocurre on-chain.</p>
+    <h2>Qué demuestra y qué no</h2>
+    <p><strong>Sí demuestra:</strong> que un usuario en México pudo recorrer el embudo MXN → USDT-SPL → Firma → Firma Alpha/eCash → Tonalli → XEC, y que la seed de Firma pudo recuperarse en Tonalli para descubrir y gastar esos activos.</p>
+    <p><strong>No demuestra:</strong> la arquitectura interna completa de conversión de Firma, ni que todos sus saldos sean Firma Alpha, ni que Bitso/Firma mantendrán para siempre las mismas redes, fees o requisitos.</p>
 
-    <h2>Problemas frecuentes</h2>
-    <ul class="checklist">
-      <li><strong>“Importé la seed y no veo saldo”:</strong> confirma que el perfil sea eCash/Cashtab 1899 y ejecuta el re-escaneo extendido.</li>
-      <li><strong>“Veo FIRMA pero no puedo enviarlo”:</strong> revisa si tienes XEC puro spendable para dust y comisión.</li>
-      <li><strong>“El bid/oráculo no está disponible”:</strong> no fuerces la firma. Espera y vuelve a generar el preview.</li>
-      <li><strong>“El bid cambió”:</strong> es una protección normal; genera una nueva previsualización.</li>
-      <li><strong>“Mi vieja wallet Tonalli quedó vacía”:</strong> usa el perfil Tonalli Legacy 899, diseñado para reproducir la derivación histórica.</li>
-    </ul>
-
-    <h2>Lo que este tutorial no promete</h2>
-    <section class="warning">
-      <p>Este flujo termina en <strong>XEC bajo autocustodia</strong>. No es por sí mismo un retiro a pesos, dólares o una cuenta bancaria. La disponibilidad de métodos de fondeo, KYC, stablecoins, Solana u otros rails pertenece a los servicios que los ofrecen y puede cambiar.</p>
-      <p>También es esencial distinguir <strong>Firma Alpha</strong> de otros productos con marca Firma. Antes de mover valor, verifica siempre Token ID, red, cantidad, destino y preview.</p>
-    </section>
-
-    <h2>Resumen</h2>
-    <p>El embudo completo es simple de visualizar, pero cada frontera importa:</p>
-    <div class="code">Fondeo en Firma → comprobar Firma Alpha → respaldar seed → restaurar en Tonalli con 1899 → re-escanear → disponer de XEC puro para fees → previsualizar redención → revalidar → firmar localmente → oferta Agora → sweeper → XEC</div>
-    <p class="small">Guía basada en una prueba mainnet controlada realizada el 14 de agosto de 2026. Empieza con cantidades pequeñas y verifica siempre el estado actual de la aplicación y del mercado.</p>
+    <section class="warning"><strong>No publiques tu seed.</strong><p>Los TXIDs son públicos; las 12 palabras no. Guarda la evidencia on-chain y tus comprobantes, pero nunca incluyas la mnemonic en capturas, chats o tickets de soporte.</p></section>
   </main>
-
   <footer class="site-footer"><div class="container"><p>© 2026 Xolos Ramírez.</p></div></footer>
   <script src="../js/main.js" defer></script>
 </body>

--- a/en/blog/firma-wallet-tonalli-firma-xec-tutorial.html
+++ b/en/blog/firma-wallet-tonalli-firma-xec-tutorial.html
@@ -3,186 +3,42 @@
 <head>
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Tutorial: Firma Wallet to Tonalli and FIRMA to XEC | Xolos Ramírez</title>
-  <meta name="description" content="Step-by-step guide to back up a Firma Wallet seed, recover it in Tonalli with eCash BIP44 1899, verify Firma Alpha and redeem FIRMA for XEC through Agora.">
+  <title>Full tutorial: MXN → Bitso → USDT Solana → Firma → Tonalli → XEC | Xolos Ramírez</title>
+  <meta name="description" content="Mainnet-tested guide for moving from MXN in Bitso to USDT on Solana, funding Firma, recovering Firma Alpha in Tonalli and redeeming FIRMA for XEC through Agora.">
   <link rel="canonical" href="https://xolosramirez.com/en/blog/firma-wallet-tonalli-firma-xec-tutorial.html">
   <link rel="alternate" hreflang="es-MX" href="https://xolosramirez.com/blog/tutorial-firma-wallet-tonalli-firma-xec.html">
   <link rel="alternate" hreflang="en" href="https://xolosramirez.com/en/blog/firma-wallet-tonalli-firma-xec-tutorial.html">
-  <link rel="alternate" hreflang="x-default" href="https://xolosramirez.com/blog/tutorial-firma-wallet-tonalli-firma-xec.html">
-  <meta property="og:type" content="article">
-  <meta property="og:locale" content="en_US">
-  <meta property="og:site_name" content="Xolos Ramírez">
-  <meta property="og:title" content="Firma Wallet → Tonalli → FIRMA → XEC: end-to-end tutorial">
-  <meta property="og:description" content="A tutorial based on a real mainnet test: recover the same Firma seed in Tonalli, discover Firma Alpha and redeem it for XEC through Agora.">
-  <meta property="og:url" content="https://xolosramirez.com/en/blog/firma-wallet-tonalli-firma-xec-tutorial.html">
-  <meta property="og:image" content="https://xolosramirez.com/img/hero/site-hero.jpg">
-  <meta name="twitter:card" content="summary_large_image">
-  <meta name="twitter:title" content="Firma Wallet → Tonalli → FIRMA → XEC">
-  <meta name="twitter:description" content="A practical tutorial for seed recovery, FIRMA discovery and on-chain redemption to XEC.">
-  <meta name="twitter:image" content="https://xolosramirez.com/img/hero/site-hero.jpg">
-  <link rel="stylesheet" href="../../css/styles.css">
-  <link rel="icon" type="image/x-icon" href="../../assets/xolosramirez.ico">
-  <script type="application/ld+json">
-  {
-    "@context":"https://schema.org",
-    "@type":"HowTo",
-    "name":"From Firma Wallet to Tonalli and from FIRMA to XEC",
-    "description":"Tutorial for recovering a Firma Wallet seed in Tonalli with BIP44 1899, checking Firma Alpha and redeeming FIRMA for XEC through Agora.",
-    "datePublished":"2026-08-14",
-    "dateModified":"2026-08-14",
-    "inLanguage":"en",
-    "url":"https://xolosramirez.com/en/blog/firma-wallet-tonalli-firma-xec-tutorial.html",
-    "publisher":{"@type":"Organization","name":"Xolos Ramírez","url":"https://xolosramirez.com/"},
-    "step":[
-      {"@type":"HowToStep","name":"Back up the Firma Wallet seed","text":"Store the 12 words offline and never share them."},
-      {"@type":"HowToStep","name":"Verify the asset is Firma Alpha","text":"Check the canonical FIRMA Token ID on eCash before continuing."},
-      {"@type":"HowToStep","name":"Restore the seed in Tonalli","text":"Use the eCash/Cashtab profile with BIP44 coin type 1899 and run an extended rescan."},
-      {"@type":"HowToStep","name":"Add pure XEC for fees if needed","text":"Sats attached to a token UTXO are not necessarily free XEC fuel for a transaction."},
-      {"@type":"HowToStep","name":"Preview the redemption","text":"Review the official bid, effective price, expected XEC, fee and sweeper capacity."},
-      {"@type":"HowToStep","name":"Sign locally and broadcast","text":"Tonalli creates an Agora offer; once the sweeper accepts it, the XEC balance updates."}
-    ]
-  }
-  </script>
-  <style>
-    .guide-wrap{max-width:960px;margin:0 auto;padding:2rem 1rem 4rem}.guide-wrap h1{line-height:1.12}.guide-wrap h2{margin-top:2.4rem}.lede{font-size:1.15rem;line-height:1.7}.flow{display:grid;grid-template-columns:repeat(auto-fit,minmax(145px,1fr));gap:.75rem;margin:1.5rem 0 2rem}.flow div,.callout,.acceptance,.warning{border:1px solid rgba(128,128,128,.35);border-radius:12px;padding:1rem}.flow div{text-align:center;font-weight:600}.callout{background:rgba(30,144,255,.08)}.warning{background:rgba(218,165,32,.10)}.acceptance{background:rgba(46,139,87,.10)}.steps{counter-reset:step}.step{counter-increment:step;margin:1.5rem 0;padding:1.25rem;border-left:4px solid #d4a83f;background:rgba(127,127,127,.06)}.step h3:before{content:counter(step) ". ";color:#b78b24}.code{font-family:ui-monospace,SFMono-Regular,Menlo,monospace;overflow-wrap:anywhere;padding:.75rem;border-radius:8px;background:rgba(0,0,0,.08)}.checklist li{margin:.55rem 0}.meta{opacity:.75;font-size:.95rem}.language-link{margin:1rem 0 2rem}.language-link a{font-weight:600}.small{font-size:.92rem;opacity:.8}
-  </style>
+  <meta property="og:type" content="article"><meta property="og:title" content="MXN → Bitso → USDT Solana → Firma → Tonalli → XEC"><meta property="og:description" content="A real-money mainnet funnel from Mexican pesos to self-custodied XEC through Firma and Tonalli."><meta property="og:image" content="https://xolosramirez.com/img/hero/site-hero.jpg">
+  <link rel="stylesheet" href="../../css/styles.css"><link rel="icon" type="image/x-icon" href="../../assets/xolosramirez.ico">
+  <script type="application/ld+json">{"@context":"https://schema.org","@type":"HowTo","name":"From MXN to XEC with Bitso, Firma and Tonalli","datePublished":"2026-08-14","dateModified":"2026-08-14","inLanguage":"en","publisher":{"@type":"Organization","name":"Xolos Ramírez"}}</script>
+  <style>.guide-wrap{max-width:980px;margin:0 auto;padding:2rem 1rem 4rem}.guide-wrap h1{line-height:1.12}.guide-wrap h2{margin-top:2.4rem}.lede{font-size:1.15rem;line-height:1.7}.flow{display:grid;grid-template-columns:repeat(auto-fit,minmax(135px,1fr));gap:.7rem;margin:1.5rem 0}.flow div,.callout,.warning,.acceptance{border:1px solid rgba(128,128,128,.35);border-radius:12px;padding:1rem}.flow div{text-align:center;font-weight:600}.warning{background:rgba(218,165,32,.1)}.callout{background:rgba(30,144,255,.08)}.acceptance{background:rgba(46,139,87,.1)}.step{margin:1.5rem 0;padding:1.25rem;border-left:4px solid #d4a83f;background:rgba(127,127,127,.06)}.code{font-family:ui-monospace,monospace;overflow-wrap:anywhere;padding:.75rem;border-radius:8px;background:rgba(0,0,0,.08)}.small{font-size:.92rem;opacity:.8}.meta{opacity:.75}</style>
 </head>
 <body>
-  <a class="skip-link" href="#main-content">Skip to main content</a>
-  <header class="site-header">
-    <div class="container header-row">
-      <a class="brand" href="../index.html"><img src="../../img/brand/XolosRamirez.jpg" alt="Xolos Ramírez" width="44" height="44"><span>Xolos Ramírez</span></a>
-      <button class="hamburger" aria-expanded="false" aria-controls="menu">☰</button>
-      <nav id="menu" class="nav-menu" data-visible="false" aria-label="Main navigation"><ul><li><a href="../index.html">Home</a></li><li><a href="../available-xolos.html">Available Xolos</a></li><li><a href="index.html">Blog</a></li><li><a href="../contact.html">Contact</a></li><li><a href="../../blog/tutorial-firma-wallet-tonalli-firma-xec.html" lang="es-MX">Español</a></li></ul></nav>
-    </div>
-  </header>
-
-  <main id="main-content" class="guide-wrap">
-    <p class="meta"><time datetime="2026-08-14">August 14, 2026</time> · Technical guide · eCash / Firma Alpha / Tonalli Wallet</p>
-    <h1>From Firma Wallet to Tonalli and from FIRMA to XEC: an end-to-end tutorial</h1>
-    <p class="lede">This guide turns a real eCash mainnet test into a reproducible learning path: back up a Firma Wallet seed, recover it in Tonalli, discover Firma Alpha under the eCash/Cashtab 1899 profile, and redeem FIRMA for XEC through an Agora offer signed locally.</p>
-    <p class="language-link"><a href="../../blog/tutorial-firma-wallet-tonalli-firma-xec.html" hreflang="es-MX">Leer este tutorial en español →</a></p>
-
-    <section class="warning" aria-label="Security">
-      <strong>Rule number one: your 12 words never leave your devices.</strong>
-      <p>Do not paste the seed into ChatGPT, Telegram, email, GitHub, web forms, screenshots or support messages. Learn with small amounts. If a seed is exposed, treat it as compromised.</p>
-    </section>
-
-    <h2>The funnel we are building</h2>
-    <div class="flow" aria-label="Firma to Tonalli and XEC flow">
-      <div>Firma Wallet<br><small>12-word seed</small></div><div>→</div><div>eCash 1899<br><small>same keys</small></div><div>→</div><div>Tonalli<br><small>scan + self-custody</small></div><div>→</div><div>FIRMA<br><small>ALP on-chain</small></div><div>→</div><div>Agora<br><small>redemption offer</small></div><div>→</div><div>XEC<br><small>self-custodied balance</small></div>
-    </div>
-
-    <section class="callout">
-      <strong>The funding rail and the on-chain asset are separate concepts.</strong>
-      <p>Firma may expose funding methods involving stablecoins or other external rails. That does not mean every balance shown in the app is Firma Alpha. Firma Alpha, Firma USD, fCHF and fEUR should not be treated as the same token. To follow the on-chain portion of this guide, verify that the asset is <strong>Firma Alpha (FIRMA)</strong>.</p>
-    </section>
-
-    <h2>Before you begin</h2>
-    <ul class="checklist">
-      <li>Set up Firma Wallet.</li>
-      <li>Have access to Tonalli Wallet at <a href="https://app.tonalli.cash/" rel="noopener">app.tonalli.cash</a> or the instance you use.</li>
-      <li>Back up the Firma Wallet seed offline.</li>
-      <li>Start with an amount you are comfortable using as a test.</li>
-      <li>Keep a small amount of pure XEC available for transaction fees.</li>
-    </ul>
-
-    <div class="steps">
-      <section class="step">
-        <h3>Create or open Firma Wallet and back up the seed</h3>
-        <p>Write the 12 words down in their exact order. Do not photograph them. The mnemonic is the cryptographic root of the wallet: restoring it in Tonalli does not “send” a balance between apps. It lets another wallet derive the same eCash keys.</p>
-      </section>
-
-      <section class="step">
-        <h3>Fund Firma using the method supported by the current app</h3>
-        <p>Firma may offer fiat or stablecoin funding and, in some versions, a Solana-wallet connection for assets such as USDC, USDT or EURC. Follow the current app flow and complete any verification requirements that apply.</p>
-        <p><strong>Do not continue based on a name or ticker alone.</strong> Verify which on-chain asset ended up under your eCash seed.</p>
-      </section>
-
-      <section class="step">
-        <h3>Verify that you actually hold Firma Alpha</h3>
-        <p>The Firma Alpha supported by Tonalli has this canonical identity:</p>
-        <div class="code">Token ID: 0387947fd575db4fb19a3e322f635dec37fd192b5941625b66bc4b2c3008cbf0<br>Protocol: ALP standard · type 0<br>Decimals: 4</div>
-        <p>If an app or explorer shows a different Token ID, do not assume it is the same asset.</p>
-      </section>
-
-      <section class="step">
-        <h3>Restore the same 12 words in Tonalli</h3>
-        <p>Choose wallet restore/import and enter the same 12 words <strong>directly on your device</strong>. For a Firma/Cashtab-compatible seed, Tonalli should use:</p>
-        <div class="code">eCash / Cashtab<br>BIP44 coin type: 1899<br>Base identity: m/44'/1899'/0'/0/0</div>
-        <p>If you are recovering an old Tonalli wallet created before this compatibility layer, use <strong>Tonalli Legacy 899</strong>. Do not use Legacy 899 for a Firma/Cashtab seed merely because “899” looks familiar.</p>
-      </section>
-
-      <section class="step">
-        <h3>Run an extended rescan</h3>
-        <p>The balance may live at a different child address within the same HD tree. Use <strong>Extended rescan</strong>. Tonalli scans receive/change branches for the active profile and aggregates UTXOs controlled by that seed.</p>
-        <p>A useful cross-check is to restore the same seed in Cashtab in a controlled environment and verify that both clients discover the same FIRMA balance. The interfaces do not necessarily have to display the same “next receive address” at a given moment for the UTXOs to belong to the same HD tree.</p>
-      </section>
-
-      <section class="step">
-        <h3>Add pure XEC for dust and fees if needed</h3>
-        <p>A UTXO containing FIRMA also carries sats, but those sats are attached to the token output. Tonalli separates <strong>pure spendable XEC</strong> from sats attached to token UTXOs. If the wallet reports insufficient pure XEC, send a small amount of XEC to the wallet's canonical eCash address and wait for it to become spendable.</p>
-      </section>
-
-      <section class="step">
-        <h3>Optional: first test a small FIRMA send</h3>
-        <p>Under <strong>Send Firma Alpha</strong>, send a small amount to an eCash address or <code>.xec</code> alias. Tonalli previews the transaction, refreshes state, and only then derives the signatories for the exact HD paths that own the selected inputs.</p>
-      </section>
-
-      <section class="step">
-        <h3>Open the DEX and choose “Redeem Firma to XEC”</h3>
-        <p>In the XEC ↔ FIRMA market, choose <strong>Redeem Firma to XEC</strong>, enter the amount and press <strong>Preview operation</strong>. Nothing is signed during preview.</p>
-        <p>Review five key values: <strong>FIRMA to lock, expected XEC, effective price, official bid and estimated fee</strong>. Tonalli also checks sweeper capacity before the offer is created.</p>
-      </section>
-
-      <section class="step">
-        <h3>Confirm, sign locally and broadcast</h3>
-        <p>At confirmation time, Tonalli rebuilds the plan from fresh state. It queries the redemption bid again; if the bid changed, the wallet requires a new preview. If all checks match, Tonalli signs locally and broadcasts an <strong>on-chain Agora offer</strong>.</p>
-        <p>This is not a bank withdrawal and Tonalli does not take custody. FIRMA is locked by the offer covenant until the sweeper accepts it. Once accepted, XEC arrives and the wallet balance updates.</p>
-      </section>
-    </div>
-
-    <h2>Real mainnet acceptance test — August 14, 2026</h2>
-    <section class="acceptance">
-      <p>During the controlled acceptance test, Tonalli displayed:</p>
-      <ul>
-        <li><strong>15.2165 FIRMA</strong> to lock.</li>
-        <li><strong>2,278,169.6 XEC</strong> estimated to receive on completion.</li>
-        <li><strong>149,717.05 XEC/FIRMA</strong> effective price.</li>
-        <li><strong>149,728.32 XEC/FIRMA</strong> official bid at that moment.</li>
-        <li><strong>6.68 XEC</strong> estimated fee.</li>
-        <li><strong>235,402,964.32 XEC</strong> sweeper capacity shown in preview.</li>
-      </ul>
-      <p>The redemption offer was broadcast as:</p>
-      <div class="code">TXID: 1d8a2bd65eed00638ae41d366164df017fecc2d7d69b09d10cd6ae3b4409472a<br>Offer ID: 1d8a2bd65eed00638ae41d366164df017fecc2d7d69b09d10cd6ae3b4409472a:1</div>
-      <p>After sweeper acceptance, the wallet's XEC balance updated. These prices and capacity figures are <strong>historical test data</strong>, not a quote for a future trade.</p>
-    </section>
-
-    <h2>What is actually happening</h2>
-    <p><strong>Firma Wallet, Cashtab and Tonalli can operate on the same eCash identity when they share the same seed and derivation scheme.</strong> Restoring a seed does not move funds; the UTXOs remain on the blockchain. A different interface simply derives the keys that control them.</p>
-    <p>FIRMA → XEC redemption is a second step: Tonalli creates an Agora offer at the current redemption bid. The sweeper accepts that offer and settlement happens on-chain.</p>
-
-    <h2>Common problems</h2>
-    <ul class="checklist">
-      <li><strong>“I restored the seed but see no balance”:</strong> verify eCash/Cashtab 1899 and run an extended rescan.</li>
-      <li><strong>“I see FIRMA but cannot send it”:</strong> check for pure spendable XEC to pay dust and fees.</li>
-      <li><strong>“The bid/oracle is unavailable”:</strong> do not bypass the protection; wait and generate a fresh preview later.</li>
-      <li><strong>“The bid changed”:</strong> this is normal protection; generate a new preview.</li>
-      <li><strong>“My old Tonalli wallet looks empty”:</strong> use Tonalli Legacy 899, which reproduces the historical derivation engine.</li>
-    </ul>
-
-    <h2>What this tutorial does not promise</h2>
-    <section class="warning">
-      <p>This funnel ends in <strong>self-custodied XEC</strong>. It is not, by itself, a withdrawal to pesos, dollars or a bank account. Funding methods, KYC, stablecoin, Solana and other external rails belong to the services that provide them and may change.</p>
-      <p>Also keep <strong>Firma Alpha</strong> distinct from other Firma-branded assets. Before moving value, always verify Token ID, network, amount, destination and preview.</p>
-    </section>
-
-    <h2>Summary</h2>
-    <div class="code">Fund Firma → verify Firma Alpha → back up seed → restore in Tonalli with 1899 → extended rescan → fund pure XEC for fees → preview redemption → fresh-state revalidation → local signature → Agora offer → sweeper → XEC</div>
-    <p class="small">Guide based on a controlled mainnet test performed on August 14, 2026. Start small and always verify the current application and market state.</p>
-  </main>
-
-  <footer class="site-footer"><div class="container"><p>© 2026 Xolos Ramírez.</p></div></footer>
-  <script src="../../js/main.js" defer></script>
-</body>
-</html>
+<a class="skip-link" href="#main-content">Skip to main content</a>
+<header class="site-header"><div class="container header-row"><a class="brand" href="../index.html"><img src="../../img/brand/XolosRamirez.jpg" alt="Xolos Ramírez" width="44" height="44"><span>Xolos Ramírez</span></a><button class="hamburger" aria-expanded="false" aria-controls="menu">☰</button><nav id="menu" class="nav-menu" data-visible="false"><ul><li><a href="../index.html">Home</a></li><li><a href="../available-xolos.html">Available Xolos</a></li><li><a href="index.html">Blog</a></li><li><a href="../contact.html">Contact</a></li><li><a href="../../blog/tutorial-firma-wallet-tonalli-firma-xec.html" lang="es-MX">Español</a></li></ul></nav></div></header>
+<main id="main-content" class="guide-wrap">
+<p class="meta"><time datetime="2026-08-14">August 14, 2026</time> · Tutorial based on a real mainnet test</p>
+<h1>From Mexican pesos to XEC: Bitso → USDT Solana → Firma → Tonalli</h1>
+<p class="lede">This guide documents a funnel tested end-to-end with real funds: deposit MXN into Bitso, buy USDT, withdraw it over Solana to firma.cash, receive Firma Alpha under an eCash seed, recover that same seed in Tonalli, and redeem FIRMA for XEC through an on-chain Agora offer.</p>
+<section class="warning"><strong>Security first.</strong><p>Never share the 12-word seed. Verify network, destination, Token ID and amount before every transfer. Start with a small test amount. Interfaces, KYC requirements, fees and supported networks can change.</p></section>
+<h2>The full tested funnel</h2>
+<div class="flow"><div>MXN<br><small>Bitso</small></div><div>USDT<br><small>Solana / SPL</small></div><div>firma.cash<br><small>deposit</small></div><div>Firma Alpha<br><small>eCash ALP</small></div><div>Tonalli<br><small>seed 1899</small></div><div>Agora<br><small>redemption</small></div><div>XEC<br><small>self-custody</small></div></div>
+<section class="callout"><strong>What the Solana → eCash step showed.</strong><p>In this test Solana served as the inbound rail for USDT. After the USDT-SPL deposit into Firma, the asset controlled by the eCash seed and later discovered by Tonalli was <strong>Firma Alpha</strong>. For the user, Solana was the funding rail; the asset subsequently recovered and spent by Tonalli was the native eCash ALP token.</p></section>
+<h2>Step by step</h2>
+<section class="step"><h3>1. Deposit MXN into Bitso</h3><p>Fund your Bitso account with Mexican pesos using a method available to you and wait for the balance to settle.</p></section>
+<section class="step"><h3>2. Buy USDT</h3><p>Buy the amount of USDT you want to use. Before withdrawal, make sure the network is <strong>Solana</strong>, not another chain.</p></section>
+<section class="step"><h3>3. Get the correct Firma deposit destination</h3><p>Open the stablecoin funding flow in Firma and use the Solana rail shown by the current app. Copy the destination exactly as displayed and re-check it before use.</p></section>
+<section class="step"><h3>4. Withdraw USDT over Solana from Bitso</h3><p>Send USDT-SPL from Bitso to the Firma deposit destination. Double-check network, address and amount, then wait for settlement in Firma.</p></section>
+<section class="step"><h3>5. Back up the Firma Wallet seed</h3><p>Store the 12 words offline, in exact order. Restoring the seed in Tonalli does not transfer funds between apps; it lets Tonalli derive the same eCash keys.</p></section>
+<section class="step"><h3>6. Restore the seed in Tonalli using eCash/Cashtab 1899</h3><div class="code">Profile: eCash / Cashtab<br>BIP44 coin type: 1899<br>Base: m/44'/1899'/0'/0/0</div><p>Then run an <strong>extended rescan</strong>. Use Tonalli Legacy 899 only for historical Tonalli wallets, not for a Firma/Cashtab seed.</p></section>
+<section class="step"><h3>7. Verify the asset is Firma Alpha</h3><div class="code">Token ID: 0387947fd575db4fb19a3e322f635dec37fd192b5941625b66bc4b2c3008cbf0<br>Protocol: ALP · 4 decimals</div><p>Do not confuse Firma Alpha with Firma USD, fCHF or fEUR.</p></section>
+<section class="step"><h3>8. Make sure you have pure XEC for fees</h3><p>Sats attached to a token UTXO are not always free XEC fuel. If Tonalli reports insufficient pure XEC, add a small spendable XEC UTXO first.</p></section>
+<section class="step"><h3>9. In the DEX choose “Redeem Firma to XEC”</h3><p>Enter the amount and preview the operation. Review FIRMA locked, expected XEC, effective price, official bid, estimated fee and sweeper capacity. Nothing is signed during preview.</p></section>
+<section class="step"><h3>10. Confirm, sign locally and broadcast</h3><p>Tonalli rebuilds from fresh state, queries the bid again and only signs if the checks still pass. The transaction creates an on-chain Agora offer. When the sweeper accepts it, the XEC balance updates.</p></section>
+<h2>Real full-funnel acceptance test</h2>
+<section class="acceptance"><p>After completing MXN → Bitso → USDT Solana → firma.cash → Firma Alpha → Tonalli, a larger redemption was executed from Tonalli:</p><ul><li><strong>243.328 FIRMA</strong> locked.</li><li><strong>36,385,587.2 XEC</strong> estimated on completion.</li><li><strong>149,533.08 XEC/FIRMA</strong> effective price.</li><li><strong>149,578.25 XEC/FIRMA</strong> official bid.</li><li><strong>5.31 XEC</strong> estimated fee.</li><li><strong>0.002 FIRMA</strong> change.</li><li><strong>233,453,847.64 XEC</strong> sweeper capacity shown.</li></ul><div class="code">Offer TXID: 49dd6237df7c6574e60440e3709f6293a424c8ce3abd87ee7311ee31ff52e191<br>Offer ID: 49dd6237df7c6574e60440e3709f6293a424c8ce3abd87ee7311ee31ff52e191:1</div><p>The wallet later showed the updated XEC balance and retained <strong>0.0020 FIRMA</strong> change. The total XEC wallet balance should not be confused with the payout of this single redemption because pre-existing XEC may already have been present.</p><p class="small">All prices, fees and capacity figures are historical data from August 14, 2026, not a current quote.</p></section>
+<h2>What this does and does not prove</h2><p><strong>It does prove:</strong> that a user in Mexico successfully traversed MXN → USDT-SPL → Firma → Firma Alpha/eCash → Tonalli → XEC, and that the Firma seed could be recovered in Tonalli to discover and spend the resulting asset.</p><p><strong>It does not prove:</strong> Firma's entire internal conversion architecture, that every Firma balance is Firma Alpha, or that Bitso/Firma will permanently keep the same networks, fees or requirements.</p>
+<section class="warning"><strong>Never publish the seed.</strong><p>TXIDs are public; the 12 words are not. Keep on-chain evidence and receipts, but never include the mnemonic in screenshots, chats or support tickets.</p></section>
+</main>
+<footer class="site-footer"><div class="container"><p>© 2026 Xolos Ramírez.</p></div></footer><script src="../../js/main.js" defer></script>
+</body></html>


### PR DESCRIPTION
## Resumen

Actualiza el tutorial bilingüe para incorporar la prueba completa realizada con fondos reales el 14 de agosto de 2026:

`MXN → Bitso → USDT sobre Solana → firma.cash → Firma Alpha en eCash → seed 1899 → Tonalli → Agora → XEC`

## Cambios

- tutorial ES reescrito con el embudo completo de fiat a XEC;
- tutorial EN actualizado con el mismo flujo;
- tarjeta destacada del índice ES actualizada;
- nueva evidencia mainnet de redención de 243.328 FIRMA;
- Offer TXID `49dd6237df7c6574e60440e3709f6293a424c8ce3abd87ee7311ee31ff52e191`;
- aclaración de que Solana actuó como rail de entrada de USDT y que Tonalli recuperó Firma Alpha nativo de eCash;
- distinción explícita entre payout de la redención y saldo total de XEC de la wallet;
- advertencias sobre seed, red, Token ID, XEC puro para fees y compatibilidad 1899 vs Legacy 899.

No se publican seeds ni datos privados. Los precios/fees/capacidad se presentan como datos históricos, no como cotización actual.