### PR TITLE
Add Xoloitzcuintli price section to English homepage

### DIFF
--- a/en/index.html
+++ b/en/index.html
@@ -388,6 +388,14 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
           <a href="available-xolos.html" class="btn">View available Xolos Ramirez</a>
         </div>
       </section>
+
+      <div class="container" style="margin-top: 4rem; margin-bottom: 4rem;">
+        <div style="background: linear-gradient(145deg, #1a1512, #2a201c); padding: 3rem 2rem; text-align: center; border-radius: 12px; border: 1px solid rgba(212, 175, 55, 0.2); box-shadow: 0 10px 30px rgba(0,0,0,0.5);">
+          <h3 style="color: var(--color-dorado, #d4af37); margin-bottom: 1rem; font-family: 'Cinzel', serif; font-size: 1.8rem;">Learn More About Xoloitzcuintli Prices and What Xolos Ramirez Offers</h3>
+          <p style="color: #e0d5c1; margin-bottom: 2rem; max-width: 600px; margin-left: auto; margin-right: auto; line-height: 1.6;">Discover everything included in our exclusive Xoloitzcuintli breeding and delivery program.</p>
+          <a href="blog/xoloitzcuintli-price.html" class="btn" style="background-color: var(--color-dorado, #d4af37); color: #111; font-weight: 800; padding: 1rem 2rem; border-radius: 999px; text-decoration: none; display: inline-block;">View Xoloitzcuintli Price Guide and What’s Included</a>
+        </div>
+      </div>
     </main>
 
     <footer>


### PR DESCRIPTION
## Summary
- add the missing Xoloitzcuintli price section to the English homepage
- mirror the Spanish homepage structure and inline styling
- link to the existing English price article

## Base
- `main`: `63bc1fd1dc9057a67cfc81b5fdd6533059ebb8b4`
- commit: `f147e2fc45befb7839eb77507c77078895c04d81`

## Files changed
- `en/index.html` only

## Location
Inserted immediately after the final English `.cta-section` and immediately before `</main>`.

## Validation
- Spanish source block in `index.html`: exactly 1 occurrence
- English price block in `en/index.html`: exactly 1 occurrence
- `blog/xoloitzcuintli-price.html` link: exactly 1 occurrence
- target `en/blog/xoloitzcuintli-price.html`: exists
- visible phrase `Xoloitzcuintli Price`: present
- `</main>` / `<footer>` nesting around insertion: verified
- `htmlhint en/index.html`: PASS, no errors
- `node scripts/test-generate-lead-tracking.mjs`: PASS
- `git diff --check`: PASS
- final diff scope: `en/index.html` only

No prices, policies, navigation, footer, CTA tracking, WalletConnect, analytics, JavaScript, CSS, or Spanish content were changed.