### PR TITLE
Actualizar enlace de WhatsApp por enlace QR en todo el sitio

### DIFF
--- a/blog/precio-xoloitzcuintle.html
+++ b/blog/precio-xoloitzcuintle.html
@@ -363,7 +363,7 @@
               <p style="margin-top: 1.25rem; margin-bottom: 0.75rem;">Solicita una orientación personalizada por:</p>
               <p style="display: flex; flex-wrap: wrap; justify-content: center; gap: 1rem; margin: 0;">
                 <a
-                  href="https://wa.me/525518555993?text=Hola%2C%20quisiera%20recibir%20orientaci%C3%B3n%20sobre%20el%20proceso%20de%20Xolos%20Ram%C3%ADrez."
+                  href="https://wa.me/qr/R2F5PRQYZSJOA1"
                   data-cta="whatsapp"
                   data-lead-type="generate_lead"
                   data-lead-intent="price_inquiry"

--- a/en/available-xolos.html
+++ b/en/available-xolos.html
@@ -93,7 +93,7 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
       </ul>
       <div class="puppy-card__actions">
         <a href="mailto:contacto@xolosarmy.xyz?subject=Inquiry%20about%20Xoloitzcuintli%20puppies" class="btn-small btn-primary-small cta-lead cta-email" data-cta="email" data-lead-type="generate_lead" data-profile="general" data-page-type="available-xolos" data-lang="en" aria-label="Contact by email about Xoloitzcuintli puppies">Contact by email</a>
-        <a href="https://wa.me/525518555993" class="btn-small btn-primary-small cta-lead cta-whatsapp" data-cta="whatsapp" data-lead-type="generate_lead" data-profile="general" data-page-type="available-xolos" data-lang="en" aria-label="Contact by WhatsApp about Xoloitzcuintli puppies">Contact by WhatsApp</a>
+        <a href="https://wa.me/qr/R2F5PRQYZSJOA1" class="btn-small btn-primary-small cta-lead cta-whatsapp" data-cta="whatsapp" data-lead-type="generate_lead" data-profile="general" data-page-type="available-xolos" data-lang="en" aria-label="Contact by WhatsApp about Xoloitzcuintli puppies">Contact by WhatsApp</a>
       </div>
     </section>
 

--- a/en/blog/xoloitzcuintli-price.html
+++ b/en/blog/xoloitzcuintli-price.html
@@ -360,7 +360,7 @@
               <p style="margin-top: 1.25rem; margin-bottom: 0.75rem;">Request personalized guidance by:</p>
               <p style="display: flex; flex-wrap: wrap; justify-content: center; gap: 1rem; margin: 0;">
                 <a
-                  href="https://wa.me/525518555993?text=Hello%2C%20I%20would%20like%20guidance%20about%20the%20Xolos%20Ram%C3%ADrez%20process."
+                  href="https://wa.me/qr/R2F5PRQYZSJOA1"
                   data-cta="whatsapp"
                   data-lead-type="generate_lead"
                   data-lead-intent="price_inquiry"

--- a/js/main.js
+++ b/js/main.js
@@ -317,7 +317,7 @@ function updateAvailableXolosCtas() {
     'a.home-email-float.video-call-float, a.home-email-float[data-cta="video_call"]',
   );
   if (floatingCta) {
-    floatingCta.href = 'https://wa.me/525518555993';
+    floatingCta.href = 'https://wa.me/qr/R2F5PRQYZSJOA1';
     floatingCta.target = '_blank';
     floatingCta.rel = 'noopener noreferrer';
     floatingCta.setAttribute('aria-label', labels.whatsappAria);

--- a/scripts/test-generate-lead-tracking.mjs
+++ b/scripts/test-generate-lead-tracking.mjs
@@ -3,7 +3,10 @@ import { readFileSync } from 'node:fs';
 
 const read = (path) => readFileSync(path, 'utf8');
 const main = read('js/main.js');
-const leadCode = main.slice(main.indexOf('function getLeadElement'));
+const leadCode = main.slice(
+  main.indexOf('function getLeadElement'),
+  main.indexOf('function initializePuppyCarousels')
+);
 
 function includes(haystack, needle, message) {
   assert.ok(haystack.includes(needle), message || 'Expected to find ' + needle);
@@ -192,7 +195,7 @@ for (const expectation of floatingVideoCallExpectations) {
 
   includes(
     html,
-    'href="https://wa.me/525518555993"',
+    'href="https://wa.me/qr/R2F5PRQYZSJOA1"',
     expectation.path + ' must keep the non-floating WhatsApp CTA'
   );
 

--- a/xolos-disponibles.html
+++ b/xolos-disponibles.html
@@ -140,7 +140,7 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
         </ul>
         <div class="puppy-card__actions">
           <a href="mailto:contacto@xolosarmy.xyz?subject=Consulta%20sobre%20xoloitzcuintles" class="btn-small btn-primary-small cta-lead cta-email" data-cta="email" data-lead-type="generate_lead" data-profile="general" data-page-type="available-xolos" data-lang="es" aria-label="Escribir por correo sobre xoloitzcuintles">Escribir por correo</a>
-          <a href="https://wa.me/525518555993" class="btn-small btn-primary-small cta-lead cta-whatsapp" data-cta="whatsapp" data-lead-type="generate_lead" data-profile="general" data-page-type="available-xolos" data-lang="es" aria-label="Consultar por WhatsApp sobre xoloitzcuintles">Consultar por WhatsApp</a>
+          <a href="https://wa.me/qr/R2F5PRQYZSJOA1" class="btn-small btn-primary-small cta-lead cta-whatsapp" data-cta="whatsapp" data-lead-type="generate_lead" data-profile="general" data-page-type="available-xolos" data-lang="es" aria-label="Consultar por WhatsApp sobre xoloitzcuintles">Consultar por WhatsApp</a>
         </div>
       </section>
 


### PR DESCRIPTION
### Motivation

- Sustituir el enlace de WhatsApp antiguo por el nuevo `https://wa.me/qr/R2F5PRQYZSJOA1` en los CTAs donde corresponde para dirigir a usuarios al código QR de contacto. 
- Asegurar que el enlace dinámico del botón flotante y las pruebas de seguimiento de leads reflejen el cambio.

### Description

- Reemplazado el `href` de WhatsApp por `https://wa.me/qr/R2F5PRQYZSJOA1` en las páginas estáticas `xolos-disponibles.html`, `en/available-xolos.html`, `blog/precio-xoloitzcuintle.html` y `en/blog/xoloitzcuintli-price.html`. 
- Actualizado el enlace del CTA flotante en `js/main.js` para usar el nuevo `wa.me/qr` en lugar del número antiguo. 
- Ajustada la prueba `scripts/test-generate-lead-tracking.mjs` para validar la nueva URL y para limitar el análisis al bloque de código relevante de generación de leads. 

### Testing

- Ejecutado `npm run test:generate-lead` y la comprobación de tracking de `generate_lead` pasó correctamente. 
- Ejecutado `npm run lint:html` (`htmlhint`) y no se encontraron errores de HTML. 
- Verificado con búsqueda que no quedan referencias al URL antiguo `https://wa.me/525518555993` y la comprobación retornó "No old WhatsApp URL remains". 
- Ejecutado `git diff --check` sin problemas detectados.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a88643d7e408332b93aa08ee6722648)