### PR TITLE
Add Onix Ramirez show to testimonials

### DIFF
--- a/testimonios.html
+++ b/testimonios.html
@@ -111,7 +111,19 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
         <h2>Historias Reales</h2>
         <div class="grid" style="display: grid; grid-template-columns: repeat(auto-fit, minmax(300px, 1fr)); gap: 2rem; padding: 2rem 0;">
 
-          
+          <article class="post-card">
+            <div class="video-container" style="position: relative; padding-bottom: 56.25%; height: 0; overflow: hidden;">
+              <iframe src="https://www.youtube.com/embed/LOrO7FgfmnE" title="Onix Ramírez y su familia en The Xolos Ramirez Show" style="position: absolute; top: 0; left: 0; width: 100%; height: 100%; border: 0;" loading="lazy" allow="accelerometer; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" referrerpolicy="strict-origin-when-cross-origin" allowfullscreen></iframe>
+            </div>
+            <div class="post-card__body">
+              <h3>Onix Ramírez — The Xolos Ramirez Show</h3>
+              <p>Adrián y su esposa comparten cómo Onix pasó de mostrarse tímido en sus primeros días a convertirse en un cachorro lleno de energía, muy cercano a su familia y con una personalidad cada vez más definida.</p>
+              <p>En esta conversación en inglés hablan de su adaptación en Texas, sus juegos, la convivencia con la gata de la familia, sus cuidados cotidianos y el orgullo de compartir una raza ancestral mexicana.</p>
+              <cite>— Adrián y su esposa sobre el xoloitzcuintle Onix Ramírez</cite>
+              <p><a href="blog/2026-07-18-entrega-onix-ramirez.html">Conoce la historia completa de Onix Ramírez</a></p>
+            </div>
+          </article>
+
           <article class="post-card">
             <div class="video-container" style="position: relative; padding-bottom: 56.25%; height: 0; overflow: hidden;">
               <iframe src="https://www.youtube.com/embed/ZytyCBXOjDQ?autoplay=1&mute=1&loop=1&playlist=ZytyCBXOjDQ" style="position: absolute; top: 0; left: 0; width: 100%; height: 100%; border: 0;" loading="lazy" allowfullscreen></iframe>


### PR DESCRIPTION
## Summary

Adds the complete **The Xolos Ramirez Show** episode with Onix Ramírez and his family to `testimonios.html` as the newest real-family story.

## Exact refs
- Base: `e80a2fdd9a1037dd33ac99bb6537ea4f16e3e633`
- Head: `24ede15b1f3b7dd9973a21578976cb3a274b3205`

## Scope
- Modifies only `testimonios.html`.
- Embeds `https://www.youtube.com/embed/LOrO7FgfmnE` without autoplay.
- Adds a concise Spanish summary of Adrián and his wife's experience with Onix in Texas.
- Links to Onix's existing story at `blog/2026-07-18-entrega-onix-ramirez.html`.
- Preserves the existing testimonial grid and all prior testimonial cards.

## Validation
- Diff scope: exactly one file.
- Existing content preserved; only the new Onix card was added plus the file-ending newline normalization.
- YouTube ID verified: `LOrO7FgfmnE`.
- Responsive 16:9 wrapper follows the page's existing testimonial pattern.