### PR TITLE
feat: add new Xilonen YouTube Short to available profiles

### DIFF
--- a/js/main.js
+++ b/js/main.js
@@ -341,15 +341,33 @@ function updateAvailableXolosCtas() {
 }
 
 function updateXilonenProfileVideo() {
-  const videoUrl = 'https://www.youtube.com/embed/nrZ-PhE4bHA';
+  const existingVideoUrl = 'https://www.youtube.com/embed/nrZ-PhE4bHA';
+  const newShortUrl = 'https://www.youtube.com/embed/cDpeJ2UQNHE';
   const grid = getAvailableXolosGrid();
   if (!grid) return;
+
+  const isEnglish = document.documentElement.lang.toLowerCase().startsWith('en');
+  const newShortTitle = isEnglish
+    ? 'Xilonen Ramirez miniature Xoloitzcuintli puppy exploring the world'
+    : 'Xilonen Ramirez, bebé xoloitzcuintle miniatura explorando el mundo';
 
   Array.from(grid.querySelectorAll('.puppy-card')).forEach((card) => {
     const name = card.querySelector('.puppy-card__name')?.textContent.trim();
     if (name !== 'Xilonen Ramirez') return;
-    const iframe = card.querySelector('.puppy-video-container iframe');
-    if (iframe) iframe.setAttribute('src', videoUrl);
+
+    const existingVideo = card.querySelector('.puppy-video-container');
+    const existingIframe = existingVideo?.querySelector('iframe');
+    if (existingIframe) existingIframe.setAttribute('src', existingVideoUrl);
+    if (!existingVideo || card.querySelector('[data-xilonen-video="cDpeJ2UQNHE"]')) return;
+
+    const newVideo = existingVideo.cloneNode(true);
+    newVideo.dataset.xilonenVideo = 'cDpeJ2UQNHE';
+    const newIframe = newVideo.querySelector('iframe');
+    if (newIframe) {
+      newIframe.setAttribute('src', newShortUrl);
+      newIframe.setAttribute('title', newShortTitle);
+    }
+    existingVideo.insertAdjacentElement('afterend', newVideo);
   });
 }
 


### PR DESCRIPTION
## Summary
- Add the new Xilonen Ramirez YouTube Short (`cDpeJ2UQNHE`) to her available profile.
- Preserve the existing Xilonen video and render the new Short as a second embedded video.
- Apply the profile enhancement to both Spanish and English available-Xolos pages through the shared page logic.
- Use localized iframe titles and prevent duplicate insertion.

## Scope
- `js/main.js` only
- No CTA, availability, pricing, wallet, or unrelated profile changes.