### PR TITLE
fix: update official WhatsApp contact link

### DIFF
--- a/blog/precio-xoloitzcuintle.html
+++ b/blog/precio-xoloitzcuintle.html
@@ -363,7 +363,7 @@
               <p style="margin-top: 1.25rem; margin-bottom: 0.75rem;">Solicita una orientación personalizada por:</p>
               <p style="display: flex; flex-wrap: wrap; justify-content: center; gap: 1rem; margin: 0;">
                 <a
-                  href="https://wa.me/525518555993"
+                  href="https://wa.me/qr/R2F5PRQYZSJOA1"
                   data-cta="whatsapp"
                   data-lead-type="generate_lead"
                   data-lead-intent="price_inquiry"

--- a/en/available-xolos.html
+++ b/en/available-xolos.html
@@ -93,7 +93,7 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
       </ul>
       <div class="puppy-card__actions">
         <a href="mailto:contacto@xolosarmy.xyz?subject=Inquiry%20about%20Xoloitzcuintli%20puppies" class="btn-small btn-primary-small cta-lead cta-email" data-cta="email" data-lead-type="generate_lead" data-profile="general" data-page-type="available-xolos" data-lang="en" aria-label="Contact by email about Xoloitzcuintli puppies">Contact by email</a>
-        <a href="https://wa.me/525518555993" class="btn-small btn-primary-small cta-lead cta-whatsapp" data-cta="whatsapp" data-lead-type="generate_lead" data-profile="general" data-page-type="available-xolos" data-lang="en" aria-label="Contact by WhatsApp about Xoloitzcuintli puppies">Contact by WhatsApp</a>
+        <a href="https://wa.me/qr/R2F5PRQYZSJOA1" class="btn-small btn-primary-small cta-lead cta-whatsapp" data-cta="whatsapp" data-lead-type="generate_lead" data-profile="general" data-page-type="available-xolos" data-lang="en" aria-label="Contact by WhatsApp about Xoloitzcuintli puppies">Contact by WhatsApp</a>
       </div>
     </section>
 

--- a/en/blog/xoloitzcuintli-price.html
+++ b/en/blog/xoloitzcuintli-price.html
@@ -360,7 +360,7 @@
               <p style="margin-top: 1.25rem; margin-bottom: 0.75rem;">Request personalized guidance by:</p>
               <p style="display: flex; flex-wrap: wrap; justify-content: center; gap: 1rem; margin: 0;">
                 <a
-                  href="https://wa.me/525518555993"
+                  href="https://wa.me/qr/R2F5PRQYZSJOA1"
                   data-cta="whatsapp"
                   data-lead-type="generate_lead"
                   data-lead-intent="price_inquiry"

--- a/js/main.js
+++ b/js/main.js
@@ -317,7 +317,7 @@ function updateAvailableXolosCtas() {
     'a.home-email-float.video-call-float, a.home-email-float[data-cta="video_call"]',
   );
   if (floatingCta) {
-    floatingCta.href = 'https://wa.me/525518555993';
+    floatingCta.href = 'https://wa.me/qr/R2F5PRQYZSJOA1';
     floatingCta.target = '_blank';
     floatingCta.rel = 'noopener noreferrer';
     floatingCta.setAttribute('aria-label', labels.whatsappAria);

--- a/scripts/test-generate-lead-tracking.mjs
+++ b/scripts/test-generate-lead-tracking.mjs
@@ -195,7 +195,7 @@ for (const expectation of floatingVideoCallExpectations) {
 
   includes(
     html,
-    'href="https://wa.me/525518555993"',
+    'href="https://wa.me/qr/R2F5PRQYZSJOA1"',
     expectation.path + ' must keep the non-floating WhatsApp CTA'
   );
 

--- a/xolos-disponibles.html
+++ b/xolos-disponibles.html
@@ -140,7 +140,7 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
         </ul>
         <div class="puppy-card__actions">
           <a href="mailto:contacto@xolosarmy.xyz?subject=Consulta%20sobre%20xoloitzcuintles" class="btn-small btn-primary-small cta-lead cta-email" data-cta="email" data-lead-type="generate_lead" data-profile="general" data-page-type="available-xolos" data-lang="es" aria-label="Escribir por correo sobre xoloitzcuintles">Escribir por correo</a>
-          <a href="https://wa.me/525518555993" class="btn-small btn-primary-small cta-lead cta-whatsapp" data-cta="whatsapp" data-lead-type="generate_lead" data-profile="general" data-page-type="available-xolos" data-lang="es" aria-label="Consultar por WhatsApp sobre xoloitzcuintles">Consultar por WhatsApp</a>
+          <a href="https://wa.me/qr/R2F5PRQYZSJOA1" class="btn-small btn-primary-small cta-lead cta-whatsapp" data-cta="whatsapp" data-lead-type="generate_lead" data-profile="general" data-page-type="available-xolos" data-lang="es" aria-label="Consultar por WhatsApp sobre xoloitzcuintles">Consultar por WhatsApp</a>
         </div>
       </section>
 


### PR DESCRIPTION
## Resumen

- actualiza los CTAs comerciales oficiales de WhatsApp en español e inglés
- actualiza el destino compartido del CTA flotante
- mantiene sincronizada la prueba de tracking `generate_lead`
- preserva textos, estilos, datos comerciales, reservas e integraciones

Destino oficial:

`https://wa.me/qr/R2F5PRQYZSJOA1`

## Validaciones

- `git diff --check`
- `node --check js/main.js`
- `node --check scripts/test-generate-lead-tracking.mjs`
- `node scripts/test-generate-lead-tracking.mjs`
- inventario global: 6 referencias nuevas y 0 referencias al destino anterior
- parseo estructural de los cuatro HTML modificados con `lxml`
- preview HTTP local: 200 para las cuatro páginas y `js/main.js`
- destino externo: HTTP 200 con redirección a `api.whatsapp.com/qr/R2F5PRQYZSJOA1`

HTMLHint no estaba instalado en el checkout y la restauración offline de dependencias fue bloqueada por el entorno; no se modificaron manifiestos ni dependencias.

No merge ni despliegue.