### PR TITLE
Document Onix community NFT trace

### DIFF
--- a/blog/2026-07-18-entrega-onix-ramirez.html
+++ b/blog/2026-07-18-entrega-onix-ramirez.html
@@ -324,6 +324,14 @@
                     <p>La conversación recorre aspectos de su vida cotidiana, como los cuidados que su familia brinda a su piel, el uso de ropa cuando hace frío y su gusto por tomar el sol. También comparten su proceso de socialización con personas y otros animales, incluida la convivencia con la gata de la familia, así como los juegos y el entrenamiento que realizan mediante refuerzo positivo.</p>
 
                     <p>Desde la experiencia personal de su familia, vivir con Onix también representa una forma de preservar y compartir en Texas la historia de una raza ancestral mexicana. Este episodio continúa la memoria de su entrega y permite conocer, directamente a través de Adrián y su esposa, cómo sigue creciendo su historia juntos.</p>
+
+                    <div class="highlight-box">
+                        <h3>NFT comunitario del episodio</h3>
+                        <p>Este capítulo de la vida de Onix también quedó registrado como un <strong>NFT de xolosArmy Community</strong>, separado de su NFT canónico de linaje. El NFT documenta su participación junto a su familia en <strong>The Xolos Ramirez Show</strong> y fue posteriormente transferido a la Tonalli Wallet de Onix.</p>
+                        <p><strong>Mint:</strong> <a href="https://explorer.xolosarmy.xyz/tx/f6c5778bd35a8bcd82662f3c95c6578ccd32d36cb4ab300e8d02e9b8d808b803" target="_blank" rel="noopener noreferrer">f6c5778bd35a8bcd82662f3c95c6578ccd32d36cb4ab300e8d02e9b8d808b803</a><br>
+                        <strong>Transferencia a la wallet de Onix:</strong> <a href="https://explorer.xolosarmy.xyz/tx/027cba903b100fdcb2f3adbc078af6afd0aef099e9f07bdbee19318ded64389a" target="_blank" rel="noopener noreferrer">027cba903b100fdcb2f3adbc078af6afd0aef099e9f07bdbee19318ded64389a</a><br>
+                        <strong>Tonalli Wallet de Onix:</strong> <code>ecash:qqnhns6ydd7xlcha9aavnmp3lccqm02j7g0ek9y4x2</code></p>
+                    </div>
                 </section>
             </div>
 


### PR DESCRIPTION
## Summary

Adds the xolosArmy Community NFT trace for Onix Ramírez's The Xolos Ramirez Show episode to his existing story.

## Exact refs
- Base: `ba8fe98e20baf23e8714e0de20e23f7ded8b91ae`
- Head: `e7cee6734b1770879ec4630b7034d7234565e8db`

## Scope
- Modifies only `blog/2026-07-18-entrega-onix-ramirez.html`.
- Documents the community NFT separately from the canonical lineage NFT.
- Adds the mint TXID, transfer TXID, and Onix's Tonalli Wallet address.
- Links both transactions to Xolos Explorer.

## Trace
- Mint: `f6c5778bd35a8bcd82662f3c95c6578ccd32d36cb4ab300e8d02e9b8d808b803`
- Transfer: `027cba903b100fdcb2f3adbc078af6afd0aef099e9f07bdbee19318ded64389a`
- Wallet: `ecash:qqnhns6ydd7xlcha9aavnmp3lccqm02j7g0ek9y4x2`

No unrelated files changed.