### PR TITLE
Namespace internal generate_lead event

### DIFF
--- a/js/main.js
+++ b/js/main.js
@@ -122,7 +122,7 @@ function getLeadIntent(element) {
 function buildLeadPayload(element) {
   const lang = element.dataset.lang || document.documentElement.lang;
   return {
-    event: 'generate_lead',
+    event: 'xolos_generate_lead',
     lead_channel: getLeadChannel(element),
     cta_location: getCtaLocation(element),
     lead_intent: getLeadIntent(element),

--- a/scripts/test-generate-lead-tracking.mjs
+++ b/scripts/test-generate-lead-tracking.mjs
@@ -21,7 +21,7 @@ function formTag(html) {
 
 includes(main, "document.addEventListener('click'", 'Expected delegated click listener');
 includes(main, "target.closest('[data-lead-type=\"generate_lead\"]')", 'Expected closest() based lead lookup');
-includes(main, "event: 'generate_lead'", 'Expected generate_lead event push');
+includes(main, "event: 'xolos_generate_lead'", 'Expected xolos_generate_lead event push');
 includes(main, "if (cta === 'video_call') return 'video_call';", 'Expected video_call lead channel');
 
 for (const key of [


### PR DESCRIPTION
Migrates the site's internal Data Layer event from `generate_lead`
to `xolos_generate_lead`.

GA4 continues to receive the analytics event as `generate_lead`
through GTM.

Changes:
- Update the internal Data Layer event name in `js/main.js`
- Update the corresponding automated expectation
- Preserve all seven lead parameters unchanged:
  - lead_channel
  - cta_location
  - lead_intent
  - profile
  - profile_status
  - page_type
  - lang

GTM was prepared beforehand to temporarily listen for both
`generate_lead` and `xolos_generate_lead`, allowing a zero-downtime
migration.

Validation:
- `node --check js/main.js` passes
- `node --check scripts/test-generate-lead-tracking.mjs` passes
- `git diff --check` passes
- Scope: 2 files, 2 insertions, 2 deletions

Known pre-existing issue:
`npm run test:generate-lead` fails on:
`AssertionError: generate_lead must not send href or Click URL`

The same failure reproduces on the base `main` commit and is unrelated
to this namespace migration.

Architecture after deployment:

`xolos_generate_lead` in Data Layer → GTM → `generate_lead` in GA4.