### PR TITLE
Feature Onix Ramirez show across site

### DIFF
--- a/blog/2026-07-18-entrega-onix-ramirez.html
+++ b/blog/2026-07-18-entrega-onix-ramirez.html
@@ -308,6 +308,23 @@
                         <figcaption>Onix Ramírez en su hogar, agosto de 2026. Fotografías compartidas por su familia.</figcaption>
                     </figure>
                 </section>
+
+                <section class="story-update" aria-labelledby="onix-show-agosto-2026">
+                    <h2 id="onix-show-agosto-2026"><time datetime="2026-08-28">28 de agosto de 2026</time> — Onix Ramírez en The Xolos Ramirez Show</h2>
+                    <p>Adrián Castellanos y su esposa participaron junto con Onix Ramírez en una conversación en inglés para <strong>The Xolos Ramirez Show</strong> sobre su experiencia de vida con él en Texas. El episodio completo fue grabado con su familia y publicado sin ediciones.</p>
+
+                    <div class="media-wrapper">
+                        <div class="video-container">
+                            <iframe src="https://www.youtube.com/embed/LOrO7FgfmnE" title="Onix Ramírez y su familia en The Xolos Ramirez Show" loading="lazy" allow="accelerometer; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" referrerpolicy="strict-origin-when-cross-origin" allowfullscreen></iframe>
+                        </div>
+                    </div>
+
+                    <p>Durante el episodio, Adrián y su esposa recuerdan los primeros días de Onix en casa: primero se mostró tímido y, en poco tiempo, comenzó a expresar la energía de un cachorro. También hablan del fuerte vínculo afectivo que ha formado con su familia, de cómo duerme con ellos desde sus primeras noches y de la manera en que se comunica mediante la mirada y el lenguaje corporal.</p>
+
+                    <p>La conversación recorre aspectos de su vida cotidiana, como los cuidados que su familia brinda a su piel, el uso de ropa cuando hace frío y su gusto por tomar el sol. También comparten su proceso de socialización con personas y otros animales, incluida la convivencia con la gata de la familia, así como los juegos y el entrenamiento que realizan mediante refuerzo positivo.</p>
+
+                    <p>Desde la experiencia personal de su familia, vivir con Onix también representa una forma de preservar y compartir en Texas la historia de una raza ancestral mexicana. Este episodio continúa la memoria de su entrega y permite conocer, directamente a través de Adrián y su esposa, cómo sigue creciendo su historia juntos.</p>
+                </section>
             </div>
 
             <div class="tags">

--- a/en/available-xolos.html
+++ b/en/available-xolos.html
@@ -156,19 +156,19 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
     <section class="live-show section" data-aos="fade-up" data-aos-duration="1000" data-aos-delay="90">
       <div class="container live-show__container">
         <div class="live-show__content">
-          <span class="live-show__eyebrow">Live</span>
-          <h2>The Xolos Ramirez Show</h2>
-          <p>Connect to our live stream to learn more about the Xolos Ramirez community, see our puppies, and keep the momentum before exploring the featured profiles.</p>
+          <span class="live-show__eyebrow">Latest episode</span>
+          <h2>Latest The Xolos Ramirez Show</h2>
+          <p><strong>Onix Ramirez and his family — Life with a Xoloitzcuintli in Texas.</strong> Watch the complete conversation, published without edits.</p>
         </div>
         <div class="live-show__frame">
-          <div class="live-show__badge" aria-label="Live stream">
+          <div class="live-show__badge" aria-label="Full episode">
             <span class="live-show__dot" aria-hidden="true"></span>
-            Live
+            Full episode
           </div>
           <div class="live-show__video">
             <iframe
-              src="https://www.youtube.com/embed/cDpeJ2UQNHE"
-              title="The Xolos Ramirez Show Live Stream"
+              src="https://www.youtube.com/embed/LOrO7FgfmnE"
+              title="Onix Ramirez and his family — Life with a Xoloitzcuintli in Texas"
               loading="lazy"
               allow="accelerometer; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share"
               referrerpolicy="strict-origin-when-cross-origin"

--- a/en/index.html
+++ b/en/index.html
@@ -275,11 +275,11 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
 
       <article class="card blog-card" data-aos="zoom-in" data-aos-delay="250">
   <picture class="card_media">
-    <img src="https://i.imgur.com/HdR92na.jpeg" width="600" height="400" loading="lazy" decoding="async" alt="Visiting Mexico for 2026, meet the xolo dog">
+    <img src="../img/blog/onix-ramirez-agosto-2026-05.webp" width="1152" height="1536" loading="lazy" decoding="async" alt="Adrián Castellanos holding Onix Ramirez outdoors">
   </picture>
-  <h2>From Tejocote to Yanga: A Xoloitzcuintle Rockstar in the Caribbean</h2>
-  <p> A month and a half after his emotional delivery in Cancun, we talked with Lola and Lee about their puppy's amazing adaptation to Playa del Carmen, his superior intelligence, and the powerful "Blaxican" heritage that inspired his new name. </p>
-  <a href="../blog/2026-05-28-the-xolos-ramirez-show.html" aria-label="The Xolos Ramirez Show">Read more here:</a>
+  <h2>Onix Ramirez: His New Life in Texas and The Xolos Ramirez Show</h2>
+  <p>Discover how Onix Ramirez’s story has continued with his family in Texas and watch their appearance on The Xolos Ramirez Show, where Adrián and his wife share their experience of living with a Xoloitzcuintli.</p>
+  <a href="../blog/2026-07-18-entrega-onix-ramirez.html" aria-label="Read Onix Ramirez’s story and watch his family on The Xolos Ramirez Show">Read more here:</a>
 </article>
 
 

--- a/index.html
+++ b/index.html
@@ -287,13 +287,13 @@ NFTs de Linaje Xoloitzcuintle</a></li>
 
       <article class="card blog-card" data-aos="zoom-in" data-aos-delay="250">
         <picture class="card_media">
-          <img src="img/blog/2026-08-13-entrega-xoloitzcuintle-teyolia-ramirez.webp"
-  width="600" height="400" loading="lazy" decoding="async"
-  alt="Entrega de Teyolia Ramírez a su nueva familia">
+          <img src="img/blog/onix-ramirez-agosto-2026-05.webp"
+  width="1152" height="1536" loading="lazy" decoding="async"
+  alt="Adrián Castellanos sosteniendo a Onix Ramírez al aire libre">
         </picture>
-        <h2>Entrega de Teyolia Ramírez, xoloitzcuintle miniatura, a su nueva familia.</h2>
-        <p>El día de hoy marca un momento muy especial para la familia de Xolos Ramírez. Tuvimos el honor de entregar a Teyolia Ramírez, una hermosa xoloitzcuintle miniatura, a su nueva familia. Una entrega llena de emoción, confianza y continuidad para la memoria viva del xoloitzcuintle mexicano.</p>
-        <a href="blog/2026-08-13-entrega-xoloitzcuintle-teyolia-ramirez.html" aria-label="Entrega de Teyolia Ramírez">Ver más aquí:</a>
+        <h2>Onix Ramírez: su nueva vida en Texas y The Xolos Ramirez Show</h2>
+        <p>Conoce cómo ha continuado la historia de Onix Ramírez con su familia en Texas y mira su participación en The Xolos Ramirez Show, donde Adrián y su esposa comparten su experiencia de vida con este xoloitzcuintle.</p>
+        <a href="blog/2026-07-18-entrega-onix-ramirez.html" aria-label="Conocer la historia de Onix Ramírez y su participación en The Xolos Ramirez Show">Ver más aquí:</a>
       </article>
 
 

--- a/xolos-disponibles.html
+++ b/xolos-disponibles.html
@@ -206,19 +206,19 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
       <section class="live-show section section-live-show" data-aos="fade-up" data-aos-duration="1000" data-aos-delay="90">
         <div class="container live-show__container">
           <div class="live-show__content">
-            <span class="live-show__eyebrow">En vivo</span>
-            <h2>The Xolos Ramirez Show</h2>
-            <p>Conéctate con nuestra transmisión en vivo para conocer más de la comunidad Xolos Ramírez, ver a nuestros ejemplares y mantener el impulso antes de explorar los perfiles destacados.</p>
+            <span class="live-show__eyebrow">Último episodio</span>
+            <h2>Último The Xolos Ramirez Show</h2>
+            <p><strong>Onix Ramírez y su familia — su experiencia de vida con un xoloitzcuintle en Texas.</strong> Mira la conversación completa, publicada sin ediciones.</p>
           </div>
           <div class="live-show__frame">
-            <div class="live-show__badge" aria-label="Transmisión en vivo">
+            <div class="live-show__badge" aria-label="Episodio completo">
               <span class="live-show__dot" aria-hidden="true"></span>
-              En Vivo
+              Episodio completo
             </div>
             <div class="live-show__video">
               <iframe
-                src="https://www.youtube.com/embed/cDpeJ2UQNHE"
-                title="The Xolos Ramirez Show en vivo"
+                src="https://www.youtube.com/embed/LOrO7FgfmnE"
+                title="Onix Ramírez y su familia — su experiencia de vida con un xoloitzcuintle en Texas"
                 loading="lazy"
                 allow="accelerometer; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share"
                 referrerpolicy="strict-origin-when-cross-origin"


### PR DESCRIPTION
## Summary

Updates the Xolos Ramírez site to feature the complete, unedited episode of **The Xolos Ramirez Show with Onix Ramírez and his family**.

## Exact refs

- Base branch: `main`
- Base SHA: `27c3a9069420c71dabafd7b035b142d4f0e0b76a`
- HEAD SHA: `0e99e1a5b5edce2a8b7ca61b462b09b519f3f672`

## Files changed

- `blog/2026-07-18-entrega-onix-ramirez.html`
- `index.html`
- `en/index.html`
- `xolos-disponibles.html`
- `en/available-xolos.html`

## Content updates

- Preserves the existing Onix delivery story and August 22 update.
- Adds a new chronological **August 28, 2026** section about Adrián Castellanos, his wife, and Onix appearing on the show.
- Embeds the complete episode with the article's existing responsive `video-container` pattern.
- Uses cautious, family-attributed editorial language for the experiences discussed in the episode.
- Updates the Spanish and English home-page feature cards to link to Onix's story.
- Reuses `img/blog/onix-ramirez-agosto-2026-05.webp` for both index cards.
- Replaces the previous show video and live-stream wording in the Spanish and English available-Xolos pages.

## Video

- Official URL: https://youtu.be/LOrO7FgfmnE
- Embed ID: `LOrO7FgfmnE`
- All three requested embeds preserve `allowfullscreen`, use the existing responsive wrappers, and do not add autoplay.

## Validation

- `git diff --check`: PASS
- Full diff and scope review: PASS (exactly five requested files)
- HTML parsing with `lxml`: PASS, with no new parser errors versus base
- Relative image/source path validation: PASS
- Onix story links from both index pages: PASS
- Exact embed ID / `allowfullscreen` / no-autoplay assertions: PASS (3/3)
- Chronological section ordering: PASS
- Spanish/English `lang` attributes and localized copy review: PASS
- Existing `generate_lead` tracking test: PASS
- No temporary files, screenshots, duplicate images, dependencies, or package changes added

## Environment limitation

Automated browser preview could not start because this static repository does not define the development-server script required by the available preview environment. No dependency or package changes were introduced solely to force preview. Responsive behavior was therefore verified structurally against the existing `video-container`, `live-show__video`, and mobile media-query patterns, but no rendered desktop/mobile screenshots were produced.

No merge or squash was performed.