### PR TITLE
Reemplazar enlaces de WhatsApp por `https://wa.me/525518555993`

### DIFF
--- a/blog/precio-xoloitzcuintle.html
+++ b/blog/precio-xoloitzcuintle.html
@@ -363,7 +363,7 @@
               <p style="margin-top: 1.25rem; margin-bottom: 0.75rem;">Solicita una orientación personalizada por:</p>
               <p style="display: flex; flex-wrap: wrap; justify-content: center; gap: 1rem; margin: 0;">
                 <a
-                  href="https://wa.me/qr/R2F5PRQYZSJOA1"
+                  href="https://wa.me/525518555993"
                   data-cta="whatsapp"
                   data-lead-type="generate_lead"
                   data-lead-intent="price_inquiry"

--- a/en/available-xolos.html
+++ b/en/available-xolos.html
@@ -93,7 +93,7 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
       </ul>
       <div class="puppy-card__actions">
         <a href="mailto:contacto@xolosarmy.xyz?subject=Inquiry%20about%20Xoloitzcuintli%20puppies" class="btn-small btn-primary-small cta-lead cta-email" data-cta="email" data-lead-type="generate_lead" data-profile="general" data-page-type="available-xolos" data-lang="en" aria-label="Contact by email about Xoloitzcuintli puppies">Contact by email</a>
-        <a href="https://wa.me/qr/R2F5PRQYZSJOA1" class="btn-small btn-primary-small cta-lead cta-whatsapp" data-cta="whatsapp" data-lead-type="generate_lead" data-profile="general" data-page-type="available-xolos" data-lang="en" aria-label="Contact by WhatsApp about Xoloitzcuintli puppies">Contact by WhatsApp</a>
+        <a href="https://wa.me/525518555993" class="btn-small btn-primary-small cta-lead cta-whatsapp" data-cta="whatsapp" data-lead-type="generate_lead" data-profile="general" data-page-type="available-xolos" data-lang="en" aria-label="Contact by WhatsApp about Xoloitzcuintli puppies">Contact by WhatsApp</a>
       </div>
     </section>
 

--- a/en/blog/xoloitzcuintli-price.html
+++ b/en/blog/xoloitzcuintli-price.html
@@ -360,7 +360,7 @@
               <p style="margin-top: 1.25rem; margin-bottom: 0.75rem;">Request personalized guidance by:</p>
               <p style="display: flex; flex-wrap: wrap; justify-content: center; gap: 1rem; margin: 0;">
                 <a
-                  href="https://wa.me/qr/R2F5PRQYZSJOA1"
+                  href="https://wa.me/525518555993"
                   data-cta="whatsapp"
                   data-lead-type="generate_lead"
                   data-lead-intent="price_inquiry"

--- a/js/main.js
+++ b/js/main.js
@@ -317,7 +317,7 @@ function updateAvailableXolosCtas() {
     'a.home-email-float.video-call-float, a.home-email-float[data-cta="video_call"]',
   );
   if (floatingCta) {
-    floatingCta.href = 'https://wa.me/qr/R2F5PRQYZSJOA1';
+    floatingCta.href = 'https://wa.me/525518555993';
     floatingCta.target = '_blank';
     floatingCta.rel = 'noopener noreferrer';
     floatingCta.setAttribute('aria-label', labels.whatsappAria);

--- a/scripts/test-generate-lead-tracking.mjs
+++ b/scripts/test-generate-lead-tracking.mjs
@@ -195,7 +195,7 @@ for (const expectation of floatingVideoCallExpectations) {
 
   includes(
     html,
-    'href="https://wa.me/qr/R2F5PRQYZSJOA1"',
+    'href="https://wa.me/525518555993"',
     expectation.path + ' must keep the non-floating WhatsApp CTA'
   );
 

--- a/xolos-disponibles.html
+++ b/xolos-disponibles.html
@@ -140,7 +140,7 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
         </ul>
         <div class="puppy-card__actions">
           <a href="mailto:contacto@xolosarmy.xyz?subject=Consulta%20sobre%20xoloitzcuintles" class="btn-small btn-primary-small cta-lead cta-email" data-cta="email" data-lead-type="generate_lead" data-profile="general" data-page-type="available-xolos" data-lang="es" aria-label="Escribir por correo sobre xoloitzcuintles">Escribir por correo</a>
-          <a href="https://wa.me/qr/R2F5PRQYZSJOA1" class="btn-small btn-primary-small cta-lead cta-whatsapp" data-cta="whatsapp" data-lead-type="generate_lead" data-profile="general" data-page-type="available-xolos" data-lang="es" aria-label="Consultar por WhatsApp sobre xoloitzcuintles">Consultar por WhatsApp</a>
+          <a href="https://wa.me/525518555993" class="btn-small btn-primary-small cta-lead cta-whatsapp" data-cta="whatsapp" data-lead-type="generate_lead" data-profile="general" data-page-type="available-xolos" data-lang="es" aria-label="Consultar por WhatsApp sobre xoloitzcuintles">Consultar por WhatsApp</a>
         </div>
       </section>
 


### PR DESCRIPTION
### Motivation
- Actualizar el número de contacto de WhatsApp usado en CTAs del sitio para apuntar al nuevo enlace `https://wa.me/525518555993`.
- Evitar que el sitio siga utilizando el enlace legado con QR (`https://wa.me/qr/R2F5PRQYZSJOA1`) en botones visibles al usuario y en pruebas automáticas.

### Description
- Reemplacé el enlace flotante/CTA de WhatsApp en `js/main.js` para usar `https://wa.me/525518555993` en lugar del QR legacy.
- Actualicé los enlaces en las páginas públicas relevantes: `xolos-disponibles.html`, `en/available-xolos.html`, `blog/precio-xoloitzcuintle.html` y `en/blog/xoloitzcuintli-price.html`.
- Ajusté la prueba de integración `scripts/test-generate-lead-tracking.mjs` para validar el nuevo `href` y evitar falsos negativos sobre el CTA.

### Testing
- Ejecuté `git diff --check` y no se reportaron problemas con el diff.
- Ejecuté `npm run test:generate-lead` y la comprobación `generate_lead tracking checks` pasó correctamente.
- Ejecuté `npm run lint:html` (via `htmlhint`) que escaneó `177` archivos y no encontró errores.
- Verifiqué que el enlace legacy ya no aparece con `rg -n 'https://wa\.me/qr/R2F5PRQYZSJOA1'` (no hay coincidencias) y que el nuevo enlace aparece en los archivos afectados con `rg -n 'https://wa\.me/525518555993'` (coincidencias encontradas).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a8b13f54ae8833296a1b87b67ea05ee)