### PR TITLE
SEO: Add Precio to home title and align og:title

### DIFF
--- a/index.html
+++ b/index.html
@@ -11,7 +11,7 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <link rel="canonical" href="https://xolosramirez.com/" />
-    <title>Criadero de Xoloitzcuintles: Venta y Adopción | Xolos Ramírez CDMX</title>
+    <title>Criadero de Xoloitzcuintles: Precio, Venta y Adopción | Xolos Ramírez CDMX</title>
     <meta
       name="description"
       content="Bienvenido al criadero de xoloitzcuintles Xolos Ramírez. Preservamos la raza miniatura, intermedia y estándar. Conoce el precio, salud y ejemplares en venta."
@@ -20,7 +20,7 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
       name="keywords"
       content="xoloitzcuintle, xolo, adopción responsable, perro sin pelo mexicano, comunidad xolo, cultura mexicana"
     />
-    <meta property="og:title" content="Xolos Ramírez – Comunidad dedicada al xoloitzcuintle" />
+    <meta property="og:title" content="Criadero de Xoloitzcuintles: Precio, Venta y Adopción | Xolos Ramírez CDMX" />
     <meta
       property="og:description"
       content="Descubre la comunidad Xolos Ramírez: historia, adopciones responsables, galería y testimonios sobre el xoloitzcuintle en México."


### PR DESCRIPTION
Controlled SEO experiment for the query `xoloitzcuintle precio`.

Search Console shows the homepage receives the overwhelming majority of impressions for this query.

Changes:
- Add singular `Precio` to the homepage title
- Align `og:title` with the HTML title
- Leave meta description, H1, content and internal links unchanged

Goal:
Improve CTR for `xoloitzcuintle precio` while preserving existing relevance for criadero, venta, adopción and CDMX.

Scope:
- 1 file
- 2 insertions
- 2 deletions