### PR TITLE
Remove legacy Tlilxochitl Ramírez profile video

### DIFF
--- a/js/main.js
+++ b/js/main.js
@@ -493,9 +493,6 @@ function insertTlilxochitlProfile() {
         <li><strong>${labels.sizeLabel}</strong>${labels.size}</li>
         <li><strong>${labels.colorLabel}</strong>${labels.color}</li>
       </ul>
-      <div class="puppy-video-container" style="margin: 1rem 0; border-radius: 8px; overflow: hidden; aspect-ratio: 16/9;">
-        <iframe width="100%" height="100%" src="https://www.youtube.com/embed/8iXxSLjaNfI" title="Tlilxóchitl Ramirez" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen loading="lazy"></iframe>
-      </div>
       <div class="puppy-video-container" data-profile-video="qdUfdKWn5aI" style="margin: 1rem 0; border-radius: 8px; overflow: hidden; aspect-ratio: 16/9;">
         <iframe width="100%" height="100%" src="https://www.youtube.com/embed/qdUfdKWn5aI" title="${labels.videoTitle}" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen loading="lazy"></iframe>
       </div>


### PR DESCRIPTION
## Resumen

Corrección posterior a PR #328: elimina el video anterior del perfil bilingüe de Tlilxóchitl Ramírez y conserva exclusivamente el Short nuevo.

El perfil compartido se genera desde `insertTlilxochitlProfile()` en `js/main.js` para:

- `xolos-disponibles.html`
- `en/available-xolos.html`

## Resultado

- Eliminado: `https://www.youtube.com/embed/8iXxSLjaNfI`
- Conservado como único video: `https://www.youtube.com/embed/qdUfdKWn5aI`
- Se mantienen los títulos accesibles localizados, `loading="lazy"`, `allowfullscreen` y el contenedor responsivo 16:9.
- Sin cambios en fotografías, precio, disponibilidad, CTA, analítica ni lógica comercial.

## Identificadores

- Base SHA: `08b7936422ddaa82912985fc77561cb2e4b26c88`
- HEAD SHA: `633a330e44c87b9d0dd6ed112d2d2be863a14eaf`
- Tree SHA: `a978b37d6ee96411c0b43a369b9e0f018bda013f`
- Patch SHA-256: `586148dd067c79687b8bc0dd7071964f140bba18e89ec1d190b83b0b753b50da`

## Alcance

- Modificado: `js/main.js`
- Diff: 3 eliminaciones, 0 inserciones

## Validaciones

- `git diff --check`: PASS
- `node --check js/main.js`: PASS
- `scripts/test-generate-lead-tracking.mjs`: PASS
- Prueba estructural bilingüe del perfil: PASS
  - exactamente 1 video en español y 1 en inglés;
  - referencias al video anterior: 0;
  - referencia al Short nuevo: exactamente 1 en fuente y 1 por perfil renderizado;
  - título localizado correcto;
  - `loading="lazy"` y `allowfullscreen`;
  - las 2 fotografías actuales permanecen intactas.
- Workspace limpio: confirmado.