### PR TITLE
Add Tlilxochitl Ramírez YouTube Short to profile

### DIFF
--- a/js/main.js
+++ b/js/main.js
@@ -452,7 +452,7 @@ function insertTlilxochitlProfile() {
         color: 'Negro',
         alt1: 'Tlilxóchitl Ramírez, bebé xoloitzcuintle hembra con la cabeza inclinada',
         alt2: 'Tlilxóchitl Ramírez, bebé xoloitzcuintle hembra de frente mirando a la cámara',
-        videoTitle: 'Tlilxóchitl Ramirez, bebé xoloitzcuintle en un retrato cercano',
+        videoTitle: 'Tlilxóchitl Ramírez, bebé xoloitzcuintle en un retrato cercano',
         subject: 'Consulta sobre Tlilxóchitl Ramirez [Ref: tlilxochitl-es-available]',
         body: 'Hola, vi el perfil de Tlilxóchitl Ramirez en Xolos Ramírez y me interesa conocer más sobre su disponibilidad, precio y proceso de reserva.',
         cta: 'Correo directo ✉️',

--- a/js/main.js
+++ b/js/main.js
@@ -427,6 +427,7 @@ function insertTlilxochitlProfile() {
         color: 'Black',
         alt1: 'Tlilxóchitl Ramirez, female Xoloitzcuintli puppy with her head tilted',
         alt2: 'Tlilxóchitl Ramirez, female Xoloitzcuintli puppy facing the camera',
+        videoTitle: 'Tlilxóchitl Ramirez, baby Xoloitzcuintli in a close-up portrait',
         subject: 'Inquiry about Tlilxóchitl Ramirez [Ref: tlilxochitl-en-available]',
         body: 'Hello, I saw Tlilxóchitl Ramirez on the Xolos Ramírez website and would like to learn more about her availability, price, and reservation process.',
         cta: 'Contact via Email',
@@ -451,6 +452,7 @@ function insertTlilxochitlProfile() {
         color: 'Negro',
         alt1: 'Tlilxóchitl Ramírez, bebé xoloitzcuintle hembra con la cabeza inclinada',
         alt2: 'Tlilxóchitl Ramírez, bebé xoloitzcuintle hembra de frente mirando a la cámara',
+        videoTitle: 'Tlilxóchitl Ramirez, bebé xoloitzcuintle en un retrato cercano',
         subject: 'Consulta sobre Tlilxóchitl Ramirez [Ref: tlilxochitl-es-available]',
         body: 'Hola, vi el perfil de Tlilxóchitl Ramirez en Xolos Ramírez y me interesa conocer más sobre su disponibilidad, precio y proceso de reserva.',
         cta: 'Correo directo ✉️',
@@ -493,6 +495,9 @@ function insertTlilxochitlProfile() {
       </ul>
       <div class="puppy-video-container" style="margin: 1rem 0; border-radius: 8px; overflow: hidden; aspect-ratio: 16/9;">
         <iframe width="100%" height="100%" src="https://www.youtube.com/embed/8iXxSLjaNfI" title="Tlilxóchitl Ramirez" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen loading="lazy"></iframe>
+      </div>
+      <div class="puppy-video-container" data-profile-video="qdUfdKWn5aI" style="margin: 1rem 0; border-radius: 8px; overflow: hidden; aspect-ratio: 16/9;">
+        <iframe width="100%" height="100%" src="https://www.youtube.com/embed/qdUfdKWn5aI" title="${labels.videoTitle}" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen loading="lazy"></iframe>
       </div>
       <div class="puppy-card__actions">
         <a href="mailto:${CURRENT_CONTACT_EMAIL}?subject=${encodeURIComponent(labels.subject)}&body=${encodeURIComponent(labels.body)}" class="btn-small btn-primary-small cta-lead cta-email" style="${labels.buttonStyle}" data-cta="email" data-lead-type="generate_lead" data-profile="tlilxochitl" data-page-type="available-xolos" data-lang="${labels.lang}" aria-label="${labels.aria}" data-status="available">${labels.cta}</a>


### PR DESCRIPTION
## Resumen

Añade el Short de YouTube de Tlilxóchitl Ramírez al perfil bilingüe compartido por:

- `xolos-disponibles.html`
- `en/available-xolos.html`

El perfil se genera desde `insertTlilxochitlProfile()` en `js/main.js`, por lo que el cambio queda centralizado en un solo archivo.

## Implementación

- Conserva el video existente `8iXxSLjaNfI`.
- Añade `qdUfdKWn5aI` inmediatamente después como segundo video.
- Usa la URL embebible canónica: `https://www.youtube.com/embed/qdUfdKWn5aI`.
- Mantiene el contenedor responsivo 16:9 existente.
- Incluye `loading="lazy"`, `allowfullscreen` y títulos accesibles localizados en español e inglés.
- No modifica fotos, precio, disponibilidad, CTA, analítica ni lógica comercial.

## Identificadores

- Base SHA: `ebe625366fa1ae43b02cb452e157c8c3eee24650`
- HEAD SHA: `59fa068de89f509b992778fa10c6725c5d5695e5`
- Tree SHA: `e0e1350f70ad577051fed0f0aaa2165106e06767`
- Patch SHA-256: `0cbdf1b256e242873beaeb23df9b6bbb88d91a2ee8e991e7e974f059a0bb89fd`

## Alcance

- Modificado: `js/main.js`
- Diff: 5 inserciones, 0 eliminaciones
- Sin cambios directos a los HTML ni a recursos multimedia locales

## Validaciones

- `git diff --check`: PASS
- `node --check js/main.js`: PASS
- `scripts/test-generate-lead-tracking.mjs`: PASS
- Prueba estructural bilingüe del perfil: PASS
  - exactamente 2 videos en español y 2 en inglés;
  - orden `8iXxSLjaNfI` → `qdUfdKWn5aI`;
  - nuevo iframe único;
  - título localizado correcto;
  - `loading="lazy"` y `allowfullscreen`;
  - las 2 fotografías actuales permanecen intactas.
- Ambas subpáginas cargan la fuente compartida `js/main.js`: confirmado.
- Workspace limpio: confirmado.